### PR TITLE
Efficient checkpointing

### DIFF
--- a/src/local_sensitivity/backsolve_adjoint.jl
+++ b/src/local_sensitivity/backsolve_adjoint.jl
@@ -93,7 +93,7 @@ end
 @noinline function ODEAdjointProblem(sol,sensealg::BacksolveAdjoint,
                                      g,t=nothing,dg=nothing;
                                      checkpoints=sol.t,
-                                     callback=CallbackSet())
+                                     callback=CallbackSet(),kwargs...)
   f = sol.prob.f
   tspan = (sol.prob.tspan[2],sol.prob.tspan[1])
   discrete = t != nothing

--- a/src/local_sensitivity/backsolve_adjoint.jl
+++ b/src/local_sensitivity/backsolve_adjoint.jl
@@ -46,7 +46,7 @@ end
     jac_config = build_jac_config(sensealg,uf,u0)
   end
 
-  y = copy(sol(tspan[1])) # TODO: Has to start at interpolation value!
+  y = copy(sol.u[end])
 
   if DiffEqBase.has_paramjac(f) || isautojacvec
     paramjac_config = nothing

--- a/src/local_sensitivity/backsolve_adjoint.jl
+++ b/src/local_sensitivity/backsolve_adjoint.jl
@@ -21,7 +21,6 @@ end
 @noinline function ODEBacksolveSensitivityFunction(g,u0,p,sensealg,discrete,sol,dg,checkpoints,tspan,colorvec)
   numparams = p isa Zygote.Params ? sum(length.(p)) : length(p)
   numindvar = length(u0)
-  # if there is an analytical Jacobian provided, we are not going to do automatic `jac*vec`
   f = sol.prob.f
   isautojacvec = get_jacvec(sensealg)
   J = isautojacvec ? nothing : similar(u0, numindvar, numindvar)

--- a/src/local_sensitivity/backsolve_adjoint.jl
+++ b/src/local_sensitivity/backsolve_adjoint.jl
@@ -1,4 +1,4 @@
-struct ODEBacksolveSensitivityFunction{rateType,uType,uType2,UF,PF,G,JC,GC,DG,TJ,PJT,PJC,CP,SType,CV} <: SensitivityFunction
+struct ODEBacksolveSensitivityFunction{rateType,uType,uType2,UF,PF,G,JC,GC,DG,TJ,PJT,PJC,CP,SType,CV,Alg<:BacksolveAdjoint} <: SensitivityFunction
   uf::UF
   pf::PF
   g::G
@@ -8,7 +8,7 @@ struct ODEBacksolveSensitivityFunction{rateType,uType,uType2,UF,PF,G,JC,GC,DG,TJ
   jac_config::JC
   g_grad_config::GC
   paramjac_config::PJC
-  sensealg::BacksolveAdjoint
+  sensealg::Alg
   f_cache::rateType
   discrete::Bool
   y::uType2

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -102,7 +102,8 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
     intervals = checkpoint_sol.intervals
     interval = intervals[checkpoint_sol.cursor]
     if !(interval[1] <= t <= interval[2])
-      cursor′ = checkpoint_sol.cursor - 1
+      # TODO: binary search like `find`
+      cursor′ = findfirst(x->x[1] <= t <= x[2], checkpoint_sol.intervals)
       interval = intervals[cursor′]
       cpsol_t = checkpoint_sol.cpsol.t
       sol(y, interval[1])
@@ -111,7 +112,6 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
       checkpoint_sol.cpsol = cpsol′
       checkpoint_sol.cursor = cursor′
     end
-    interval[1] <= t <= interval[2] || error("A step rejection (around t=$t) happened at a checkpoint, please coarsen the checkpoints to resolve this error.")
     checkpoint_sol.cpsol(y, t)
   end
 

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -111,6 +111,7 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
       checkpoint_sol.cpsol = cpsol′
       checkpoint_sol.cursor = cursor′
     end
+    interval[1] <= t <= interval[2] || error("A step rejection (around t=$t) happened at a checkpoint, please coarsen the checkpoints to resolve this error.")
     checkpoint_sol.cpsol(y, t)
   end
 

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -89,6 +89,13 @@ end
                                checkpoint_sol,colorvec)
 end
 
