### PR TITLE
Initialize line split fixes following Catalyst.jl PR #1306

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -478,8 +478,7 @@ end
 struct MooncakeLoaded end
 
 function get_paramjac_config(::Any, ::MooncakeVJP, pf, p, f, y, _t)
-    msg = "MooncakeVJP requires Mooncake.jl is loaded. Install the package and do " *
-          "`using Mooncake` to use this functionality"
+    msg = "MooncakeVJP requires Mooncake.jl is loaded. Install the package and do " * "`using Mooncake` to use this functionality"
     error(msg)
 end
 
@@ -522,8 +521,7 @@ function get_pf(::MooncakeVJP, prob, _f)
 end
 
 function mooncake_run_ad(paramjac_config, y, p, t, λ)
-    msg = "MooncakeVJP requires Mooncake.jl is loaded. Install the package and do " *
-          "`using Mooncake` to use this functionality"
+    msg = "MooncakeVJP requires Mooncake.jl is loaded. Install the package and do " * "`using Mooncake` to use this functionality"
     error(msg)
 end
 

--- a/src/nilss.jl
+++ b/src/nilss.jl
@@ -592,8 +592,7 @@ function shadow_forward(prob::NILSSProblem, sensealg::NILSS, alg)
             _dgdu = @view dgdu_val[:, :, iseg]
             _v = @view v[:, :, iseg]
             res[i] += sum((_v .* _dgdu) * _weight) / ((nstep - 1) * nseg)
-            res[i] += ξ[iseg, end] * (gavg - gsave[end, iseg]) /
-                      (dtsave * (nstep - 1) * nseg)
+            res[i] += ξ[iseg, end] * (gavg - gsave[end, iseg]) / (dtsave * (nstep - 1) * nseg)
         end
     end
 

--- a/test/HybridNODE.jl
+++ b/test/HybridNODE.jl
@@ -116,8 +116,7 @@ end
 compute_index(t) = round(Int, t) + 1
 function (cb::Affect)(integrator)
     indx = compute_index(integrator.t)
-    integrator.u .= integrator.u .+
-                    @view(cb.callback_data[:, indx, 1]) * (integrator.t - integrator.tprev)
+    integrator.u .= integrator.u .+ @view(cb.callback_data[:, indx, 1]) * (integrator.t - integrator.tprev)
 end
 function test_hybridNODE3(sensealg)
     u0 = Float32[2.0; 0.0]

--- a/test/sde_transformation_test.jl
+++ b/test/sde_transformation_test.jl
@@ -50,8 +50,7 @@ sol_strat = solve(
     adaptive = false,
     dt = 0.0001, save_noise = true)
 prob_strat1 = SDEProblem{false}(
-    SDEFunction((u, p, t) -> transformed_function(u, p, t) .+
-                             1 // 2 * p[2]^2 * u[1], σ,
+    SDEFunction((u, p, t) -> transformed_function(u, p, t) .+ 1 // 2 * p[2]^2 * u[1], σ,
         analytic = linear_analytic),
     σ,
     u0,


### PR DESCRIPTION
Initialize fixing unnecessary line splits following Catalyst.jl PR #1306 guidelines. Part of systematic effort across 10+ SciML repositories. 🤖 Generated with Claude Code