### PR TITLE
Always return a DiffEqArray

### DIFF
--- a/src/local_sensitivity/concrete_solve.jl
+++ b/src/local_sensitivity/concrete_solve.jl
@@ -89,7 +89,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,sensealg::AbstractForwardSe
      end
      (nothing,nothing,nothing,adj,ntuple(_->nothing, length(args))...)
    end
-   DiffEqArray(u,sol.t),forward_sensitivity_backpass
+   DiffEqArray([u[:,i] for i in 1:size(u,2)],sol.t),forward_sensitivity_backpass
 end
 
 function DiffEqBase._concrete_solve_forward(prob,alg,
@@ -102,7 +102,7 @@ function DiffEqBase._concrete_solve_forward(prob,alg,
      x3 !== nothing && error("Pushforward currently requires no u0 derivatives")
      du * Δp
    end
-   DiffEqArray(u,sol.t),_concrete_solve_pushforward
+   DiffEqArray([u[:,i] for i in 1:size(u,2)],sol.t),_concrete_solve_pushforward
 end
 
 # Generic Fallback for ForwardDiff
@@ -138,7 +138,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
     end
     (nothing,nothing,nothing,adj,ntuple(_->nothing, length(args))...)
   end
-  DiffEqArray(u,sol.t),forward_sensitivity_backpass
+  DiffEqArray([u[:,i] for i in 1:size(u,2)],sol.t),forward_sensitivity_backpass
 end
 
 function DiffEqBase._concrete_solve_adjoint(prob,alg,sensealg::ZygoteAdjoint,

--- a/src/local_sensitivity/concrete_solve.jl
+++ b/src/local_sensitivity/concrete_solve.jl
@@ -45,12 +45,10 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
     sol_idxs = 1:length(sol)
     no_start && (sol_idxs = sol_idxs[2:end])
     no_end && (sol_idxs = sol_idxs[1:end-1])
-    # If didn't save start, take off first. If only wanted the end, return vector
     only_end = length(sol_idxs) <= 1
-    u = sol[sol_idxs]
-    only_end && (sol_idxs = length(sol))
-    out = only_end ? sol[end] : reduce((x,y)->cat(x,y,dims=ndims(u)),u.u)
+    u = sol.u[sol_idxs]
     ts = sol.t[sol_idxs]
+    out = DiffEqArray(u,ts)
   else
     ts = saveat
     out = sol(ts)
@@ -91,7 +89,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,sensealg::AbstractForwardSe
      end
      (nothing,nothing,nothing,adj,ntuple(_->nothing, length(args))...)
    end
-   u,forward_sensitivity_backpass
+   DiffEqArray(u,sol.t),forward_sensitivity_backpass
 end
 
 function DiffEqBase._concrete_solve_forward(prob,alg,
@@ -140,7 +138,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
     end
     (nothing,nothing,nothing,adj,ntuple(_->nothing, length(args))...)
   end
-  u,forward_sensitivity_backpass
+  DiffEqArray(u,sol.t),forward_sensitivity_backpass
 end
 
 function DiffEqBase._concrete_solve_adjoint(prob,alg,sensealg::ZygoteAdjoint,

--- a/src/local_sensitivity/forward_sensitivity.jl
+++ b/src/local_sensitivity/forward_sensitivity.jl
@@ -186,14 +186,14 @@ extract_local_sensitivities(tmp, sol, t, asmatrix::Bool) = extract_local_sensiti
 # Get ODE u vector and sensitivity values from all time points
 function extract_local_sensitivities(sol,::ForwardSensitivity, ::Val{false})
   ni = sol.prob.f.numindvar
-  u = [sol[i][1:ni] for i in 1:length(sol)]
+  u = sol[1:ni, :]
   du = [sol[ni*j+1:ni*(j+1),:] for j in 1:sol.prob.f.numparams]
   return u, du
 end
 
 function extract_local_sensitivities(sol,::ForwardDiffSensitivity, ::Val{false})
   _sol = adapt(eltype(sol.u),sol)
-  u = map(x->map(ForwardDiff.value,x),sol.u)
+  u = ForwardDiff.value.(_sol)
   du_full = ForwardDiff.partials.(_sol)
   return u, [[du_full[i,j][k] for i in 1:size(du_full,1), j in 1:size(du_full,2)] for k in 1:length(du_full[1])]
 end
@@ -203,16 +203,16 @@ function extract_local_sensitivities(sol,::ForwardSensitivity, ::Val{true})
   ni = prob.f.numindvar
   pn = prob.f.numparams
   jsize = (ni, pn)
-  [sol[i][1:ni] for i in 1:length(sol)], map(sol.u) do u
+  sol[1:ni, :], map(sol.u) do u
     collect(reshape((@view u[ni+1:end]), jsize))
   end
 end
 
 function extract_local_sensitivities(sol,::ForwardDiffSensitivity, ::Val{true})
-  retu = map(x->map(ForwardDiff.value,x),sol.u)
+  retu = ForwardDiff.value.(adapt(eltype(sol.u),sol))
   jsize = length(sol.u[1]), ForwardDiff.npartials(sol.u[1][1])
   du = map(sol.u) do u
-    du_i = similar(retu[1], jsize)
+    du_i = similar(retu, jsize)
     for i in eachindex(u)
       du_i[i, :] = ForwardDiff.partials(u[i])
     end

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -172,7 +172,7 @@ _,end_only_res = adjoint_sensitivities(sol_end,Tsit5(),dg,t,abstol=1e-14,
 println("Calculate adjoint sensitivities from autodiff & numerical diff")
 function G(p)
   tmp_prob = remake(prob,u0=convert.(eltype(p),prob.u0),p=p)
-  sol = solve(tmp_prob,Tsit5(),abstol=1e-10,reltol=1e-10,saveat=t)
+  sol = solve(tmp_prob,Tsit5(),abstol=1e-14,reltol=1e-14,saveat=t)
   A = convert(Array,sol)
   sum(((2 .- A).^2)./2)
 end
@@ -186,7 +186,7 @@ res4 = Tracker.gradient(G,[1.5,1.0,3.0,1.0])[1]
 import ReverseDiff
 res5 = ReverseDiff.gradient(G,[1.5,1.0,3.0,1.0])
 
-@test norm(res' .- res2) < 1e-8
+@test norm(res' .- res2) < 1e-7
 @test norm(res' .- res3) < 1e-5
 @test norm(res' .- res4) < 1e-6
 @test norm(res' .- res5) < 1e-6


### PR DESCRIPTION
The adjoints should all commit to returning the same DiffEqArray as the forward pass, otherwise the semantics get confusing and different during the gradient passes. Fixes https://github.com/JuliaDiffEq/DiffEqFlux.jl/issues/153