+function findcursor(checkpoint_sol, t)
+  # equivalent with `findfirst(x->x[1] <= t <= x[2], checkpoint_sol.intervals)`
+  intervals = checkpoint_sol.intervals
+  lt(x, t) = <(x[2], t)
+  return searchsortedfirst(intervals, t, lt=lt)
+end
+
 # u = λ'
 # add tstop on all the checkpoints
 function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
@@ -102,8 +109,7 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
     intervals = checkpoint_sol.intervals
     interval = intervals[checkpoint_sol.cursor]
     if !(interval[1] <= t <= interval[2])
-      # TODO: binary search like `find`
-      cursor′ = findfirst(x->x[1] <= t <= x[2], checkpoint_sol.intervals)
+      cursor′ = findcursor(checkpoint_sol, t)
       interval = intervals[cursor′]
       cpsol_t = checkpoint_sol.cpsol.t
       sol(y, interval[1])

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -54,7 +54,7 @@ end
     jac_config = build_jac_config(sensealg,uf,u0)
   end
 
-  y = copy(sol(tspan[1]))
+  y = copy(sol.u[end])
 
   if DiffEqBase.has_paramjac(f) || isautojacvec
     paramjac_config = nothing

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -1,4 +1,4 @@
-struct ODEInterpolatingAdjointSensitivityFunction{rateType,uType,uType2,UF,PF,G,JC,GC,DG,TJ,PJT,PJC,CP,SType,INT,CV} <: SensitivityFunction
+struct ODEInterpolatingAdjointSensitivityFunction{rateType,uType,uType2,UF,PF,G,JC,GC,DG,TJ,PJT,PJC,CP,SType,INT,CV,Alg<:InterpolatingAdjoint} <: SensitivityFunction
   uf::UF
   pf::PF
   g::G
@@ -8,7 +8,7 @@ struct ODEInterpolatingAdjointSensitivityFunction{rateType,uType,uType2,UF,PF,G,
   jac_config::JC
   g_grad_config::GC
   paramjac_config::PJC
-  sensealg::InterpolatingAdjoint
+  sensealg::Alg
   f_cache::rateType
   discrete::Bool
   y::uType2
@@ -75,7 +75,8 @@ end
   return ODEInterpolatingAdjointSensitivityFunction(uf,pf,pg,J,pJ,dg_val,
                                jac_config,pg_config,paramjac_config,
                                sensealg,f_cache,
-                               discrete,y,sol,dg,checkpointing,checkpoints,integrator,colorvec)
+                               discrete,y,sol,dg,checkpointing,checkpoints,
+                               integrator,colorvec)
 end
 
 # u = λ'

--- a/src/local_sensitivity/quadrature_adjoint.jl
+++ b/src/local_sensitivity/quadrature_adjoint.jl
@@ -41,7 +41,7 @@ end
     jac_config = build_jac_config(sensealg,uf,u0)
   end
 
-  y = copy(sol(tspan[1])) # TODO: Has to start at interpolation value!
+  y = copy(sol.u[end])
   dg_val = similar(u0, numindvar) # number of funcs size
   f_cache = deepcopy(u0)
 

--- a/src/local_sensitivity/quadrature_adjoint.jl
+++ b/src/local_sensitivity/quadrature_adjoint.jl
@@ -1,11 +1,11 @@
-struct ODEQuadratureAdjointSensitivityFunction{rateType,uType,uType2,UF,G,JC,GC,DG,TJ,SType,CV} <: SensitivityFunction
+struct ODEQuadratureAdjointSensitivityFunction{rateType,uType,uType2,UF,G,JC,GC,DG,TJ,SType,CV,Alg<:QuadratureAdjoint} <: SensitivityFunction
   uf::UF
   g::G
   J::TJ
   dg_val::uType
   jac_config::JC
   g_grad_config::GC
