### PR TITLE
Wrong elem_effect assignment if effects is not preallocated

### DIFF
--- a/src/morris_sensitivity.jl
+++ b/src/morris_sensitivity.jl
@@ -67,8 +67,7 @@ end
 
 function morris_sensitivity(f,p_range,p_steps;relative_scale=false,kwargs...)
     design_matrices = sample_matrices(p_range,p_steps;kwargs...)
-    y1 = f(design_matrices[1][1])
-    effects = [[]]
+    effects = [[] for i=1:length(p)]
     for i in design_matrices
         y1 = f(i[1])
         for j in 1:length(i)-1
@@ -92,10 +91,8 @@ function morris_sensitivity(f,p_range,p_steps;relative_scale=false,kwargs...)
                     elem_effect = @. abs((y1-y2)/(y1*del))
                 end
             end
-            if length(effects) >= change_index && change_index > 0 
+            if change_index > 0
                 push!(effects[change_index],elem_effect)
-            elseif change_index > 0
-                push!(effects,[elem_effect])
             end
         end
     end


### PR DESCRIPTION
In case the effects array is not preallocated the change_index doesn’t match to the position of the requested parameter index. The array will instead grow dynamically until the max parameter index is reached…
Additionally the y1 assignment at line 70 is not used (will be overriden on line 73).