### PR TITLE
Second order sensitivity analysis

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqSensitivity"
 uuid = "41bf760c-e81c-5289-8e54-58b1f1f8abe2"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.7.2"
+version = "6.8.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/DiffEqSensitivity.jl
+++ b/src/DiffEqSensitivity.jl
@@ -19,6 +19,7 @@ include("local_sensitivity/backsolve_adjoint.jl")
 include("local_sensitivity/interpolating_adjoint.jl")
 include("local_sensitivity/quadrature_adjoint.jl")
 include("local_sensitivity/concrete_solve.jl")
+include("local_sensitivity/second_order.jl")
 include("global_sensitivity/morris_sensitivity.jl")
 include("global_sensitivity/sobol_sensitivity.jl")
 include("global_sensitivity/regression_sensitivity.jl")
@@ -34,7 +35,10 @@ export ODEForwardSensitivityFunction, ODEForwardSensitivityProblem, SensitivityF
 
 export BacksolveAdjoint, QuadratureAdjoint, InterpolatingAdjoint,
        TrackerAdjoint, ZygoteAdjoint,
-       ForwardSensitivity, ForwardDiffSensitivity
+       ForwardSensitivity, ForwardDiffSensitivity,
+       ForwardDiffOverAdjoint
+
+export second_order_sensitivities, second_order_sensitivity_product
 
 export TrackerVJP, ZygoteVJP, ReverseDiffVJP
 end # module

--- a/src/local_sensitivity/second_order.jl
+++ b/src/local_sensitivity/second_order.jl
@@ -1,0 +1,17 @@
+function _second_order_sensitivities(loss,prob,alg,sensealg::ForwardDiffOverAdjoint,
+                                     args...;kwargs...)
+   ForwardDiff.jacobian(prob.p) do p
+     x = Zygote.gradient(p) do _p
+       loss(concrete_solve(prob,alg,prob.u0,_p,args...;sensealg=sensealg.adjalg,kwargs...))
+     end
+     first(x)
+   end
+end
+
+function _second_order_sensitivity_product(loss,v,prob,alg,sensealg::ForwardDiffOverAdjoint,
+                                           args...;kwargs...)
+
+   θ = ForwardDiff.Dual.(prob.p,v)
+   _loss = p -> loss(concrete_solve(prob,alg,prob.u0,p,args...;sensealg=sensealg.adjalg,kwargs...))
+   getindex.(ForwardDiff.partials.(Zygote.gradient(_loss,θ)[1]),1)
+end