-  sensealg::QuadratureAdjoint
+  sensealg::Alg
   f_cache::rateType
   discrete::Bool
   y::uType2

--- a/src/local_sensitivity/quadrature_adjoint.jl
+++ b/src/local_sensitivity/quadrature_adjoint.jl
@@ -16,7 +16,6 @@ end
 
 @noinline function ODEQuadratureAdjointSensitivityFunction(g,u0,p,sensealg,discrete,sol,dg,tspan,colorvec)
   numindvar = length(u0)
-  # if there is an analytical Jacobian provided, we are not going to do automatic `jac*vec`
   f = sol.prob.f
   isautojacvec = get_jacvec(sensealg)
   J = isautojacvec ? nothing : similar(u0, numindvar, numindvar)

--- a/src/local_sensitivity/sensitivity_interface.jl
+++ b/src/local_sensitivity/sensitivity_interface.jl
@@ -7,13 +7,15 @@ function adjoint_sensitivities_u0(sol,args...;
 end
 
 function _adjoint_sensitivities_u0(sol,sensealg,alg,g,t=nothing,dg=nothing;
+                                   abstol=1e-6,reltol=1e-3,
                                    checkpoints=nothing,
                                    kwargs...)
-  adj_prob = ODEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints)
+  adj_prob = ODEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints,
+                               abstol=abstol,reltol=reltol)
   tstops = checkpoints === nothing ? similar(sol.t, 0) : checkpoints
-  adj_sol = solve(adj_prob,alg;kwargs...,
+  adj_sol = solve(adj_prob,alg;
                   save_everystep=false,save_start=false,saveat=eltype(sol[1])[],
-                  tstops=tstops)
+                  tstops=tstops,abstol=abstol,reltol=reltol,kwargs...)
 
   l = sol.prob.p isa Zygote.Params ? sum(length.(sol.prob.p)) : length(sol.prob.p)
   -adj_sol[end][1:length(sol.prob.u0)],
@@ -32,7 +34,8 @@ function _adjoint_sensitivities(sol,sensealg,alg,g,t=nothing,dg=nothing;
                                iabstol=abstol, ireltol=reltol,
                                checkpoints=nothing,
                                kwargs...)
-  adj_prob = ODEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints)
+  adj_prob = ODEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints,
+                               abstol=abstol,reltol=reltol)
   tstops = checkpoints === nothing ? similar(sol.t, 0) : checkpoints
   adj_sol = solve(adj_prob,alg;abstol=abstol,reltol=reltol,
                   tstops=tstops,save_everystep=false,save_start=false,kwargs...)

--- a/src/local_sensitivity/sensitivity_interface.jl
+++ b/src/local_sensitivity/sensitivity_interface.jl
@@ -2,8 +2,13 @@
 
 function adjoint_sensitivities_u0(sol,args...;
                                   sensealg=InterpolatingAdjoint(),
+                                  checkpoints=nothing,
                                   kwargs...)
