### PR TITLE
Fix DiffEqBase to SciMLBase references in aqua.jl

### DIFF
--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,12 +1,12 @@
-using SciMLSensitivity, Aqua, DiffEqBase, ExplicitImports
+using SciMLSensitivity, Aqua, SciMLBase, ExplicitImports
 
 @testset "Aqua" begin
     Aqua.find_persistent_tasks_deps(SciMLSensitivity)
     Aqua.test_ambiguities(SciMLSensitivity, recursive = false)
     Aqua.test_deps_compat(SciMLSensitivity)
     Aqua.test_piracies(SciMLSensitivity;
-        treat_as_own = [DiffEqBase._concrete_solve_adjoint,
-            DiffEqBase._concrete_solve_forward])
+        treat_as_own = [SciMLBase._concrete_solve_adjoint,
+            SciMLBase._concrete_solve_forward])
     Aqua.test_project_extras(SciMLSensitivity)
     Aqua.test_stale_deps(SciMLSensitivity)
     Aqua.test_unbound_args(SciMLSensitivity)


### PR DESCRIPTION
## Summary
- Change `_concrete_solve_adjoint` and `_concrete_solve_forward` references from `DiffEqBase` to `SciMLBase` in `test/aqua.jl`
- Update import from `DiffEqBase` to `SciMLBase`

This follows the API migration where these functions moved to SciMLBase.

## Test plan
- [ ] CI passes for Aqua tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)