### PR TITLE
Fix ExplicitImports: access _concrete_solve_* via SciMLBase

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -370,7 +370,7 @@ function SciMLBase._concrete_solve_adjoint(
             QuadratureAdjoint,
             InterpolatingAdjoint,
             GaussAdjoint,
-			GaussKronrodAdjoint},
+            GaussKronrodAdjoint},
         u0, p, originator::SciMLBase.ADOriginator,
         args...; save_start = true, save_end = true,
         saveat = eltype(prob.tspan)[],


### PR DESCRIPTION
## Summary
- Change qualified accesses from `DiffEqBase._concrete_solve_adjoint` to `SciMLBase._concrete_solve_adjoint`
- Change qualified accesses from `DiffEqBase._concrete_solve_forward` to `SciMLBase._concrete_solve_forward`

These functions are owned by `SciMLBase`, so they should be accessed via their owner module to satisfy ExplicitImports checks.

## Test plan
- [ ] CI should pass, specifically the ExplicitImports test

🤖 Generated with [Claude Code](https://claude.com/claude-code)