--- a/src/local_sensitivity/sensitivity_algorithms.jl
+++ b/src/local_sensitivity/sensitivity_algorithms.jl
@@ -2,6 +2,7 @@ SensitivityAlg(args...;kwargs...) = @error("The SensitivtyAlg choice mechanism w
 
 abstract type AbstractForwardSensitivityAlgorithm{CS,AD,FDT} <: DiffEqBase.AbstractSensitivityAlgorithm{CS,AD,FDT} end
 abstract type AbstractAdjointSensitivityAlgorithm{CS,AD,FDT} <: DiffEqBase.AbstractSensitivityAlgorithm{CS,AD,FDT} end
+abstract type AbstractSecondOrderSensitivityAlgorithm{CS,AD,FDT} <: DiffEqBase.AbstractSensitivityAlgorithm{CS,AD,FDT} end
 
 struct ForwardSensitivity{CS,AD,FDT} <: AbstractForwardSensitivityAlgorithm{CS,AD,FDT}
   autojacvec::Bool
@@ -73,3 +74,7 @@ end
 @inline ischeckpointing(alg::DiffEqBase.AbstractSensitivityAlgorithm, ::Vararg) = isdefined(alg, :checkpointing) ? alg.checkpointing : false
 @inline ischeckpointing(alg::InterpolatingAdjoint, sol) = alg.checkpointing || !sol.dense
 @inline compile_tape(vjp::ReverseDiffVJP{compile}) where compile = compile
+
+struct ForwardDiffOverAdjoint{A} <: AbstractSecondOrderSensitivityAlgorithm{nothing,true,nothing}
+  adjalg::A
+end

--- a/src/local_sensitivity/sensitivity_interface.jl
+++ b/src/local_sensitivity/sensitivity_interface.jl
@@ -21,3 +21,15 @@ function _adjoint_sensitivities(sol,sensealg,alg,g,t=nothing,dg=nothing;
   -adj_sol[end][1:length(sol.prob.u0)],
     adj_sol[end][(1:l) .+ length(sol.prob.u0)]'
 end
+
+function second_order_sensitivities(loss,prob,alg,args...;
+                                    sensealg=ForwardDiffOverAdjoint(InterpolatingAdjoint(autojacvec=ReverseDiffVJP())),
+                                    kwargs...)
+  _second_order_sensitivities(loss,prob,alg,sensealg,args...;kwargs...)
+end
+
+function second_order_sensitivity_product(loss,v,prob,alg,args...;
+                                          sensealg=ForwardDiffOverAdjoint(InterpolatingAdjoint(autojacvec=ReverseDiffVJP())),
+                                          kwargs...)
+  _second_order_sensitivity_product(loss,v,prob,alg,sensealg,args...;kwargs...)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ const is_TRAVIS = haskey(ENV,"TRAVIS")
 if GROUP == "All" || GROUP == "Core" || GROUP == "Downstream"
     @time @safetestset "Forward Sensitivity" begin include("forward.jl") end
     @time @safetestset "Adjoint Sensitivity" begin include("adjoint.jl") end
+    @time @safetestset "Second Order Sensitivity" begin include("second_order.jl") end
     @time @safetestset "Concrete Solve Derivatives" begin include("concrete_solve_derivatives.jl") end
     @time @safetestset "Morris Method" begin include("morris_method.jl") end
     @time @safetestset "Sobol Method" begin include("sobol_method.jl") end

--- a/test/second_order.jl
+++ b/test/second_order.jl
@@ -1,0 +1,31 @@
+using DiffEqSensitivity, OrdinaryDiffEq, DiffEqBase, ForwardDiff
+using Test
+
+function fb(du,u,p,t)
+  du[1] = dx = p[1]*u[1] - p[2]*u[1]*u[2]
+  du[2] = dy = -p[3]*u[2] + p[4]*u[1]*u[2]
+end
+
+function jac(J,u,p,t)
+  (x, y, a, b, c) = (u[1], u[2], p[1], p[2], p[3])
+  J[1,1] = a + y * b * -1
+  J[2,1] = y
+  J[1,2] = b * x * -1
+  J[2,2] = c * -1 + x
+end
+
+f = ODEFunction(fb,jac=jac)
+p = [1.5,1.0,3.0,1.0]; u0 = [1.0;1.0]
+prob = ODEProblem(f,u0,(0.0,10.0),p)
+loss(sol) = sum(sol)
+v = ones(4)
+
+H  = second_order_sensitivities(loss,prob,Vern9(),saveat=0.1,abstol=1e-12,reltol=1e-12)
+Hv = second_order_sensitivity_product(loss,v,prob,Vern9(),saveat=0.1,abstol=1e-12,reltol=1e-12)
+
+_loss(p) = loss(concrete_solve(prob,Vern9(),u0,p,saveat=0.1,abstol=1e-12,reltol=1e-12))
+H2 = ForwardDiff.hessian(_loss,p)
+H2v = H*v
+
+@test H ≈ H2
+@test Hv ≈ H2v


### PR DESCRIPTION
Actually figuring out how to do this is somewhat tricky, so while I think there's still a lot more work to be done and better interfaces can be had, this is at least something we can release as an "experimental" interface to users. Down the line I will want to set this up with using `dg` instead of a `loss(sol)` and such (and then it could use a continuous loss and all of that), that way it can dig into the adjoints more, but we can punt on that for now. At least like this users can start to use it.

One function generates H, the other does Hv. There's some optimizations you get in the H calculation (due to chunk size), so it makes sense to have both.

I plan to label them in the docs as experimental so that I have the freedom to break the interface in the feature, but for now, this is very helpful for some users.

Fixes https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/375