### PR TITLE
better tspandual defaulting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqSensitivity"
 uuid = "41bf760c-e81c-5289-8e54-58b1f1f8abe2"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.7.1"
+version = "6.7.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/local_sensitivity/concrete_solve.jl
+++ b/src/local_sensitivity/concrete_solve.jl
@@ -118,7 +118,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
   if (convert_tspan(sensealg) === nothing && (
         (haskey(kwargs,:callback) && has_continuous_callback(kwargs.callback)) ||
         (haskey(prob.kwargs,:callback) && has_continuous_callback(prob.kwargs.callback))
-        )) || convert_tspan(alg)
+        )) || (convert_tspan(alg) !== nothing && convert_tspan(alg))
 
     tspandual = convert.(eltype(pdual),prob.tspan)
   else

--- a/src/local_sensitivity/concrete_solve.jl
+++ b/src/local_sensitivity/concrete_solve.jl
@@ -118,7 +118,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
   if (convert_tspan(sensealg) === nothing && (
         (haskey(kwargs,:callback) && has_continuous_callback(kwargs.callback)) ||
         (haskey(prob.kwargs,:callback) && has_continuous_callback(prob.kwargs.callback))
-        )) || (convert_tspan(alg) !== nothing && convert_tspan(alg))
+        )) || (convert_tspan(sensealg) !== nothing && convert_tspan(alg))
 
     tspandual = convert.(eltype(pdual),prob.tspan)
   else

--- a/src/local_sensitivity/concrete_solve.jl
+++ b/src/local_sensitivity/concrete_solve.jl
@@ -114,11 +114,17 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
   MyTag = typeof(prob.f)
   pdual = seed_duals(p,MyTag)
   u0dual = convert.(eltype(pdual),u0)
-  if convert_tspan(sensealg)
+
+  if (convert_tspan(sensealg) === nothing && (
+        (haskey(kwargs,:callback) && has_continuous_callback(kwargs.callback)) ||
+        (haskey(prob.kwargs,:callback) && has_continuous_callback(prob.kwargs.callback))
+        )) || convert_tspan(alg)
+
     tspandual = convert.(eltype(pdual),prob.tspan)
   else
     tspandual = prob.tspan
   end
+
   _prob = remake(prob,u0=u0dual,p=pdual,tspan=tspandual)
 
   if saveat isa Number

--- a/src/local_sensitivity/forward_sensitivity.jl
+++ b/src/local_sensitivity/forward_sensitivity.jl
@@ -170,9 +170,9 @@ function ODEForwardSensitivityProblem(f::DiffEqBase.AbstractODEFunction,u0,
   pdual = seed_duals(p,MyTag)
   u0dual = convert.(eltype(pdual),u0)
 
-  if (convert_tspan(alg) === nothing && 
+  if (convert_tspan(alg) === nothing &&
     haskey(kwargs,:callback) && has_continuous_callback(kwargs.callback)
-    ) || convert_tspan(alg)
+    ) || (convert_tspan(alg) !== nothing && convert_tspan(alg))
     tspandual = convert.(eltype(pdual),tspan)
   else
     tspandual = tspan

--- a/src/local_sensitivity/forward_sensitivity.jl
+++ b/src/local_sensitivity/forward_sensitivity.jl
@@ -170,13 +170,14 @@ function ODEForwardSensitivityProblem(f::DiffEqBase.AbstractODEFunction,u0,
   pdual = seed_duals(p,MyTag)
   u0dual = convert.(eltype(pdual),u0)
 
-  if convert_tspan(alg) === nothing
-    tspandual = haskey(kwargs,:callback) && has_continuous_callback(kwargs.callback) 
-  elseif convert_tspan(alg)
+  if (convert_tspan(alg) === nothing && 
+    haskey(kwargs,:callback) && has_continuous_callback(kwargs.callback)
+    ) || convert_tspan(alg)
     tspandual = convert.(eltype(pdual),tspan)
   else
     tspandual = tspan
   end
+
   prob_dual = ODEProblem(f,u0dual,tspan,pdual;
                          problem_type=ODEForwardSensitivityProblem{DiffEqBase.isinplace(f),
                                                                    typeof(alg)}(alg),

--- a/src/local_sensitivity/sensitivity_algorithms.jl
+++ b/src/local_sensitivity/sensitivity_algorithms.jl
@@ -15,7 +15,7 @@ end
 
 struct ForwardDiffSensitivity{CS,CTS} <: AbstractForwardSensitivityAlgorithm{CS,Nothing,Nothing}
 end
-Base.@pure function ForwardDiffSensitivity(;chunk_size=0,convert_tspan=true)
+Base.@pure function ForwardDiffSensitivity(;chunk_size=0,convert_tspan=nothing)
   ForwardDiffSensitivity{chunk_size,convert_tspan}()
 end
 


### PR DESCRIPTION
Everything here can be done with type information, so it should optimize at compile time and remove the possible type instability. Even if it doesn't... it's so small and hits a function barrier.