### PR TITLE
Make sure do not mutate `p` in adjoint sensitivity

### DIFF
--- a/src/adjoint_sensitivity.jl
+++ b/src/adjoint_sensitivity.jl
@@ -95,7 +95,7 @@ function ODEAdjointProblem(sol,g,t=nothing,dg=nothing,
   λ = similar(u0)
   sense = ODEAdjointSensitvityFunction(f,nothing,f.jac,f.paramjac,
                                        uf,pg,u0,jac_config,pg_config,
-                                       λ,p,alg,discrete,
+                                       λ,deepcopy(p),alg,discrete,
                                        y,sol,dg,mass_matrix)
 
   if discrete


### PR DESCRIPTION
Without a copy, the function will mutate `p` in an unexpected way which could produce an incorrect result.