-  _adjoint_sensitivities_u0(sol,sensealg,args...;kwargs...)
+  tstops = checkpoints === nothing ? similar(sol.t, 0) : checkpoints
+  _adjoint_sensitivities_u0(sol,sensealg,args...;
+                            tstops=tstops,
+                            checkpoints=checkpoints,
+                            kwargs...)
 end
 
 function _adjoint_sensitivities_u0(sol,sensealg,alg,g,t=nothing,dg=nothing;
@@ -19,8 +24,13 @@ end
 
 function adjoint_sensitivities(sol,args...;
                                sensealg=InterpolatingAdjoint(),
+                               checkpoints=nothing,
                                kwargs...)
-  _adjoint_sensitivities(sol,sensealg,args...;kwargs...)
+  tstops = checkpoints === nothing ? similar(sol.t, 0) : checkpoints
+  _adjoint_sensitivities(sol,sensealg,args...;
+                         tstops=tstops,
+                         checkpoints=checkpoints,
+                         kwargs...)
 end
 
 function _adjoint_sensitivities(sol,sensealg,alg,g,t=nothing,dg=nothing;

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -249,10 +249,12 @@ ū032,adj32 = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
 
 ū04,adj4 = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
                                     sensealg=InterpolatingAdjoint(checkpointing=true),
+                                    checkpoints=sol.t[1:10:end],
                                     reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
 
 ū042,adj42 = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
                                     sensealg=InterpolatingAdjoint(checkpointing=true,autojacvec=false),
+                                    checkpoints=sol.t[1:10:end],
                                     reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
 
 ū0args,adjargs = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
@@ -348,9 +350,11 @@ easy_res26 = adjoint_sensitivities(sol,Tsit5(),g,nothing,dg,abstol=1e-14,
 println("27")
 easy_res27 = adjoint_sensitivities(sol,Tsit5(),g,nothing,dg,abstol=1e-14,
                                   reltol=1e-14,iabstol=1e-14,ireltol=1e-12,
+                                  checkpoints=sol.t[1:10:end],
                                   sensealg=InterpolatingAdjoint(checkpointing=true))
 easy_res28 = adjoint_sensitivities(sol,Tsit5(),g,nothing,dg,abstol=1e-14,
                                   reltol=1e-14,iabstol=1e-14,ireltol=1e-12,
+                                  checkpoints=sol.t[1:10:end],
                                   sensealg=InterpolatingAdjoint(checkpointing=true,autojacvec=false))
 println("3")
 easy_res3 = adjoint_sensitivities(sol,Tsit5(),g,nothing,abstol=1e-14,
@@ -376,9 +380,11 @@ easy_res36 = adjoint_sensitivities(sol,Tsit5(),g,nothing,abstol=1e-14,
 println("37")
 easy_res37 = adjoint_sensitivities(sol,Tsit5(),g,nothing,abstol=1e-14,
                                   reltol=1e-14,iabstol=1e-14,ireltol=1e-12,
+                                  checkpoints=sol.t[1:10:end],
                                   sensealg=InterpolatingAdjoint(checkpointing=true))
 easy_res38 = adjoint_sensitivities(sol,Tsit5(),g,nothing,abstol=1e-14,
                                   reltol=1e-14,iabstol=1e-14,ireltol=1e-12,
+                                  checkpoints=sol.t[1:10:end],
                                   sensealg=InterpolatingAdjoint(checkpointing=true,autojacvec=false))
 
 @test norm(easy_res .- res) < 1e-8

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -79,17 +79,17 @@ easy_res5 = adjoint_sensitivities(sol,Kvaerno5(nlsolve=NLAnderson(), smooth_est=
 easy_res6 = adjoint_sensitivities(sol_nodense,Tsit5(),dg,t,abstol=1e-14,
                                   reltol=1e-14,
                                   sensealg=InterpolatingAdjoint(checkpointing=true),
-                                  checkpoints=sol.t[1:5:end])
+                                  checkpoints=sol.t[1:500:end])
 easy_res62 = adjoint_sensitivities(sol_nodense,Tsit5(),dg,t,abstol=1e-14,
                                    reltol=1e-14,
                                    sensealg=InterpolatingAdjoint(checkpointing=true,autojacvec=false),
-                                   checkpoints=sol.t[1:5:end])
+                                   checkpoints=sol.t[1:500:end])
 
 # It should automatically be checkpointing since the solution isn't dense
 easy_res7 = adjoint_sensitivities(sol_nodense,Tsit5(),dg,t,abstol=1e-14,
                                   reltol=1e-14,
                                   sensealg=InterpolatingAdjoint(),
-                                  checkpoints=sol.t[1:5:end])
+                                  checkpoints=sol.t[1:500:end])
 
 adj_prob = ODEAdjointProblem(sol,QuadratureAdjoint(),dg,t)
 adj_sol = solve(adj_prob,Tsit5(),abstol=1e-14,reltol=1e-14)
@@ -249,17 +249,17 @@ ū032,adj32 = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
 
 ū04,adj4 = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
                                     sensealg=InterpolatingAdjoint(checkpointing=true),
-                                    checkpoints=sol.t[1:10:end],
+                                    checkpoints=sol.t[1:500:end],
                                     reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
 
 @test_nowarn adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
-                         sensealg=InterpolatingAdjoint(checkpointing=true),
-                         checkpoints=sol.t[1:5:end],
-                         reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
+                                      sensealg=InterpolatingAdjoint(checkpointing=true),
+                                      checkpoints=sol.t[1:5:end],
+                                      reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
 
 ū042,adj42 = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
                                     sensealg=InterpolatingAdjoint(checkpointing=true,autojacvec=false),
-                                    checkpoints=sol.t[1:10:end],
+                                    checkpoints=sol.t[1:500:end],
                                     reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
 
 ū0args,adjargs = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
@@ -355,11 +355,11 @@ easy_res26 = adjoint_sensitivities(sol,Tsit5(),g,nothing,dg,abstol=1e-14,
 println("27")
 easy_res27 = adjoint_sensitivities(sol,Tsit5(),g,nothing,dg,abstol=1e-14,
                                   reltol=1e-14,iabstol=1e-14,ireltol=1e-12,
-                                  checkpoints=sol.t[1:10:end],
+                                  checkpoints=sol.t[1:500:end],
                                   sensealg=InterpolatingAdjoint(checkpointing=true))
 easy_res28 = adjoint_sensitivities(sol,Tsit5(),g,nothing,dg,abstol=1e-14,
                                   reltol=1e-14,iabstol=1e-14,ireltol=1e-12,
-                                  checkpoints=sol.t[1:10:end],
+                                  checkpoints=sol.t[1:500:end],
                                   sensealg=InterpolatingAdjoint(checkpointing=true,autojacvec=false))
 println("3")
 easy_res3 = adjoint_sensitivities(sol,Tsit5(),g,nothing,abstol=1e-14,
@@ -385,11 +385,11 @@ easy_res36 = adjoint_sensitivities(sol,Tsit5(),g,nothing,abstol=1e-14,
 println("37")
 easy_res37 = adjoint_sensitivities(sol,Tsit5(),g,nothing,abstol=1e-14,
                                   reltol=1e-14,iabstol=1e-14,ireltol=1e-12,
-                                  checkpoints=sol.t[1:10:end],
+                                  checkpoints=sol.t[1:500:end],
                                   sensealg=InterpolatingAdjoint(checkpointing=true))
 easy_res38 = adjoint_sensitivities(sol,Tsit5(),g,nothing,abstol=1e-14,
                                   reltol=1e-14,iabstol=1e-14,ireltol=1e-12,
-                                  checkpoints=sol.t[1:10:end],
+                                  checkpoints=sol.t[1:500:end],
                                   sensealg=InterpolatingAdjoint(checkpointing=true,autojacvec=false))
 
 @test norm(easy_res .- res) < 1e-8

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -252,6 +252,11 @@ ū04,adj4 = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
                                     checkpoints=sol.t[1:10:end],
                                     reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
 
+@test_throws Any adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
+                         sensealg=InterpolatingAdjoint(checkpointing=true),
+                         checkpoints=sol.t[1:5:end],
+                         reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
+
 ū042,adj42 = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
                                     sensealg=InterpolatingAdjoint(checkpointing=true,autojacvec=false),
                                     checkpoints=sol.t[1:10:end],

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -252,7 +252,7 @@ ū04,adj4 = adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
                                     checkpoints=sol.t[1:10:end],
                                     reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
 
-@test_throws Any adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
+@test_nowarn adjoint_sensitivities_u0(sol,Tsit5(),dg,t,abstol=1e-14,
                          sensealg=InterpolatingAdjoint(checkpointing=true),
                          checkpoints=sol.t[1:5:end],
                          reltol=1e-14,iabstol=1e-14,ireltol=1e-12)


### PR DESCRIPTION
Fix https://github.com/JuliaDiffEq/DiffEqSensitivity.jl/issues/145

I removed the internal logic for enabling checkpointing, so that the user can take full control, e.g. use linear interpolation without doing checkpointing.