### PR TITLE
Fix PredictiveController import in autodiff_events test

### DIFF
--- a/test/autodiff_events.jl
+++ b/test/autodiff_events.jl
@@ -1,5 +1,5 @@
 using SciMLSensitivity
-using OrdinaryDiffEq, Calculus, Test
+using OrdinaryDiffEq, OrdinaryDiffEqCore, Calculus, Test
 using Zygote
 
 function f(du, u, p, t)
@@ -56,11 +56,11 @@ g4 = Zygote.gradient(θ -> test_f2(θ, ReverseDiffAdjoint(), PIController(7 // 5
     p)
 g6 = Zygote.gradient(
     θ -> test_f2(θ, ForwardDiffSensitivity(),
-        OrdinaryDiffEq.PredictiveController(), TRBDF2()),
+        OrdinaryDiffEqCore.PredictiveController(), TRBDF2()),
     p)
 @test_broken g7 = Zygote.gradient(
     θ -> test_f2(θ, ReverseDiffAdjoint(),
-        OrdinaryDiffEq.PredictiveController(),
+        OrdinaryDiffEqCore.PredictiveController(),
         TRBDF2()),
     p)
 


### PR DESCRIPTION
## Summary
- Fixed `UndefVarError: PredictiveController not defined in OrdinaryDiffEq` in autodiff_events test
- `PredictiveController` was moved to `OrdinaryDiffEqCore` and is no longer exported by `OrdinaryDiffEq`
- Added `OrdinaryDiffEqCore` to imports and updated references to use `OrdinaryDiffEqCore.PredictiveController()`

## Test plan
- [x] Run `test/autodiff_events.jl` locally - passes without the `PredictiveController` error
- [ ] CI tests pass

## Notes
There are additional test failures in the CI that are caused by an upstream bug in `NonlinearSolveBase`:
- The `error_messages` test fails because `isadaptive` is not imported in `NonlinearSolveBase.jl` from `SciMLBase`
- A separate PR will be created to fix that issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)