### PR TITLE
Fix headers for markdown admonition blocks

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -1,6 +1,6 @@
 # [Getting Started with SciMLSensitivity: Differentiating ODE Solutions](@id auto_diff)
 
-!!! warn
+!!! warning
     
     This tutorial assumes familiarity with DifferentialEquations.jl.
     If you are not familiar with DifferentialEquations.jl, please consult

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -691,7 +691,7 @@ TrackerAdjoint()
 This `sensealg` supports any `DEProblem` if the algorithm is `SciMLBase.isautodifferentiable`
 Compatible with a limited subset of `AbstractArray` types for `u0`, including `CuArrays`.
 
-!!! warn
+!!! warning
 
     TrackerAdjoint is incompatible with Stiff ODE solvers using forward-mode automatic
     differentiation for the Jacobians. Thus, for example, `TRBDF2()` will error. Instead,
@@ -710,7 +710,7 @@ MooncakeAdjoint <: AbstractAdjointSensitivityAlgorithm{nothing, true, nothing}
 An implementation of discrete adjoint sensitivity analysis
 using the Mooncake.jl direct differentiation.
 
-!!! warn
+!!! warning
 
     This is currently experimental and supports only explicit solvers. It will
     support all solvers in the future.
@@ -756,7 +756,7 @@ An implementation of discrete adjoint sensitivity analysis
 using the Zygote.jl source-to-source AD directly on the differential equation
 solver.
 
-!!! warn
+!!! warning
 
     This is only supports SimpleDiffEq.jl solvers due to limitations of Enzyme.
 
@@ -779,7 +779,7 @@ An implementation of discrete adjoint sensitivity analysis
 using the Enzyme.jl source-to-source AD directly on the differential equation
 solver.
 
-!!! warn
+!!! warning
 
     This is currently experimental and supports only explicit solvers. It will
     support all solvers in the future.


### PR DESCRIPTION

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

`warn` → `warning`. Markdown.jl doesn't recognize `warn` as a admonition block header.
