### PR TITLE
Fix ExplicitImports: access _concrete_solve_adjoint via SciMLBase in Mooncake ext

### DIFF
--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -28,7 +28,7 @@ function mooncake_run_ad(paramjac_config::Tuple, y, p, t, λ)
     return dy, y_grad, p_grad
 end
 
-function DiffEqBase._concrete_solve_adjoint(
+function SciMLBase._concrete_solve_adjoint(
         prob::Union{SciMLBase.AbstractDiscreteProblem,
             SciMLBase.AbstractODEProblem,
             SciMLBase.AbstractDAEProblem,


### PR DESCRIPTION
## Summary
Fix ExplicitImports test failure by changing `DiffEqBase._concrete_solve_adjoint` to `SciMLBase._concrete_solve_adjoint` in the Mooncake extension.

This is a follow-up to PR #1298 which made the same change in the main `concrete_solve.jl` but missed the extension file.

## Test plan
- [ ] Verify ExplicitImports test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)