### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -4,39 +4,16 @@ on:
   push:
     branches:
       - 'master'
+      - 'main'
       - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+  runic:
+    runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
         with:
-          version: ${{ matrix.julia-version }}
-
-      - uses: actions/checkout@v6
-      - name: Install JuliaFormatter and format
-        # This will use the latest version by default but you can set the version like so:
-        #
-        # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
-        run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
-          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
-      - name: Format check
-        run: |
-          julia -e '
-          out = Cmd(`git diff --name-only`) |> read |> String
-          if out == ""
-              exit(0)
-          else
-              @error "Some files have not been formatted !!!"
-              write(stdout, out)
-              exit(1)
-          end'
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,14 +9,20 @@ using Plots
 
 include("pages.jl")
 
-makedocs(sitename = "SciMLSensitivity.jl",
+makedocs(
+    sitename = "SciMLSensitivity.jl",
     authors = "Chris Rackauckas et al.",
     modules = [SciMLSensitivity],
     clean = true, doctest = false, linkcheck = true,
     warnonly = [:missing_docs],
-    format = Documenter.HTML(assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/SciMLSensitivity/stable/"),
-    pages = pages)
+    format = Documenter.HTML(
+        assets = ["assets/favicon.ico"],
+        canonical = "https://docs.sciml.ai/SciMLSensitivity/stable/"
+    ),
+    pages = pages
+)
 
-deploydocs(repo = "github.com/SciML/SciMLSensitivity.jl.git";
-    push_preview = true)
+deploydocs(
+    repo = "github.com/SciML/SciMLSensitivity.jl.git";
+    push_preview = true
+)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,40 +1,54 @@
-pages = ["index.md",
+pages = [
+    "index.md",
     "getting_started.md",
-    "Tutorials" => Any["tutorials/parameter_estimation_ode.md",
+    "Tutorials" => Any[
+        "tutorials/parameter_estimation_ode.md",
         "tutorials/direct_sensitivity.md",
         "tutorials/adjoint_continuous_functional.md",
         "tutorials/data_parallel.md",
         "tutorials/chaotic_ode.md",
-        "Training Techniques and Tips" => Any["tutorials/training_tips/local_minima.md",
+        "Training Techniques and Tips" => Any[
+            "tutorials/training_tips/local_minima.md",
             "tutorials/training_tips/divergence.md",
-            "tutorials/training_tips/multiple_nn.md"]],
+            "tutorials/training_tips/multiple_nn.md",
+        ],
+    ],
     "Frequently Asked Questions (FAQ)" => "faq.md",
     "Examples" => Any[
-        "Ordinary Differential Equations (ODEs)" => Any["examples/ode/exogenous_input.md",
+        "Ordinary Differential Equations (ODEs)" => Any[
+            "examples/ode/exogenous_input.md",
             "examples/ode/prediction_error_method.md",
             "examples/ode/second_order_adjoints.md",
-            "examples/ode/second_order_neural.md"],
+            "examples/ode/second_order_neural.md",
+        ],
         "Neural Ordinary Differential Equations (Neural ODE)" => Any[
-            "examples/neural_ode/simplechains.md"],
+            "examples/neural_ode/simplechains.md",
+        ],
         "Stochastic Differential Equations (SDEs)" => Any[
             "examples/sde/optimization_sde.md",
-            "examples/sde/SDE_control.md"],
+            "examples/sde/SDE_control.md",
+        ],
         "Delay Differential Equations (DDEs)" => Any["examples/dde/delay_diffeq.md"],
         "Partial Differential Equations (PDEs)" => Any[
             "examples/pde/pde_constrained.md",
-            "examples/pde/brusselator.md"
+            "examples/pde/brusselator.md",
         ],
-        "Hybrid and Jump Equations" => Any["examples/hybrid_jump/hybrid_diffeq.md",
-            "examples/hybrid_jump/bouncing_ball.md"],
+        "Hybrid and Jump Equations" => Any[
+            "examples/hybrid_jump/hybrid_diffeq.md",
+            "examples/hybrid_jump/bouncing_ball.md",
+        ],
         "Bayesian Estimation" => Any["examples/bayesian/turing_bayesian.md"],
         "Optimal and Model Predictive Control" => Any[
             "examples/optimal_control/optimal_control.md",
-            "examples/optimal_control/feedback_control.md"]],
+            "examples/optimal_control/feedback_control.md",
+        ],
+    ],
     "Manual and APIs" => Any[
         "manual/differential_equation_sensitivities.md",
         "manual/nonlinear_solve_sensitivities.md",
         "manual/direct_forward_sensitivity.md",
-        "manual/direct_adjoint_sensitivities.md"],
+        "manual/direct_adjoint_sensitivities.md",
+    ],
     "Benchmarks" => "Benchmark.md",
-    "Sensitivity Math Details" => "sensitivity_math.md"
+    "Sensitivity Math Details" => "sensitivity_math.md",
 ]

--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -3,11 +3,11 @@ module SciMLSensitivityMooncakeExt
 using SciMLSensitivity: SciMLSensitivity
 using Mooncake: Mooncake
 import SciMLSensitivity: get_paramjac_config, mooncake_run_ad, MooncakeVJP, MooncakeLoaded,
-                         DiffEqBase, MooncakeAdjoint
+    DiffEqBase, MooncakeAdjoint
 using SciMLSensitivity: SciMLBase, SciMLStructures, canonicalize, Tunable, isscimlstructure,
-                        SciMLStructuresCompatibilityError, convert_tspan,
-                        has_continuous_callback,
-                        unwrapped_f, state_values, current_time
+    SciMLStructuresCompatibilityError, convert_tspan,
+    has_continuous_callback,
+    unwrapped_f, state_values, current_time
 using SciMLSensitivity: FunctionWrappersWrappers, ODEFunction
 using ChainRulesCore: NoTangent, ZeroTangent, Tangent, unthunk
 using Accessors: @reset
@@ -29,17 +29,20 @@ function mooncake_run_ad(paramjac_config::Tuple, y, p, t, λ)
 end
 
 function SciMLBase._concrete_solve_adjoint(
-        prob::Union{SciMLBase.AbstractDiscreteProblem,
+        prob::Union{
+            SciMLBase.AbstractDiscreteProblem,
             SciMLBase.AbstractODEProblem,
             SciMLBase.AbstractDAEProblem,
             SciMLBase.AbstractDDEProblem,
             SciMLBase.AbstractSDEProblem,
             SciMLBase.AbstractSDDEProblem,
-            SciMLBase.AbstractRODEProblem},
+            SciMLBase.AbstractRODEProblem,
+        },
         alg, sensealg::MooncakeAdjoint,
         u0, p, originator::SciMLBase.ADOriginator,
         args...;
-        kwargs...)
+        kwargs...
+    )
     if !(p === nothing || p isa SciMLBase.NullParameters)
         if !isscimlstructure(p)
             throw(SciMLStructuresCompatibilityError())
@@ -53,9 +56,11 @@ function SciMLBase._concrete_solve_adjoint(
     end
 
     function mooncake_adjoint_forwardpass(_u0, _p)
-        if (convert_tspan(sensealg) === nothing &&
-            ((haskey(kwargs, :callback) && has_continuous_callback(kwargs[:callback])))) ||
-           (convert_tspan(sensealg) !== nothing && convert_tspan(sensealg))
+        if (
+                convert_tspan(sensealg) === nothing &&
+                    ((haskey(kwargs, :callback) && has_continuous_callback(kwargs[:callback])))
+            ) ||
+                (convert_tspan(sensealg) !== nothing && convert_tspan(sensealg))
             _tspan = convert.(eltype(_p), prob.tspan)
         else
             _tspan = prob.tspan
@@ -63,29 +68,36 @@ function SciMLBase._concrete_solve_adjoint(
 
         if DiffEqBase.isinplace(prob)
             if prob.f isa ODEFunction &&
-               (prob.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper ||
-                SciMLBase.specialization(prob.f) === SciMLBase.AutoSpecialize)
+                    (
+                    prob.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper ||
+                        SciMLBase.specialization(prob.f) === SciMLBase.AutoSpecialize
+                )
                 f = ODEFunction{isinplace(prob), SciMLBase.FullSpecialize}(unwrapped_f(prob.f))
                 _prob = remake(
-                    prob, f = f, u0 = _u0, p = _p, tspan = _tspan, callback = nothing)
+                    prob, f = f, u0 = _u0, p = _p, tspan = _tspan, callback = nothing
+                )
             else
                 _prob = remake(prob, u0 = _u0, p = _p, tspan = _tspan, callback = nothing)
             end
         else
-            _prob = remake(prob, u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p),
-                tspan = _tspan, callback = nothing)
+            _prob = remake(
+                prob, u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p),
+                tspan = _tspan, callback = nothing
+            )
         end
 
         kwargs_filtered = NamedTuple(filter(x -> x[1] != :sensealg, kwargs))
-        sol = solve(_prob, alg, args...; sensealg = DiffEqBase.SensitivityADPassThrough(),
-            kwargs_filtered...)
+        sol = solve(
+            _prob, alg, args...; sensealg = DiffEqBase.SensitivityADPassThrough(),
+            kwargs_filtered...
+        )
         sol = SciMLBase.sensitivity_solution(sol, state_values(sol), current_time(sol))
         @reset sol.prob = prob
-        sol
+        return sol
     end
 
     out,
-    pullback = Mooncake.value_and_pullback!!(
+        pullback = Mooncake.value_and_pullback!!(
         Mooncake.CoDual(mooncake_adjoint_forwardpass, Mooncake.NoFData()),
         Mooncake.CoDual(u0, Mooncake.zero_rdata(u0)),
         Mooncake.CoDual(tunables, Mooncake.zero_rdata(tunables))
@@ -115,20 +127,24 @@ function SciMLBase._concrete_solve_adjoint(
         _, u0bar, pbar = pullback(tmp)
         _u0bar = u0bar
 
-        if originator isa SciMLBase.TrackerOriginator ||
-           originator isa SciMLBase.ReverseDiffOriginator
-            (NoTangent(), NoTangent(), _u0bar, pbar, NoTangent(),
-                ntuple(_ -> NoTangent(), length(args))...)
+        return if originator isa SciMLBase.TrackerOriginator ||
+                originator isa SciMLBase.ReverseDiffOriginator
+            (
+                NoTangent(), NoTangent(), _u0bar, pbar, NoTangent(),
+                ntuple(_ -> NoTangent(), length(args))...,
+            )
         else
-            (NoTangent(), NoTangent(), NoTangent(),
+            (
+                NoTangent(), NoTangent(), NoTangent(),
                 _u0bar, pbar, NoTangent(),
-                ntuple(_ -> NoTangent(), length(args))...)
+                ntuple(_ -> NoTangent(), length(args))...,
+            )
         end
     end
 
     u = state_values(out)
-    SciMLBase.sensitivity_solution(out, u, current_time(out)),
-    mooncake_adjoint_backpass
+    return SciMLBase.sensitivity_solution(out, u, current_time(out)),
+        mooncake_adjoint_backpass
 end
 
 end

--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -1,13 +1,13 @@
 module SciMLSensitivity
 
 using ADTypes: ADTypes, AutoEnzyme, AutoFiniteDiff, AutoForwardDiff,
-               AutoReverseDiff, AutoTracker, AutoZygote
+    AutoReverseDiff, AutoTracker, AutoZygote
 using Accessors: @reset
 using Adapt: Adapt, adapt
 using ArrayInterface: ArrayInterface
 using DiffEqBase: DiffEqBase, SensitivityADPassThrough
 using DiffEqCallbacks: DiffEqCallbacks, IntegrandValuesSum, IntegratingSumCallback,
-                       IntegratingGKSumCallback, PresetTimeCallback
+    IntegratingGKSumCallback, PresetTimeCallback
 using DiffEqNoiseProcess: DiffEqNoiseProcess
 using FastBroadcast: @..
 using Functors: Functors, fmap
@@ -16,36 +16,36 @@ using FunctionWrappersWrappers: FunctionWrappersWrappers
 using GPUArraysCore: GPUArraysCore
 using LinearSolve: LinearSolve
 using PreallocationTools: PreallocationTools, dualcache, get_tmp, DiffCache,
-                          LazyBufferCache
+    LazyBufferCache
 using RandomNumbers: Xorshifts
 using RecursiveArrayTools: RecursiveArrayTools, AbstractDiffEqArray,
-                           AbstractVectorOfArray, ArrayPartition, DiffEqArray,
-                           VectorOfArray
+    AbstractVectorOfArray, ArrayPartition, DiffEqArray,
+    VectorOfArray
 using SciMLJacobianOperators: VecJacOperator, StatefulJacobianOperator
 using SciMLLogging: SciMLLogging, verbosity_to_bool
 using SciMLStructures: SciMLStructures, canonicalize, Tunable, isscimlstructure
 using SymbolicIndexingInterface: SymbolicIndexingInterface, current_time, getu,
-                                 parameter_values, state_values
+    parameter_values, state_values
 using QuadGK: quadgk
 using SciMLBase: SciMLBase, AbstractOverloadingSensitivityAlgorithm,
-                 AbstractForwardSensitivityAlgorithm, AbstractAdjointSensitivityAlgorithm,
-                 AbstractSecondOrderSensitivityAlgorithm,
-                 AbstractShadowingSensitivityAlgorithm,
-                 AbstractNonlinearProblem, AbstractSensitivityAlgorithm,
-                 AbstractDiffEqFunction, AbstractODEFunction, unwrapped_f, CallbackSet,
-                 ContinuousCallback, DESolution, NonlinearFunction, NonlinearProblem,
-                 DiscreteCallback, LinearProblem, ODEFunction, ODEProblem, DAEProblem,
-                 RODEFunction, RODEProblem, ReturnCode, SDEFunction,
-                 SDEProblem, VectorContinuousCallback, deleteat!,
-                 get_tmp_cache, has_adjoint, isinplace, reinit!, remake,
-                 solve, u_modified!, LinearAliasSpecifier, OverrideInit
+    AbstractForwardSensitivityAlgorithm, AbstractAdjointSensitivityAlgorithm,
+    AbstractSecondOrderSensitivityAlgorithm,
+    AbstractShadowingSensitivityAlgorithm,
+    AbstractNonlinearProblem, AbstractSensitivityAlgorithm,
+    AbstractDiffEqFunction, AbstractODEFunction, unwrapped_f, CallbackSet,
+    ContinuousCallback, DESolution, NonlinearFunction, NonlinearProblem,
+    DiscreteCallback, LinearProblem, ODEFunction, ODEProblem, DAEProblem,
+    RODEFunction, RODEProblem, ReturnCode, SDEFunction,
+    SDEProblem, VectorContinuousCallback, deleteat!,
+    get_tmp_cache, has_adjoint, isinplace, reinit!, remake,
+    solve, u_modified!, LinearAliasSpecifier, OverrideInit
 
 using OrdinaryDiffEqCore: OrdinaryDiffEqCore, BrownFullBasicInit, DefaultInit,
-                          default_nlsolve, has_autodiff
+    default_nlsolve, has_autodiff
 
 # AD Backends
 using ChainRulesCore: unthunk, @thunk, NoTangent, @not_implemented, Tangent, ZeroTangent,
-                      AbstractThunk, AbstractTangent
+    AbstractThunk, AbstractTangent
 using Enzyme: Enzyme
 using FiniteDiff: FiniteDiff
 using ForwardDiff: ForwardDiff
@@ -56,8 +56,8 @@ using SciMLBase.ConstructionBase: setproperties
 
 # Std Libs
 using LinearAlgebra: LinearAlgebra, Diagonal, I, UniformScaling, adjoint, axpy!,
-                     convert, copyto!, dot, issuccess, ldiv!, lu, lu!, mul!,
-                     norm, normalize!, qr, transpose
+    convert, copyto!, dot, issuccess, ldiv!, lu, lu!, mul!,
+    norm, normalize!, qr, transpose
 using Markdown: Markdown, @doc_str
 using Random: Random, rand!
 using Statistics: Statistics, mean
@@ -88,20 +88,20 @@ include("sde_tools.jl")
 export extract_local_sensitivities
 
 export ODEForwardSensitivityFunction, ODEForwardSensitivityProblem, SensitivityFunction,
-       ODEAdjointProblem, AdjointSensitivityIntegrand,
-       SDEAdjointProblem, RODEAdjointProblem, SensitivityAlg,
-       adjoint_sensitivities,
-       ForwardLSSProblem, AdjointLSSProblem,
-       NILSSProblem, NILSASProblem,
-       shadow_forward, shadow_adjoint
+    ODEAdjointProblem, AdjointSensitivityIntegrand,
+    SDEAdjointProblem, RODEAdjointProblem, SensitivityAlg,
+    adjoint_sensitivities,
+    ForwardLSSProblem, AdjointLSSProblem,
+    NILSSProblem, NILSASProblem,
+    shadow_forward, shadow_adjoint
 
 export BacksolveAdjoint, QuadratureAdjoint, GaussAdjoint, GaussKronrodAdjoint,
-       InterpolatingAdjoint,
-       TrackerAdjoint, ZygoteAdjoint, ReverseDiffAdjoint, MooncakeAdjoint,
-       EnzymeAdjoint, ForwardSensitivity, ForwardDiffSensitivity,
-       ForwardDiffOverAdjoint,
-       SteadyStateAdjoint,
-       ForwardLSS, AdjointLSS, NILSS, NILSAS
+    InterpolatingAdjoint,
+    TrackerAdjoint, ZygoteAdjoint, ReverseDiffAdjoint, MooncakeAdjoint,
+    EnzymeAdjoint, ForwardSensitivity, ForwardDiffSensitivity,
+    ForwardDiffOverAdjoint,
+    SteadyStateAdjoint,
+    ForwardLSS, AdjointLSS, NILSS, NILSAS
 
 export second_order_sensitivities, second_order_sensitivity_product
 

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -115,7 +115,7 @@ function (ff::RODEParamJacobianWrapper)(p)
 end
 
 function determine_chunksize(u, alg::AbstractOverloadingSensitivityAlgorithm)
-    determine_chunksize(u, get_chunksize(alg))
+    return determine_chunksize(u, get_chunksize(alg))
 end
 
 function determine_chunksize(u, CS)
@@ -126,8 +126,10 @@ function determine_chunksize(u, CS)
     end
 end
 
-function jacobian(f, x::AbstractArray{<:Number},
-        alg::AbstractOverloadingSensitivityAlgorithm)
+function jacobian(
+        f, x::AbstractArray{<:Number},
+        alg::AbstractOverloadingSensitivityAlgorithm
+    )
     if alg_autodiff(alg)
         uf = unwrapped_f(f)
         J = ForwardDiff.jacobian(uf, x)
@@ -144,18 +146,22 @@ function jacobian(f, x::AbstractArray{<:Number},
     return J
 end
 
-function jacobian!(J::Nothing, f, x::AbstractArray{<:Number},
+function jacobian!(
+        J::Nothing, f, x::AbstractArray{<:Number},
         fx::Union{Nothing, AbstractArray{<:Number}},
-        alg::AbstractOverloadingSensitivityAlgorithm, jac_config::Nothing)
+        alg::AbstractOverloadingSensitivityAlgorithm, jac_config::Nothing
+    )
     @assert isempty(x)
-    J
+    return J
 end
 function jacobian!(J::PreallocationTools.DiffCache, x::SciMLBase.UJacobianWrapper, args...)
-    jacobian!(J.du, x, args...)
+    return jacobian!(J.du, x, args...)
 end
-function jacobian!(J::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number},
+function jacobian!(
+        J::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number},
         fx::Union{Nothing, AbstractArray{<:Number}},
-        alg::AbstractOverloadingSensitivityAlgorithm, jac_config)
+        alg::AbstractOverloadingSensitivityAlgorithm, jac_config
+    )
     if alg_autodiff(alg)
         uf = unwrapped_f(f)
         if fx === nothing
@@ -166,29 +172,33 @@ function jacobian!(J::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number},
     else
         FiniteDiff.finite_difference_jacobian!(J, f, x, jac_config)
     end
-    nothing
+    return nothing
 end
 
-function derivative!(df::AbstractArray{<:Number}, f,
+function derivative!(
+        df::AbstractArray{<:Number}, f,
         x::Number,
-        alg::AbstractOverloadingSensitivityAlgorithm, der_config)
+        alg::AbstractOverloadingSensitivityAlgorithm, der_config
+    )
     if alg_autodiff(alg)
         ForwardDiff.derivative!(df, f, x) # der_config doesn't work
     else
         FiniteDiff.finite_difference_derivative!(df, f, x, der_config)
     end
-    nothing
+    return nothing
 end
 
-function gradient!(df::AbstractArray{<:Number}, f,
+function gradient!(
+        df::AbstractArray{<:Number}, f,
         x::Union{Number, AbstractArray{<:Number}},
-        alg::AbstractOverloadingSensitivityAlgorithm, grad_config)
+        alg::AbstractOverloadingSensitivityAlgorithm, grad_config
+    )
     if alg_autodiff(alg)
         ForwardDiff.gradient!(df, f, x, grad_config)
     else
         FiniteDiff.finite_difference_gradient!(df, f, x, grad_config)
     end
-    nothing
+    return nothing
 end
 
 """
@@ -196,8 +206,10 @@ jacobianvec!(Jv, f, x, v, alg, (buffer, seed)) -> nothing
 
 ``Jv <- J(f(x))v``
 """
-function jacobianvec!(Jv::AbstractArray{<:Number}, f, x::AbstractArray{<:Number},
-        v, alg::AbstractOverloadingSensitivityAlgorithm, config)
+function jacobianvec!(
+        Jv::AbstractArray{<:Number}, f, x::AbstractArray{<:Number},
+        v, alg::AbstractOverloadingSensitivityAlgorithm, config
+    )
     if alg_autodiff(alg)
         buffer, seed = config
         TD = typeof(first(seed))
@@ -217,10 +229,12 @@ function jacobianvec!(Jv::AbstractArray{<:Number}, f, x::AbstractArray{<:Number}
         @. x -= ϵ * v
         @. Jv = (buffer2 - buffer1) / ϵ
     end
-    nothing
+    return nothing
 end
-function jacobianmat!(JM::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number},
-        M, alg::AbstractOverloadingSensitivityAlgorithm, config)
+function jacobianmat!(
+        JM::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number},
+        M, alg::AbstractOverloadingSensitivityAlgorithm, config
+    )
     buffer, seed = config
     T = eltype(seed)
     numparams = length(ForwardDiff.partials(seed[1]))
@@ -235,21 +249,27 @@ function jacobianmat!(JM::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number
     end
     return nothing
 end
-function vecjacobian!(dλ, y, λ, p, t, S::TS;
+function vecjacobian!(
+        dλ, y, λ, p, t, S::TS;
         dgrad = nothing, dy = nothing,
-        W = nothing) where {TS <: SensitivityFunction}
+        W = nothing
+    ) where {TS <: SensitivityFunction}
     _vecjacobian!(dλ, y, λ, p, t, S, S.sensealg.autojacvec, dgrad, dy, W)
     return
 end
 
-function vecjacobian(y, λ, p, t, S::TS;
+function vecjacobian(
+        y, λ, p, t, S::TS;
         dgrad = nothing, dy = nothing,
-        W = nothing) where {TS <: SensitivityFunction}
+        W = nothing
+    ) where {TS <: SensitivityFunction}
     return _vecjacobian(y, λ, p, t, S, S.sensealg.autojacvec, dgrad, dy, W)
 end
 
-function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::Bool, dgrad, dy,
-        W) where {TS <: SensitivityFunction}
+function _vecjacobian!(
+        dλ, y, λ, p, t, S::TS, isautojacvec::Bool, dgrad, dy,
+        W
+    ) where {TS <: SensitivityFunction}
     (; sensealg, f) = S
     prob = getprob(S)
 
@@ -347,41 +367,43 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::Bool, dgrad, dy,
 end
 
 const TRACKERVJP_NOTHING_MESSAGE = """
-                                   `nothing` returned from a Tracker vector-Jacobian product (vjp) calculation.
-                                   This indicates that your function `f` is not a function of `p` or `u`, i.e. that
-                                   the derivative is constant zero. In many cases this is due to an error in
-                                   the model definition, for example accidentally using a global parameter
-                                   instead of the one in the model (`f(u,p,t)= _p .* u`).
+`nothing` returned from a Tracker vector-Jacobian product (vjp) calculation.
+This indicates that your function `f` is not a function of `p` or `u`, i.e. that
+the derivative is constant zero. In many cases this is due to an error in
+the model definition, for example accidentally using a global parameter
+instead of the one in the model (`f(u,p,t)= _p .* u`).
 
-                                   One common cause of this is using Flux neural networks with implicit parameters,
-                                   for example `f(u,p,t) = NN(u)` does not use `p` and therefore will have a zero
-                                   derivative. The answer is to use `Flux.destructure` in this case, for example:
+One common cause of this is using Flux neural networks with implicit parameters,
+for example `f(u,p,t) = NN(u)` does not use `p` and therefore will have a zero
+derivative. The answer is to use `Flux.destructure` in this case, for example:
 
-                                   ```julia
-                                   p,re = Flux.destructure(NN)
-                                   f(u,p,t) = re(p)(u)
-                                   prob = ODEProblem(f,u0,tspan,p)
-                                   ```
+```julia
+p,re = Flux.destructure(NN)
+f(u,p,t) = re(p)(u)
+prob = ODEProblem(f,u0,tspan,p)
+```
 
-                                   Note that restructuring outside of `f`, i.e. `reNN = re(p); f(u,p,t) = reNN(u)` will
-                                   also trigger a zero gradient. The `p` must be used inside of `f`, not globally outside.
+Note that restructuring outside of `f`, i.e. `reNN = re(p); f(u,p,t) = reNN(u)` will
+also trigger a zero gradient. The `p` must be used inside of `f`, not globally outside.
 
-                                   If this zero gradient with respect to `u` or `p` is intended, then one can set
-                                   `TrackerVJP(allow_nothing=true)` to override this error message. For example:
+If this zero gradient with respect to `u` or `p` is intended, then one can set
+`TrackerVJP(allow_nothing=true)` to override this error message. For example:
 
-                                   ```julia
-                                   solve(prob,alg,sensealg=InterpolatingAdjoint(autojacvec=TrackerVJP(allow_nothing=true)))
-                                   ```
-                                   """
+```julia
+solve(prob,alg,sensealg=InterpolatingAdjoint(autojacvec=TrackerVJP(allow_nothing=true)))
+```
+"""
 
 struct TrackerVJPNothingError <: Exception end
 
 function Base.showerror(io::IO, e::TrackerVJPNothingError)
-    print(io, TRACKERVJP_NOTHING_MESSAGE)
+    return print(io, TRACKERVJP_NOTHING_MESSAGE)
 end
 
-function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::TrackerVJP, dgrad, dy,
-        W) where {TS <: SensitivityFunction}
+function _vecjacobian!(
+        dλ, y, λ, p, t, S::TS, isautojacvec::TrackerVJP, dgrad, dy,
+        W
+    ) where {TS <: SensitivityFunction}
     (; sensealg) = S
     f = unwrapped_f(S.f)
 
@@ -401,7 +423,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::TrackerVJP, dgrad,
         end
 
         if !(typeof(_dy) isa TrackedArray) && !(eltype(_dy) <: Tracker.TrackedReal) &&
-           !sensealg.autojacvec.allow_nothing
+                !sensealg.autojacvec.allow_nothing
             throw(TrackerVJPNothingError())
         end
 
@@ -423,7 +445,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::TrackerVJP, dgrad,
         end
 
         if !(typeof(_dy) isa TrackedArray) && !(eltype(_dy) <: Tracker.TrackedReal) &&
-           !sensealg.autojacvec.allow_nothing
+                !sensealg.autojacvec.allow_nothing
             throw(TrackerVJPNothingError())
         end
 
@@ -437,8 +459,10 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::TrackerVJP, dgrad,
     return
 end
 
-function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ReverseDiffVJP, dgrad, dy,
-        W) where {TS <: SensitivityFunction}
+function _vecjacobian!(
+        dλ, y, λ, p, t, S::TS, isautojacvec::ReverseDiffVJP, dgrad, dy,
+        W
+    ) where {TS <: SensitivityFunction}
     (; sensealg) = S
     prob = getprob(S)
     f = unwrapped_f(S.f)
@@ -457,8 +481,10 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ReverseDiffVJP, dg
 
     u0 = state_values(prob)
     if prob isa AbstractNonlinearProblem ||
-       (eltype(λ) <: eltype(u0) && t isa eltype(u0) &&
-        compile_tape(sensealg.autojacvec))
+            (
+            eltype(λ) <: eltype(u0) && t isa eltype(u0) &&
+                compile_tape(sensealg.autojacvec)
+        )
         tape = S.diffcache.paramjac_config
 
         ## These other cases happen due to autodiff in stiff ODE solvers
@@ -473,10 +499,10 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ReverseDiffVJP, dg
             end
         else
             _W = eltype(W) === eltype(λ) ? W :
-                 convert.(promote_type(eltype(W), eltype(λ)), W)
+                convert.(promote_type(eltype(W), eltype(λ)), W)
             tape = ReverseDiff.GradientTape((_y, _p, [t], _W)) do u, p, t, Wloc
                 du1 = p !== nothing && p !== SciMLBase.NullParameters() ?
-                      similar(p, size(u)) : similar(u)
+                    similar(p, size(u)) : similar(u)
                 f(du1, u, p, first(t), Wloc)
                 return vec(du1)
             end
@@ -490,7 +516,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ReverseDiffVJP, dg
             end
         else
             _W = eltype(W) === eltype(λ) ? W :
-                 convert.(promote_type(eltype(W), eltype(λ)), W)
+                convert.(promote_type(eltype(W), eltype(λ)), W)
             tape = ReverseDiff.GradientTape((_y, _p, [t], _W)) do u, p, t, Wloc
                 vec(f(u, p, first(t), Wloc))
             end
@@ -530,41 +556,43 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ReverseDiffVJP, dg
 end
 
 const ZYGOTEVJP_NOTHING_MESSAGE = """
-                                  `nothing` returned from a Zygote vector-Jacobian product (vjp) calculation.
-                                  This indicates that your function `f` is not a function of `p` or `u`, i.e. that
-                                  the derivative is constant zero. In many cases this is due to an error in
-                                  the model definition, for example accidentally using a global parameter
-                                  instead of the one in the model (`f(u,p,t)= _p .* u`).
+`nothing` returned from a Zygote vector-Jacobian product (vjp) calculation.
+This indicates that your function `f` is not a function of `p` or `u`, i.e. that
+the derivative is constant zero. In many cases this is due to an error in
+the model definition, for example accidentally using a global parameter
+instead of the one in the model (`f(u,p,t)= _p .* u`).
 
-                                  One common cause of this is using Flux neural networks with implicit parameters,
-                                  for example `f(u,p,t) = NN(u)` does not use `p` and therefore will have a zero
-                                  derivative. The answer is to use `Flux.destructure` in this case, for example:
+One common cause of this is using Flux neural networks with implicit parameters,
+for example `f(u,p,t) = NN(u)` does not use `p` and therefore will have a zero
+derivative. The answer is to use `Flux.destructure` in this case, for example:
 
-                                  ```julia
-                                  p,re = Flux.destructure(NN)
-                                  f(u,p,t) = re(p)(u)
-                                  prob = ODEProblem(f,u0,tspan,p)
-                                  ```
+```julia
+p,re = Flux.destructure(NN)
+f(u,p,t) = re(p)(u)
+prob = ODEProblem(f,u0,tspan,p)
+```
 
-                                  Note that restructuring outside of `f`, i.e. `reNN = re(p); f(u,p,t) = reNN(u)` will
-                                  also trigger a zero gradient. The `p` must be used inside of `f`, not globally outside.
+Note that restructuring outside of `f`, i.e. `reNN = re(p); f(u,p,t) = reNN(u)` will
+also trigger a zero gradient. The `p` must be used inside of `f`, not globally outside.
 
-                                  If this zero gradient with respect to `u` or `p` is intended, then one can set
-                                  `ZygoteVJP(allow_nothing=true)` to override this error message, for example:
+If this zero gradient with respect to `u` or `p` is intended, then one can set
+`ZygoteVJP(allow_nothing=true)` to override this error message, for example:
 
-                                  ```julia
-                                  solve(prob,alg,sensealg=InterpolatingAdjoint(autojacvec=ZygoteVJP(allow_nothing=true)))
-                                  ```
-                                  """
+```julia
+solve(prob,alg,sensealg=InterpolatingAdjoint(autojacvec=ZygoteVJP(allow_nothing=true)))
+```
+"""
 
 struct ZygoteVJPNothingError <: Exception end
 
 function Base.showerror(io::IO, e::ZygoteVJPNothingError)
-    print(io, ZYGOTEVJP_NOTHING_MESSAGE)
+    return print(io, ZYGOTEVJP_NOTHING_MESSAGE)
 end
 
-function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, dy,
-        W) where {TS <: SensitivityFunction}
+function _vecjacobian!(
+        dλ, y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, dy,
+        W
+    ) where {TS <: SensitivityFunction}
     (; sensealg) = S
     prob = getprob(S)
     f = unwrapped_f(S.f)
@@ -628,8 +656,10 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, 
     return
 end
 
-function _vecjacobian(y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, dy,
-        W) where {TS <: SensitivityFunction}
+function _vecjacobian(
+        y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, dy,
+        W
+    ) where {TS <: SensitivityFunction}
     (; sensealg) = S
     prob = getprob(S)
     f = unwrapped_f(S.f)
@@ -666,16 +696,18 @@ end
 
 function gclosure1(f, du, u, p, t)
     Base.copyto!(du, f(u, p, t))
-    nothing
-end
-            
-function gclosure2(f, du, u, p, t, W)
-    Base.copyto!(du, f(u, p, t, W))
-    nothing
+    return nothing
 end
 
-function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, dy,
-        W) where {TS <: SensitivityFunction}
+function gclosure2(f, du, u, p, t, W)
+    Base.copyto!(du, f(u, p, t, W))
+    return nothing
+end
+
+function _vecjacobian!(
+        dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, dy,
+        W
+    ) where {TS <: SensitivityFunction}
     (; sensealg) = S
     f = unwrapped_f(S.f)
 
@@ -744,17 +776,21 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, 
         end
 
         if W === nothing
-            Enzyme.autodiff(enzyme_mode, Enzyme.Duplicated(SciMLBase.Void(f), _tmp6),
+            Enzyme.autodiff(
+                enzyme_mode, Enzyme.Duplicated(SciMLBase.Void(f), _tmp6),
                 Enzyme.Const, Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Duplicated(ytmp, tmp1),
                 dup,
-                Enzyme.Const(t))
+                Enzyme.Const(t)
+            )
         else
-            Enzyme.autodiff(enzyme_mode, Enzyme.Duplicated(SciMLBase.Void(f), _tmp6),
+            Enzyme.autodiff(
+                enzyme_mode, Enzyme.Duplicated(SciMLBase.Void(f), _tmp6),
                 Enzyme.Const, Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Duplicated(ytmp, tmp1),
                 dup,
-                Enzyme.Const(t), Enzyme.Const(W))
+                Enzyme.Const(t), Enzyme.Const(W)
+            )
         end
         dλ !== nothing && recursive_copyto!(dλ, tmp1)
         dgrad !== nothing && !(tmp2 isa SciMLBase.NullParameters) &&
@@ -763,18 +799,22 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, 
     else
         if W === nothing
             _tmp6 = Enzyme.make_zero(f)
-            Enzyme.autodiff(enzyme_mode, Enzyme.Const(gclosure1), Enzyme.Const,
+            Enzyme.autodiff(
+                enzyme_mode, Enzyme.Const(gclosure1), Enzyme.Const,
                 Enzyme.Duplicated(f, _tmp6),
                 Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Duplicated(ytmp, tmp1),
-                dup, Enzyme.Const(t))
+                dup, Enzyme.Const(t)
+            )
         else
             _tmp6 = Enzyme.make_zero(f)
-            Enzyme.autodiff(enzyme_mode, Enzyme.Const(gclosure2), Enzyme.Const,
+            Enzyme.autodiff(
+                enzyme_mode, Enzyme.Const(gclosure2), Enzyme.Const,
                 Enzyme.Duplicated(f, _tmp6),
                 Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Duplicated(ytmp, tmp1),
-                dup, Enzyme.Const(t), Enzyme.Const(W))
+                dup, Enzyme.Const(t), Enzyme.Const(W)
+            )
         end
         if dy !== nothing
             out_ = if W === nothing
@@ -800,14 +840,18 @@ function _vecjacobian!(dλ, y, λ, p, t, S::SensitivityFunction, ::MooncakeVJP, 
     return
 end
 
-function jacNoise!(λ, y, p, t, S::SensitivityFunction;
-        dgrad = nothing, dλ = nothing, dy = nothing)
+function jacNoise!(
+        λ, y, p, t, S::SensitivityFunction;
+        dgrad = nothing, dλ = nothing, dy = nothing
+    )
     _jacNoise!(λ, y, p, t, S, S.sensealg.autojacvec, dgrad, dλ, dy)
     return
 end
 
-function _jacNoise!(λ, y, p, t, S::TS, isnoise::Bool, dgrad, dλ,
-        dy) where {TS <: SensitivityFunction}
+function _jacNoise!(
+        λ, y, p, t, S::TS, isnoise::Bool, dgrad, dλ,
+        dy
+    ) where {TS <: SensitivityFunction}
     (; sensealg, f) = S
     prob = getprob(S)
 
@@ -845,7 +889,7 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::Bool, dgrad, dλ,
     end
 
     if dλ !== nothing &&
-       (isnoisemixing(sensealg) || !SciMLBase.is_diagonal_noise(prob))
+            (isnoisemixing(sensealg) || !SciMLBase.is_diagonal_noise(prob))
         (; J, uf, f_cache, jac_noise_config) = S.diffcache
         if dy !== nothing
             if inplace_sensitivity(S)
@@ -894,8 +938,10 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::Bool, dgrad, dλ,
     return
 end
 
-function _jacNoise!(λ, y, p, t, S::TS, isnoise::ReverseDiffVJP, dgrad, dλ,
-        dy) where {TS <: SensitivityFunction}
+function _jacNoise!(
+        λ, y, p, t, S::TS, isnoise::ReverseDiffVJP, dgrad, dλ,
+        dy
+    ) where {TS <: SensitivityFunction}
     (; sensealg) = S
     prob = getprob(S)
     f = unwrapped_f(S.f)
@@ -941,8 +987,10 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ReverseDiffVJP, dgrad, dλ,
     return
 end
 
-function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
-        dy) where {TS <: SensitivityFunction}
+function _jacNoise!(
+        λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
+        dy
+    ) where {TS <: SensitivityFunction}
     (; sensealg) = S
     prob = getprob(S)
     p_ = parameter_values(prob)
@@ -1011,7 +1059,7 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
                     f(out_, u, repack(p), t)
                     copy(out_[:, i])
                 end
-                tmp1, tmp2 = back(λ)#issue with Zygote.Buffer
+                tmp1, tmp2 = back(λ) #issue with Zygote.Buffer
                 if dgrad !== nothing
                     if tmp2 !== nothing
                         !isempty(dgrad) && (dgrad[:, i] .= vec(tmp2))
@@ -1044,8 +1092,10 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
     return
 end
 
-function accumulate_cost!(dλ, y, p, t, S::TS,
-        dgrad = nothing) where {TS <: SensitivityFunction}
+function accumulate_cost!(
+        dλ, y, p, t, S::TS,
+        dgrad = nothing
+    ) where {TS <: SensitivityFunction}
     (; dgdu, dgdp, dg_val, g, g_grad_config) = S.diffcache
 
     if dgdu !== nothing
@@ -1075,8 +1125,10 @@ function accumulate_cost!(dλ, y, p, t, S::TS,
     return nothing
 end
 
-function accumulate_cost(dλ, y, p, t, S::TS,
-        dgrad = nothing) where {TS <: SensitivityFunction}
+function accumulate_cost(
+        dλ, y, p, t, S::TS,
+        dgrad = nothing
+    ) where {TS <: SensitivityFunction}
     (; dgdu, dgdp) = S.diffcache
 
     dλ -= dgdu(y, p, t)
@@ -1091,54 +1143,72 @@ end
 build_jac_config(alg, uf, u::Nothing) = nothing
 function build_jac_config(alg, uf, u)
     if alg_autodiff(alg)
-        jac_config = ForwardDiff.JacobianConfig(uf, u, u,
+        jac_config = ForwardDiff.JacobianConfig(
+            uf, u, u,
             ForwardDiff.Chunk{
-                determine_chunksize(u,
-                alg)}())
+                determine_chunksize(
+                    u,
+                    alg
+                ),
+            }()
+        )
     else
         if diff_type(alg) != Val{:complex}
-            jac_config = FiniteDiff.JacobianCache(zero(u), zero(u),
-                zero(u), diff_type(alg))
+            jac_config = FiniteDiff.JacobianCache(
+                zero(u), zero(u),
+                zero(u), diff_type(alg)
+            )
         else
             tmp = Complex{eltype(u)}.(u)
             du1 = Complex{eltype(u)}.(du1)
             jac_config = FiniteDiff.JacobianCache(tmp, du1, nothing, diff_type(alg))
         end
     end
-    jac_config
+    return jac_config
 end
 
 function build_param_jac_config(alg, pf, u, p)
     if alg_autodiff(alg)
         tunables, repack, aliases = canonicalize(Tunable(), p)
-        jac_config = ForwardDiff.JacobianConfig(pf, u, tunables,
+        jac_config = ForwardDiff.JacobianConfig(
+            pf, u, tunables,
             ForwardDiff.Chunk{
-                determine_chunksize(tunables,
-                alg)}())
+                determine_chunksize(
+                    tunables,
+                    alg
+                ),
+            }()
+        )
     else
         if diff_type(alg) != Val{:complex}
-            jac_config = FiniteDiff.JacobianCache(similar(p), similar(u),
-                similar(u), diff_type(alg))
+            jac_config = FiniteDiff.JacobianCache(
+                similar(p), similar(u),
+                similar(u), diff_type(alg)
+            )
         else
             tmp = Complex{eltype(p)}.(p)
             du1 = Complex{eltype(u)}.(u)
             jac_config = FiniteDiff.JacobianCache(tmp, du1, nothing, diff_type(alg))
         end
     end
-    jac_config
+    return jac_config
 end
 
 function build_grad_config(alg, tf, du1, t)
     if alg_autodiff(alg)
-        grad_config = ForwardDiff.GradientConfig(tf, du1,
+        grad_config = ForwardDiff.GradientConfig(
+            tf, du1,
             ForwardDiff.Chunk{
-                determine_chunksize(du1,
-                alg),
-            }())
+                determine_chunksize(
+                    du1,
+                    alg
+                ),
+            }()
+        )
     else
         grad_config = FiniteDiff.GradientCache(du1, t, diff_type(alg))
     end
-    grad_config
+    return grad_config
 end
 
 function build_deriv_config(alg, tf, du1, t)
@@ -1147,5 +1217,5 @@ function build_deriv_config(alg, tf, du1, t)
     else
         grad_config = FiniteDiff.DerivativeCache(du1, t, diff_type(alg))
     end
-    grad_config
+    return grad_config
 end

--- a/src/nilss.jl
+++ b/src/nilss.jl
@@ -1,7 +1,8 @@
-struct NILSSSensitivityFunction{iip, F, Alg,
-    PGPU, PGPP, CONFU, CONGP, DGVAL, DG1, DG2, jType, RefType
-} <:
-       AbstractODEFunction{iip}
+struct NILSSSensitivityFunction{
+        iip, F, Alg,
+        PGPU, PGPP, CONFU, CONGP, DGVAL, DG1, DG2, jType, RefType,
+    } <:
+    AbstractODEFunction{iip}
     f::F
     alg::Alg
     numparams::Int
@@ -17,11 +18,15 @@ struct NILSSSensitivityFunction{iip, F, Alg,
     cur_time::RefType
 end
 
-function NILSSSensitivityFunction(sensealg, f, u0, p, tspan, g, dgdu, dgdp,
+function NILSSSensitivityFunction(
+        sensealg, f, u0, p, tspan, g, dgdu, dgdp,
         jevery = nothing,
-        cur_time = nothing)
-    !(f.mass_matrix isa UniformScaling ||
-      f.mass_matrix isa Tuple{UniformScaling, UniformScaling}) &&
+        cur_time = nothing
+    )
+    !(
+        f.mass_matrix isa UniformScaling ||
+            f.mass_matrix isa Tuple{UniformScaling, UniformScaling}
+    ) &&
         throw(SHADOWING_DAE_ERROR())
 
     numparams = length(p)
@@ -51,22 +56,28 @@ function NILSSSensitivityFunction(sensealg, f, u0, p, tspan, g, dgdu, dgdp,
         dg_val[2] .= false
     end
 
-    NILSSSensitivityFunction{isinplace(f), typeof(f), typeof(sensealg),
+    return NILSSSensitivityFunction{
+        isinplace(f), typeof(f), typeof(sensealg),
         typeof(pgpu), typeof(pgpp), typeof(pgpu_config),
         typeof(pgpp_config), typeof(dg_val), typeof(dgdu),
         typeof(dgdp),
-        typeof(jevery), typeof(cur_time)}(f, sensealg, numparams,
+        typeof(jevery), typeof(cur_time),
+    }(
+        f, sensealg, numparams,
         numindvar, pgpu, pgpp,
         pgpu_config, pgpp_config,
         dg_val, dgdu, dgdp, jevery,
-        cur_time)
+        cur_time
+    )
 end
 
-struct NILSSProblem{A, CacheType, FSprob, probType, u0Type, vstar0Type, w0Type,
-    TType, dtType, gType, yType, vstarType,
-    wType, RType, bType, weightType, CType, dType, BType, aType, vType,
-    xiType,
-    G, resType}
+struct NILSSProblem{
+        A, CacheType, FSprob, probType, u0Type, vstar0Type, w0Type,
+        TType, dtType, gType, yType, vstarType,
+        wType, RType, bType, weightType, CType, dType, BType, aType, vType,
+        xiType,
+        G, resType,
+    }
     sensealg::A
     diffcache::CacheType
     forward_prob::FSprob
@@ -99,10 +110,12 @@ struct NILSSProblem{A, CacheType, FSprob, probType, u0Type, vstar0Type, w0Type,
     res::resType
 end
 
-function NILSSProblem(prob, sensealg::NILSS;
+function NILSSProblem(
+        prob, sensealg::NILSS;
         t = nothing, dgdu_discrete = nothing, dgdp_discrete = nothing,
         dgdu_continuous = nothing, dgdp_continuous = nothing, g = sensealg.g,
-        kwargs...)
+        kwargs...
+    )
     (; f, p, u0, tspan) = prob
     (; nseg, nstep, nus, rng) = sensealg  #number of segments on time interval, number of steps saved on each segment
 
@@ -144,9 +157,9 @@ function NILSSProblem(prob, sensealg::NILSS;
         cur_time = nothing
         @assert dgdu_discrete === nothing && dgdp_discrete === nothing
         dgdu = dgdu_continuous === nothing ? dgdu_continuous :
-               (out, u, p, t, i) -> dgdu_continuous(out, u, p, t)
+            (out, u, p, t, i) -> dgdu_continuous(out, u, p, t)
         dgdp = dgdp_continuous === nothing ? dgdp_continuous :
-               (out, u, p, t, i) -> dgdp_continuous(out, u, p, t)
+            (out, u, p, t, i) -> dgdp_continuous(out, u, p, t)
     end
 
     # inhomogeneous forward sensitivity problem
@@ -155,15 +168,21 @@ function NILSSProblem(prob, sensealg::NILSS;
     difftype = diff_type(sensealg)
     autojacvec = sensealg.autojacvec
     # homogeneous + inhomogeneous forward sensitivity problems
-    forward_prob = ODEForwardSensitivityProblem(f, u0, tspan, p,
-        ForwardSensitivity(chunk_size = chunk_size,
+    forward_prob = ODEForwardSensitivityProblem(
+        f, u0, tspan, p,
+        ForwardSensitivity(
+            chunk_size = chunk_size,
             autodiff = autodiff,
             diff_type = difftype,
-            autojacvec = autojacvec);
-        nus = nus, kwargs...)
+            autojacvec = autojacvec
+        );
+        nus = nus, kwargs...
+    )
 
-    sense = NILSSSensitivityFunction(sensealg, f, u0, p, tspan, g, dgdu, dgdp, jevery,
-        cur_time)
+    sense = NILSSSensitivityFunction(
+        sensealg, f, u0, p, tspan, g, dgdu, dgdp, jevery,
+        cur_time
+    )
 
     # pre-allocate variables
     gsave = Matrix{eltype(u0)}(undef, nstep, nseg)
@@ -216,18 +235,22 @@ function NILSSProblem(prob, sensealg::NILSS;
 
     res = similar(u0, numparams)
 
-    NILSSProblem{typeof(sensealg), typeof(sense), typeof(forward_prob), typeof(prob),
+    return NILSSProblem{
+        typeof(sensealg), typeof(sense), typeof(forward_prob), typeof(prob),
         typeof(u0), typeof(vstar0), typeof(w0),
         typeof(T_seg), typeof(dtsave), typeof(gsave), typeof(y), typeof(vstar),
         typeof(w), typeof(R),
         typeof(b), typeof(weight), typeof(Cinv), typeof(d), typeof(B), typeof(a),
         typeof(v), typeof(ξ),
-        typeof(g), typeof(res)}(sensealg, sense, forward_prob, prob,
+        typeof(g), typeof(res),
+    }(
+        sensealg, sense, forward_prob, prob,
         u0, vstar0, w0,
         nus, T_seg, dtsave, gsave, y, dudt,
         dgdu_val, vstar, vstar_perp, w, w_perp, R,
         b, weight, Cinv, d,
-        B, a, v, v_perp, ξ, g, res)
+        B, a, v, v_perp, ξ, g, res
+    )
 end
 
 function (NS::NILSSForwardSensitivityFunction)(du, u, p, t)
@@ -281,8 +304,10 @@ end
 
 function forward_sense(prob::NILSSProblem, nilss::NILSS, alg)
     #TODO determine a good dtsave (ΔT in paper, see Sec.4.2)
-    (; nus, T_seg, dtsave, vstar, vstar_perp, w, w_perp, R, b, y,
-        dudt, gsave, dgdu_val, forward_prob, u0, vstar0, w0) = prob
+    (;
+        nus, T_seg, dtsave, vstar, vstar_perp, w, w_perp, R, b, y,
+        dudt, gsave, dgdu_val, forward_prob, u0, vstar0, w0,
+    ) = prob
     (; p, f) = forward_prob
     (; S, sensealg) = f
     (; nseg, nstep) = nilss
@@ -293,7 +318,8 @@ function forward_sense(prob::NILSSProblem, nilss::NILSS, alg)
     t2 = forward_prob.tspan[1] + T_seg
     _prob = ODEForwardSensitivityProblem(
         S.f, u0, (t1, t2), p; sensealg = sensealg, nus = nus, w0 = w0,
-        v0 = vstar0)
+        v0 = vstar0
+    )
 
     for iseg in 1:nseg
         # compute y, w, vstar
@@ -316,12 +342,15 @@ function forward_sense(prob::NILSSProblem, nilss::NILSS, alg)
             renormalize!(R, b, w_perp, vstar_perp, y, vstar, w, iseg, numparams, nus)
             t1 = forward_prob.tspan[1] + iseg * T_seg
             t2 = forward_prob.tspan[1] + (iseg + 1) * T_seg
-            _prob = ODEForwardSensitivityProblem(S.f, y[:, 1, iseg + 1], (t1, t2), p;
+            _prob = ODEForwardSensitivityProblem(
+                S.f, y[:, 1, iseg + 1], (t1, t2), p;
                 sensealg = sensealg, nus = nus,
                 w0 = vec(w[:, 1, iseg + 1, :]),
-                v0 = vec(vstar[:, :, 1, iseg + 1]))
+                v0 = vec(vstar[:, :, 1, iseg + 1])
+            )
         end
     end
+    return
 end
 
 function store_y_w_vstar!(y, w, vstar, sol, nus, numindvar, numparams, iseg)
@@ -408,7 +437,7 @@ function perp!(w_perp, vstar_perp, w, vstar, dudt, iseg, numparams, nsteps, nus)
 end
 
 function perp!(v1, v2, v3)
-    v1 .= v2 - dot(v2, v3) / dot(v3, v3) * v3
+    return v1 .= v2 - dot(v2, v3) / dot(v3, v3) * v3
 end
 
 function renormalize!(R, b, w_perp, vstar_perp, y, vstar, w, iseg, numparams, nus)
@@ -440,8 +469,10 @@ function compute_Cinv!(Cinv, w_perp, weight, nseg, nus, indxp)
     # construct Schur complement of Lagrange multiplier
     _weight = @view weight[1, :]
     for iseg in 1:nseg
-        _C = @view Cinv[((iseg - 1) * nus + 1):(iseg * nus),
-        ((iseg - 1) * nus + 1):(iseg * nus)]
+        _C = @view Cinv[
+            ((iseg - 1) * nus + 1):(iseg * nus),
+            ((iseg - 1) * nus + 1):(iseg * nus),
+        ]
         for i in 1:nus
             wi = @view w_perp[:, :, iseg, i]
             for j in 1:nus
@@ -471,8 +502,10 @@ end
 
 function compute_B!(B, R, nseg, nus, indxp)
     for iseg in 1:(nseg - 1)
-        _B = @view B[((iseg - 1) * nus + 1):(iseg * nus),
-        ((iseg - 1) * nus + 1):(iseg * nus)]
+        _B = @view B[
+            ((iseg - 1) * nus + 1):(iseg * nus),
+            ((iseg - 1) * nus + 1):(iseg * nus),
+        ]
         _R = @view R[indxp, iseg, :, :]
         copyto!(_B, -_R)
         # off diagonal one
@@ -525,12 +558,14 @@ function compute_xi(ξ, v, dudt, nseg)
     end
     # check if segmentation is chosen correctly
     _ξ = ξ[:, 1]
-    all(_ξ .< 1e-4) || @warn "Detected a large value of ξ at the beginning of a segment."
+    all(_ξ .< 1.0e-4) || @warn "Detected a large value of ξ at the beginning of a segment."
     return nothing
 end
 
-function accumulate_cost!(_dgdu, u, p, t, sensealg::NILSS,
-        diffcache::NILSSSensitivityFunction, j)
+function accumulate_cost!(
+        _dgdu, u, p, t, sensealg::NILSS,
+        diffcache::NILSSSensitivityFunction, j
+    )
     (; dgdu, dgdp, dg_val, pgpu, pgpu_config, pgpp, pgpp_config) = diffcache
 
     if dgdu === nothing
@@ -555,13 +590,15 @@ function accumulate_cost!(_dgdu, u, p, t, sensealg::NILSS,
 end
 
 function shadow_forward(prob::NILSSProblem, alg; sensealg = prob.sensealg)
-    shadow_forward(prob, sensealg, alg)
+    return shadow_forward(prob, sensealg, alg)
 end
 
 function shadow_forward(prob::NILSSProblem, sensealg::NILSS, alg)
     (; nseg, nstep) = sensealg
-    (; res, nus, dtsave, vstar, vstar_perp, w, w_perp, R, b, dudt,
-        gsave, dgdu_val, forward_prob, weight, Cinv, d, B, a, v, v_perp, ξ) = prob
+    (;
+        res, nus, dtsave, vstar, vstar_perp, w, w_perp, R, b, dudt,
+        gsave, dgdu_val, forward_prob, weight, Cinv, d, B, a, v, v_perp, ξ,
+    ) = prob
     (; numindvar, numparams) = forward_prob.f.S
 
     # reset dg pointer
@@ -600,5 +637,5 @@ function shadow_forward(prob::NILSSProblem, sensealg::NILSS, alg)
 end
 
 function check_for_g(sensealg::NILSS, g)
-    (g === nothing && error("To use NILSS, g must be passed as a kwarg to `NILSS(g=g)`."))
+    return (g === nothing && error("To use NILSS, g must be passed as a kwarg to `NILSS(g=g)`."))
 end

--- a/src/parameters_handling.jl
+++ b/src/parameters_handling.jl
@@ -10,13 +10,13 @@ recursive_copyto!(y::AbstractArray, x::AbstractArray) = copyto!(y, x)
 recursive_copyto!(y::AbstractArray, x::Number) = y .= x
 recursive_copyto!(y::Tuple, x::Tuple) = map(recursive_copyto!, y, x)
 function recursive_copyto!(y::NamedTuple{F}, x::NamedTuple{F}) where {F}
-    map(recursive_copyto!, values(y), values(x))
+    return map(recursive_copyto!, values(y), values(x))
 end
 recursive_copyto!(y::T, x::T) where {T} = fmap(recursive_copyto!, y, x)
 recursive_copyto!(y, ::Nothing) = y
 recursive_copyto!(::Nothing, ::Nothing) = nothing
 function recursive_copyto!(y::T, x::NamedTuple) where {T}
-    fmap(recursive_copyto!, y, x)
+    return fmap(recursive_copyto!, y, x)
 end
 
 """
@@ -38,7 +38,7 @@ recursive_neg!(::Nothing) = nothing
 recursive_sub!(y::AbstractArray, x::AbstractArray) = axpy!(-1, x, y)
 recursive_sub!(y::Tuple, x::Tuple) = map(recursive_sub!, y, x)
 function recursive_sub!(y::NamedTuple{F}, x::NamedTuple{F}) where {F}
-    NamedTuple{F}(map(recursive_sub!, values(y), values(x)))
+    return NamedTuple{F}(map(recursive_sub!, values(y), values(x)))
 end
 recursive_sub!(y::T, x::T) where {T} = fmap(recursive_sub!, y, x)
 recursive_sub!(y, ::Nothing) = y
@@ -52,7 +52,7 @@ recursive_sub!(::Nothing, ::Nothing) = nothing
 recursive_add!(y::AbstractArray, x::AbstractArray) = y .+= x
 recursive_add!(y::Tuple, x::Tuple) = recursive_add!.(y, x)
 function recursive_add!(y::NamedTuple{F}, x::NamedTuple{F}) where {F}
-    NamedTuple{F}(recursive_add!(values(y), values(x)))
+    return NamedTuple{F}(recursive_add!(values(y), values(x)))
 end
 recursive_add!(y::T, x::T) where {T} = fmap(recursive_add!, y, x)
 recursive_add!(y, ::Nothing) = y
@@ -65,11 +65,11 @@ recursive_add!(::Nothing, ::Nothing) = nothing
 `similar(λ, size(x))` for generic `x`. This is used to handle non-array parameters!
 """
 function allocate_vjp(λ::AbstractArray{T}, x::AbstractArray) where {T}
-    fill!(similar(λ, size(x)), zero(T))
+    return fill!(similar(λ, size(x)), zero(T))
 end
 allocate_vjp(λ::AbstractArray, x::Tuple) = allocate_vjp.((λ,), x)
 function allocate_vjp(λ::AbstractArray, x::NamedTuple{F}) where {F}
-    NamedTuple{F}(allocate_vjp.((λ,), values(x)))
+    return NamedTuple{F}(allocate_vjp.((λ,), values(x)))
 end
 allocate_vjp(λ::AbstractArray, x) = fmap(Base.Fix1(allocate_vjp, λ), x)
 

--- a/src/sde_tools.jl
+++ b/src/sde_tools.jl
@@ -1,6 +1,8 @@
 # for Ito / Stratonovich conversion
-struct StochasticTransformedFunction{pType, fType <: AbstractDiffEqFunction,
-    gType, noiseType, cfType} <: TransformedFunction
+struct StochasticTransformedFunction{
+        pType, fType <: AbstractDiffEqFunction,
+        gType, noiseType, cfType,
+    } <: TransformedFunction
     prob::pType
     f::fType
     g::gType
@@ -18,8 +20,10 @@ function StochasticTransformedFunction(sol, f, g, corfunc_analytical = nothing)
         gtmp = similar(prob.p, size(prob.noise_rate_prototype))
     end
 
-    return StochasticTransformedFunction(prob, f, g, gtmp, DiffEqBase.isinplace(prob),
-        corfunc_analytical)
+    return StochasticTransformedFunction(
+        prob, f, g, gtmp, DiffEqBase.isinplace(prob),
+        corfunc_analytical
+    )
 end
 
 function (Tfunc::StochasticTransformedFunction)(du, u, p, t)

--- a/src/second_order.jl
+++ b/src/second_order.jl
@@ -1,6 +1,8 @@
-function _second_order_sensitivities(loss, prob, alg, sensealg::ForwardDiffOverAdjoint,
-        args...; kwargs...)
-    ForwardDiff.jacobian(prob.p) do p
+function _second_order_sensitivities(
+        loss, prob, alg, sensealg::ForwardDiffOverAdjoint,
+        args...; kwargs...
+    )
+    return ForwardDiff.jacobian(prob.p) do p
         x = Zygote.gradient(p) do _p
             loss(solve(prob, alg, args...; p = _p, sensealg = sensealg.adjalg, kwargs...))
         end
@@ -10,12 +12,18 @@ end
 
 struct SciMLSensitivityTag end
 
-function _second_order_sensitivity_product(loss, v, prob, alg,
+function _second_order_sensitivity_product(
+        loss, v, prob, alg,
         sensealg::ForwardDiffOverAdjoint,
-        args...; kwargs...)
+        args...; kwargs...
+    )
     T = typeof(ForwardDiff.Tag(SciMLSensitivityTag(), eltype(v)))
     θ = ForwardDiff.Dual{T, eltype(v), 1}.(prob.p, ForwardDiff.Partials.(Tuple.(v)))
-    _loss = p -> loss(solve(prob, alg, args...; p = p, sensealg = sensealg.adjalg,
-        kwargs...))
-    getindex.(ForwardDiff.partials.(Zygote.gradient(_loss, θ)[1]), 1)
+    _loss = p -> loss(
+        solve(
+            prob, alg, args...; p = p, sensealg = sensealg.adjalg,
+            kwargs...
+        )
+    )
+    return getindex.(ForwardDiff.partials.(Zygote.gradient(_loss, θ)[1]), 1)
 end

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -1,5 +1,5 @@
 function SensitivityAlg(args...; kwargs...)
-    @error("The SensitivityAlg choice mechanism was completely overhauled. Please consult the local sensitivity documentation for more information")
+    return @error("The SensitivityAlg choice mechanism was completely overhauled. Please consult the local sensitivity documentation for more information")
 end
 
 """
@@ -59,11 +59,12 @@ function ForwardSensitivity(;
         chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
         autojacvec = autodiff,
-        autojacmat = false)
+        autojacmat = false
+    )
     autojacvec && autojacmat &&
         error("Choose either Jacobian matrix products or Jacobian vector products,
                 autojacmat and autojacvec cannot both be true")
-    ForwardSensitivity{chunk_size, autodiff, diff_type}(autojacvec, autojacmat)
+    return ForwardSensitivity{chunk_size, autodiff, diff_type}(autojacvec, autojacmat)
 end
 
 """
@@ -97,9 +98,9 @@ This `sensealg` supports any `SciMLProblem`s, provided that the solver algorithm
 accurately differentiate code with callbacks only when `convert_tspan=true`.
 """
 struct ForwardDiffSensitivity{CS, CTS} <:
-       AbstractForwardSensitivityAlgorithm{CS, Nothing, Nothing} end
+    AbstractForwardSensitivityAlgorithm{CS, Nothing, Nothing} end
 function ForwardDiffSensitivity(; chunk_size = 0, convert_tspan = nothing)
-    ForwardDiffSensitivity{chunk_size, convert_tspan}()
+    return ForwardDiffSensitivity{chunk_size, convert_tspan}()
 end
 
 """
@@ -249,23 +250,29 @@ Scalable Gradients for Stochastic Differential Equations,
 PMLR 108, pp. 3870-3882 (2020), http://proceedings.mlr.press/v108/li20i.html
 """
 struct BacksolveAdjoint{CS, AD, FDT, VJP} <:
-       AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
+    AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
     autojacvec::VJP
     checkpointing::Bool
     noisemixing::Bool
 end
-Base.@pure function BacksolveAdjoint(; chunk_size = 0, autodiff = true,
+Base.@pure function BacksolveAdjoint(;
+        chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
         autojacvec = nothing,
-        checkpointing = true, noisemixing = false)
-    BacksolveAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(autojacvec,
+        checkpointing = true, noisemixing = false
+    )
+    BacksolveAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(
+        autojacvec,
         checkpointing,
-        noisemixing)
+        noisemixing
+    )
 end
 
 function setvjp(sensealg::BacksolveAdjoint{CS, AD, FDT, Nothing}, vjp) where {CS, AD, FDT}
-    BacksolveAdjoint{CS, AD, FDT, typeof(vjp)}(vjp, sensealg.checkpointing,
-        sensealg.noisemixing)
+    return BacksolveAdjoint{CS, AD, FDT, typeof(vjp)}(
+        vjp, sensealg.checkpointing,
+        sensealg.noisemixing
+    )
 end
 
 """
@@ -365,24 +372,32 @@ continuous sensitivity analysis for derivatives of differential equation solutio
 arXiv:1812.01892
 """
 struct InterpolatingAdjoint{CS, AD, FDT, VJP} <:
-       AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
+    AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
     autojacvec::VJP
     checkpointing::Bool
     noisemixing::Bool
 end
-Base.@pure function InterpolatingAdjoint(; chunk_size = 0, autodiff = true,
+Base.@pure function InterpolatingAdjoint(;
+        chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
         autojacvec = nothing,
-        checkpointing = false, noisemixing = false)
-    InterpolatingAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(autojacvec,
+        checkpointing = false, noisemixing = false
+    )
+    InterpolatingAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(
+        autojacvec,
         checkpointing,
-        noisemixing)
+        noisemixing
+    )
 end
 
-function setvjp(sensealg::InterpolatingAdjoint{CS, AD, FDT, Nothing},
-        vjp) where {CS, AD, FDT}
-    InterpolatingAdjoint{CS, AD, FDT, typeof(vjp)}(vjp, sensealg.checkpointing,
-        sensealg.noisemixing)
+function setvjp(
+        sensealg::InterpolatingAdjoint{CS, AD, FDT, Nothing},
+        vjp
+    ) where {CS, AD, FDT}
+    return InterpolatingAdjoint{CS, AD, FDT, typeof(vjp)}(
+        vjp, sensealg.checkpointing,
+        sensealg.noisemixing
+    )
 end
 
 """
@@ -463,22 +478,28 @@ Kim, S., Ji, W., Deng, S., Ma, Y., & Rackauckas, C. (2021). Stiff neural ordinar
 differential equations. Chaos: An Interdisciplinary Journal of Nonlinear Science, 31(9), 093122.
 """
 struct QuadratureAdjoint{CS, AD, FDT, VJP} <:
-       AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
+    AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
     autojacvec::VJP
     abstol::Float64
     reltol::Float64
 end
-Base.@pure function QuadratureAdjoint(; chunk_size = 0, autodiff = true,
+Base.@pure function QuadratureAdjoint(;
+        chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
-        autojacvec = nothing, abstol = 1e-6,
-        reltol = 1e-3)
-    QuadratureAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(autojacvec,
-        abstol, reltol)
+        autojacvec = nothing, abstol = 1.0e-6,
+        reltol = 1.0e-3
+    )
+    QuadratureAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(
+        autojacvec,
+        abstol, reltol
+    )
 end
 
 function setvjp(sensealg::QuadratureAdjoint{CS, AD, FDT, Nothing}, vjp) where {CS, AD, FDT}
-    QuadratureAdjoint{CS, AD, FDT, typeof(vjp)}(vjp, sensealg.abstol,
-        sensealg.reltol)
+    return QuadratureAdjoint{CS, AD, FDT, typeof(vjp)}(
+        vjp, sensealg.abstol,
+        sensealg.reltol
+    )
 end
 
 """
@@ -559,20 +580,23 @@ Kim, S., Ji, W., Deng, S., Ma, Y., & Rackauckas, C. (2021). Stiff neural ordinar
 differential equations. Chaos: An Interdisciplinary Journal of Nonlinear Science, 31(9), 093122.
 """
 struct GaussAdjoint{CS, AD, FDT, VJP} <:
-       AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
+    AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
     autojacvec::VJP
     checkpointing::Bool
 end
-Base.@pure function GaussAdjoint(; chunk_size = 0, autodiff = true,
+Base.@pure function GaussAdjoint(;
+        chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
         autojacvec = nothing,
-        checkpointing = false)
+        checkpointing = false
+    )
     GaussAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(
-        autojacvec, checkpointing)
+        autojacvec, checkpointing
+    )
 end
 
 function setvjp(sensealg::GaussAdjoint{CS, AD, FDT, Nothing}, vjp) where {CS, AD, FDT}
-    GaussAdjoint{CS, AD, FDT, typeof(vjp)}(vjp, sensealg.checkpointing)
+    return GaussAdjoint{CS, AD, FDT, typeof(vjp)}(vjp, sensealg.checkpointing)
 end
 
 """
@@ -650,21 +674,25 @@ Kim, S., Ji, W., Deng, S., Ma, Y., & Rackauckas, C. (2021). Stiff neural ordinar
 differential equations. Chaos: An Interdisciplinary Journal of Nonlinear Science, 31(9), 093122.
 """
 struct GaussKronrodAdjoint{CS, AD, FDT, VJP} <:
-       AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
+    AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
     autojacvec::VJP
     checkpointing::Bool
 end
-Base.@pure function GaussKronrodAdjoint(; chunk_size = 0, autodiff = true,
+Base.@pure function GaussKronrodAdjoint(;
+        chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
         autojacvec = nothing,
-        checkpointing = false)
+        checkpointing = false
+    )
     GaussKronrodAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(
-        autojacvec, checkpointing)
+        autojacvec, checkpointing
+    )
 end
 
 function setvjp(sensealg::GaussKronrodAdjoint{CS, AD, FDT, Nothing}, vjp) where {
-        CS, AD, FDT}
-    GaussKronrodAdjoint{CS, AD, FDT, typeof(vjp)}(vjp, sensealg.checkpointing)
+        CS, AD, FDT,
+    }
+    return GaussKronrodAdjoint{CS, AD, FDT, typeof(vjp)}(vjp, sensealg.checkpointing)
 end
 
 # Supertype of gauss methods, internal
@@ -802,7 +830,7 @@ EnzymeAdjoint(mode = nothing)
 Currently fails on almost every solver.
 """
 struct EnzymeAdjoint{M <: Union{Nothing, Enzyme.EnzymeCore.Mode}} <:
-       AbstractAdjointSensitivityAlgorithm{nothing, true, nothing}
+    AbstractAdjointSensitivityAlgorithm{nothing, true, nothing}
     mode::M
     EnzymeAdjoint(mode = nothing) = new{typeof(mode)}(mode)
 end
@@ -872,7 +900,7 @@ Blonigan, P., Gomez, S., Wang, Q., Least Squares Shadowing for sensitivity analy
 fluid flows, in: 52nd Aerospace Sciences Meeting, 1–24 (2014).
 """
 struct ForwardLSS{CS, AD, FDT, RType, gType} <:
-       AbstractShadowingSensitivityAlgorithm{CS, AD, FDT}
+    AbstractShadowingSensitivityAlgorithm{CS, AD, FDT}
     LSSregularizer::RType
     g::gType
 end
@@ -880,10 +908,12 @@ Base.@pure function ForwardLSS(;
         chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
         LSSregularizer = TimeDilation(10.0, 0.0, 0.0),
-        g = nothing)
+        g = nothing
+    )
     ForwardLSS{chunk_size, autodiff, diff_type, typeof(LSSregularizer), typeof(g)}(
         LSSregularizer,
-        g)
+        g
+    )
 end
 
 """
@@ -943,7 +973,7 @@ Wang, Q., Hu, R., and Blonigan, P. Least squares shadowing sensitivity analysis 
 chaotic limit cycle oscillations. Journal of Computational Physics, 267, 210-224 (2014).
 """
 struct AdjointLSS{CS, AD, FDT, RType, gType} <:
-       AbstractShadowingSensitivityAlgorithm{CS, AD, FDT}
+    AbstractShadowingSensitivityAlgorithm{CS, AD, FDT}
     LSSregularizer::RType
     g::gType
 end
@@ -951,10 +981,12 @@ Base.@pure function AdjointLSS(;
         chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
         LSSregularizer = TimeDilation(10.0, 0.0, 0.0),
-        g = nothing)
+        g = nothing
+    )
     AdjointLSS{chunk_size, autodiff, diff_type, typeof(LSSregularizer), typeof(g)}(
         LSSregularizer,
-        g)
+        g
+    )
 end
 
 abstract type AbstractLSSregularizer end
@@ -984,7 +1016,7 @@ struct TimeDilation{T1 <: Number} <: AbstractLSSregularizer
     t1skip::T1
 end
 function TimeDilation(alpha, t0skip = zero(alpha), t1skip = zero(alpha))
-    TimeDilation{typeof(alpha)}(alpha, t0skip, t1skip)
+    return TimeDilation{typeof(alpha)}(alpha, t0skip, t1skip)
 end
 """
 ```
@@ -1056,7 +1088,7 @@ Ni, A., and Wang, Q. Sensitivity analysis on chaotic dynamical systems by Non-In
 Least Squares Shadowing (NILSS). Journal of Computational Physics 347, 56-77 (2017).
 """
 struct NILSS{CS, AD, FDT, RNG, nType, gType} <:
-       AbstractShadowingSensitivityAlgorithm{CS, AD, FDT}
+    AbstractShadowingSensitivityAlgorithm{CS, AD, FDT}
     rng::RNG
     nseg::Int
     nstep::Int
@@ -1064,16 +1096,20 @@ struct NILSS{CS, AD, FDT, RNG, nType, gType} <:
     autojacvec::Bool
     g::gType
 end
-Base.@pure function NILSS(nseg, nstep; nus = nothing,
+Base.@pure function NILSS(
+        nseg, nstep; nus = nothing,
         rng = Xorshifts.Xoroshiro128Plus(rand(UInt64)),
         chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
         autojacvec = autodiff,
-        g = nothing)
-    NILSS{chunk_size, autodiff, diff_type, typeof(rng), typeof(nus), typeof(g)}(rng, nseg,
+        g = nothing
+    )
+    NILSS{chunk_size, autodiff, diff_type, typeof(rng), typeof(nus), typeof(g)}(
+        rng, nseg,
         nstep, nus,
         autojacvec,
-        g)
+        g
+    )
 end
 
 """
@@ -1156,7 +1192,7 @@ by Non-Intrusive Least Squares Adjoint Shadowing (NILSAS). Journal of Computatio
 Physics 395, 690-709 (2019).
 """
 struct NILSAS{CS, AD, FDT, RNG, SENSE, gType} <:
-       AbstractShadowingSensitivityAlgorithm{CS, AD, FDT}
+    AbstractShadowingSensitivityAlgorithm{CS, AD, FDT}
     rng::RNG
     adjoint_sensealg::SENSE
     M::Int
@@ -1164,12 +1200,14 @@ struct NILSAS{CS, AD, FDT, RNG, SENSE, gType} <:
     nstep::Int
     g::gType
 end
-Base.@pure function NILSAS(nseg, nstep, M = nothing;
+Base.@pure function NILSAS(
+        nseg, nstep, M = nothing;
         rng = Xorshifts.Xoroshiro128Plus(rand(UInt64)),
         adjoint_sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()),
         chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
-        g = nothing)
+        g = nothing
+    )
 
     # integer dimension of the unstable subspace
     M === nothing &&
@@ -1181,9 +1219,11 @@ Base.@pure function NILSAS(nseg, nstep, M = nothing;
         diff_type,
         typeof(rng),
         typeof(adjoint_sensealg),
-        typeof(g)
-    }(rng, adjoint_sensealg, M,
-        nseg, nstep, g)
+        typeof(g),
+    }(
+        rng, adjoint_sensealg, M,
+        nseg, nstep, g
+    )
 end
 
 """
@@ -1240,22 +1280,30 @@ Johnson, S. G., Notes on Adjoint Methods for 18.336, Online at
 http://math.mit.edu/stevenj/18.336/adjoint.pdf (2007)
 """
 struct SteadyStateAdjoint{CS, AD, FDT, VJP, LS, LK} <:
-       AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
+    AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
     autojacvec::VJP
     linsolve::LS
     linsolve_kwargs::LK
 end
 
-Base.@pure function SteadyStateAdjoint(; chunk_size = 0, autodiff = true,
+Base.@pure function SteadyStateAdjoint(;
+        chunk_size = 0, autodiff = true,
         diff_type = Val{:central}, autojacvec = nothing, linsolve = nothing,
-        linsolve_kwargs = (;))
-    return SteadyStateAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec),
-        typeof(linsolve), typeof(linsolve_kwargs)}(autojacvec, linsolve, linsolve_kwargs)
+        linsolve_kwargs = (;)
+    )
+    return SteadyStateAdjoint{
+        chunk_size, autodiff, diff_type, typeof(autojacvec),
+        typeof(linsolve), typeof(linsolve_kwargs),
+    }(autojacvec, linsolve, linsolve_kwargs)
 end
-function setvjp(sensealg::SteadyStateAdjoint{CS, AD, FDT, VJP, LS, LK},
-        vjp) where {CS, AD, FDT, VJP, LS, LK}
-    return SteadyStateAdjoint{CS, AD, FDT, typeof(vjp), LS, LK}(vjp, sensealg.linsolve,
-        sensealg.linsolve_kwargs)
+function setvjp(
+        sensealg::SteadyStateAdjoint{CS, AD, FDT, VJP, LS, LK},
+        vjp
+    ) where {CS, AD, FDT, VJP, LS, LK}
+    return SteadyStateAdjoint{CS, AD, FDT, typeof(vjp), LS, LK}(
+        vjp, sensealg.linsolve,
+        sensealg.linsolve_kwargs
+    )
 end
 
 abstract type VJPChoice end
@@ -1320,7 +1368,7 @@ EnzymeVJP(; chunksize = 0, mode = EnzymeCore.Reverse)
   - `mode`: the parameterized Enzyme mode, default set to EnzymeCore.Reverse. Alternatively one
     may want to pass Enzyme.set_runtime_activity(Enzyme.Reverse)
 """
-struct EnzymeVJP{Mode<:Enzyme.ReverseMode} <: VJPChoice
+struct EnzymeVJP{Mode <: Enzyme.ReverseMode} <: VJPChoice
     chunksize::Int
     mode::Mode
 end
@@ -1410,44 +1458,50 @@ struct MooncakeVJP <: VJPChoice end
 
 @inline convert_tspan(::ForwardDiffSensitivity{CS, CTS}) where {CS, CTS} = CTS
 @inline convert_tspan(::Any) = nothing
-@inline function alg_autodiff(alg::AbstractSensitivityAlgorithm{
+@inline function alg_autodiff(
+        alg::AbstractSensitivityAlgorithm{
+            CS,
+            AD,
+            FDT,
+        }
+    ) where {
         CS,
         AD,
-        FDT
-}) where {
-        CS,
-        AD,
-        FDT
-}
-    AD
+        FDT,
+    }
+    return AD
 end
-@inline function get_chunksize(alg::AbstractSensitivityAlgorithm{
+@inline function get_chunksize(
+        alg::AbstractSensitivityAlgorithm{
+            CS,
+            AD,
+            FDT,
+        }
+    ) where {
         CS,
         AD,
-        FDT
-}) where {
-        CS,
-        AD,
-        FDT
-}
-    CS
+        FDT,
+    }
+    return CS
 end
-@inline function diff_type(alg::AbstractSensitivityAlgorithm{
+@inline function diff_type(
+        alg::AbstractSensitivityAlgorithm{
+            CS,
+            AD,
+            FDT,
+        }
+    ) where {
         CS,
         AD,
-        FDT
-}) where {
-        CS,
-        AD,
-        FDT
-}
-    FDT
+        FDT,
+    }
+    return FDT
 end
 @inline function get_jacvec(alg::AbstractSensitivityAlgorithm)
-    alg.autojacvec isa Bool ? alg.autojacvec : true
+    return alg.autojacvec isa Bool ? alg.autojacvec : true
 end
 @inline function get_jacmat(alg::AbstractSensitivityAlgorithm)
-    alg.autojacmat isa Bool ? alg.autojacmat : true
+    return alg.autojacmat isa Bool ? alg.autojacmat : true
 end
 @inline ischeckpointing(alg::AbstractSensitivityAlgorithm, sol = nothing) = false
 @inline ischeckpointing(alg::InterpolatingAdjoint) = alg.checkpointing
@@ -1491,7 +1545,7 @@ differential/algebraic equation solvers, ACM Transactions on Mathematical
 Software (TOMS), 31, pp:363–396 (2005)
 """
 struct ForwardDiffOverAdjoint{A} <:
-       AbstractSecondOrderSensitivityAlgorithm{nothing, true, nothing}
+    AbstractSecondOrderSensitivityAlgorithm{nothing, true, nothing}
     adjalg::A
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,7 @@
 function isfunctor(x)
-    !isempty(Functors.children(x))
+    return !isempty(Functors.children(x))
 end
 
 function to_nt(s::T) where {T}
-    NamedTuple{propertynames(s)}(map(x -> getproperty(s, x), propertynames(s)))
+    return NamedTuple{propertynames(s)}(map(x -> getproperty(s, x), propertynames(s)))
 end

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -1,367 +1,492 @@
 using SciMLSensitivity, OrdinaryDiffEq, RecursiveArrayTools, DiffEqBase,
-      ForwardDiff, Calculus, QuadGK, LinearAlgebra, Zygote, Mooncake
+    ForwardDiff, Calculus, QuadGK, LinearAlgebra, Zygote, Mooncake
 using Test
 
 function fb(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2] * t
-    du[2] = dy = -p[3] * u[2] + t * p[4] * u[1] * u[2]
+    return du[2] = dy = -p[3] * u[2] + t * p[4] * u[1] * u[2]
 end
 function foop(u, p, t)
     dx = p[1] * u[1] - p[2] * u[1] * u[2] * t
     dy = -p[3] * u[2] + t * p[4] * u[1] * u[2]
-    [dx, dy]
+    return [dx, dy]
 end
 function jac(J, u, p, t)
     (x, y, a, b, c, d) = (u[1], u[2], p[1], p[2], p[3], p[4])
     J[1, 1] = a + y * b * -1 * t
     J[2, 1] = t * y * d
     J[1, 2] = b * x * -1 * t
-    J[2, 2] = c * -1 + t * x * d
+    return J[2, 2] = c * -1 + t * x * d
 end
 
 f = ODEFunction(fb, jac = jac)
 p = [1.5, 1.0, 3.0, 1.0];
 u0 = [1.0; 1.0];
 prob = ODEProblem(f, u0, (0.0, 10.0), p)
-sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
+sol = solve(prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
 probb = ODEProblem(fb, u0, (0.0, 10.0), p)
 proboop = ODEProblem(foop, u0, (0.0, 10.0), p)
 
-solb = solve(probb, Tsit5(), abstol = 1e-14, reltol = 1e-14)
-sol_end = solve(probb, Tsit5(), abstol = 1e-14, reltol = 1e-14,
-    save_everystep = false, save_start = false)
+solb = solve(probb, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
+sol_end = solve(
+    probb, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14,
+    save_everystep = false, save_start = false
+)
 
-sol_nodense = solve(probb, Tsit5(), abstol = 1e-14, reltol = 1e-14, dense = false)
-soloop = solve(proboop, Tsit5(), abstol = 1e-14, reltol = 1e-14)
-soloop_nodense = solve(proboop, Tsit5(), abstol = 1e-14, reltol = 1e-14, dense = false)
+sol_nodense = solve(probb, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14, dense = false)
+soloop = solve(proboop, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
+soloop_nodense = solve(proboop, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14, dense = false)
 
 # Do a discrete adjoint problem
 println("Calculate discrete adjoint sensitivities")
 t = 0.0:0.5:10.0
 # g(t,u,i) = (1-u)^2/2, L2 away from 1
 function dg(out, u, p, t, i)
-    (out .= -2.0 .+ u)
+    return (out .= -2.0 .+ u)
 end
 
 _,
-easy_res = adjoint_sensitivities(
-    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
-    reltol = 1e-14)
+    easy_res = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
+    reltol = 1.0e-14
+)
 _,
-easy_res2 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(abstol = 1e-14,
-        reltol = 1e-14))
+    easy_res2 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        abstol = 1.0e-14,
+        reltol = 1.0e-14
+    )
+)
 _,
-easy_res22 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(autojacvec = false,
-        abstol = 1e-14,
-        reltol = 1e-14))
+    easy_res22 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        autojacvec = false,
+        abstol = 1.0e-14,
+        reltol = 1.0e-14
+    )
+)
 _,
-easy_res23 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(abstol = 1e-14,
-        reltol = 1e-14,
-        autojacvec = ReverseDiffVJP(true)))
+    easy_res23 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        abstol = 1.0e-14,
+        reltol = 1.0e-14,
+        autojacvec = ReverseDiffVJP(true)
+    )
+)
 _,
-easy_res3 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint())
+    easy_res3 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint()
+)
 _,
-easy_res32 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = false))
+    easy_res32 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = false)
+)
 _,
-easy_res4 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint())
+    easy_res4 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint()
+)
 _,
-easy_res42 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint(autojacvec = false))
+    easy_res42 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint(autojacvec = false)
+)
 _,
-easy_res43 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint(autojacvec = false,
-        checkpointing = false))
+    easy_res43 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint(
+        autojacvec = false,
+        checkpointing = false
+    )
+)
 _,
-easy_res5 = adjoint_sensitivities(sol,
+    easy_res5 = adjoint_sensitivities(
+    sol,
     Kvaerno5(nlsolve = NLAnderson(), smooth_est = false),
-    t = t, dgdu_discrete = dg, abstol = 1e-12,
-    reltol = 1e-10,
-    sensealg = BacksolveAdjoint())
+    t = t, dgdu_discrete = dg, abstol = 1.0e-12,
+    reltol = 1.0e-10,
+    sensealg = BacksolveAdjoint()
+)
 _,
-easy_res6 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res6 = adjoint_sensitivities(
+    sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     sensealg = InterpolatingAdjoint(checkpointing = true),
-    checkpoints = sol.t[1:10:end])
+    checkpoints = sol.t[1:10:end]
+)
 _,
-easy_res62 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(checkpointing = true,
-        autojacvec = false),
-    checkpoints = sol.t[1:500:end])
+    easy_res62 = adjoint_sensitivities(
+    sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(
+        checkpointing = true,
+        autojacvec = false
+    ),
+    checkpoints = sol.t[1:500:end]
+)
 # It should automatically be checkpointing since the solution isn't dense
 _,
-easy_res7 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res7 = adjoint_sensitivities(
+    sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     sensealg = InterpolatingAdjoint(),
-    checkpoints = sol.t[1:500:end])
+    checkpoints = sol.t[1:500:end]
+)
 _,
-easy_res8 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.TrackerVJP()))
+    easy_res8 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.TrackerVJP())
+)
 _,
-easy_res9 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ZygoteVJP()))
+    easy_res9 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ZygoteVJP())
+)
 _,
-easy_res10 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP()))
+    easy_res10 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP())
+)
 _,
-easy_res11 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP(true)))
+    easy_res11 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP(true))
+)
 _,
-easy_res12 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.EnzymeVJP()))
+    easy_res12 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.EnzymeVJP())
+)
 _,
-easy_res13 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(autojacvec = SciMLSensitivity.EnzymeVJP()))
+    easy_res13 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(autojacvec = SciMLSensitivity.EnzymeVJP())
+)
 _,
-easy_res14 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint())
+    easy_res14 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint()
+)
 _,
-easy_res14k = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint())
+    easy_res14k = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint()
+)
 _,
-easy_res15 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP()))
+    easy_res15 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP())
+)
 _,
-easy_res16 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP()))
+    easy_res16 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP())
+)
 _,
-easy_res142 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint(autojacvec = false))
+    easy_res142 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint(autojacvec = false)
+)
 _,
-easy_res143 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint(autojacvec = ReverseDiffVJP(true)))
+    easy_res143 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint(autojacvec = ReverseDiffVJP(true))
+)
 _,
-easy_res144 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint(autojacvec = SciMLSensitivity.EnzymeVJP()))
+    easy_res144 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint(autojacvec = SciMLSensitivity.EnzymeVJP())
+)
 _,
-easy_res145 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res145 = adjoint_sensitivities(
+    sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     sensealg = GaussAdjoint(checkpointing = true),
-    checkpoints = sol.t[1:500:end])
+    checkpoints = sol.t[1:500:end]
+)
 _,
-easy_res146 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint(checkpointing = true,
-        autojacvec = false),
-    checkpoints = sol.t[1:500:end])
+    easy_res146 = adjoint_sensitivities(
+    sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint(
+        checkpointing = true,
+        autojacvec = false
+    ),
+    checkpoints = sol.t[1:500:end]
+)
 _,
-easy_res147 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP()))
+    easy_res147 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP())
+)
 _,
-easy_res142k = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint(autojacvec = false))
+    easy_res142k = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint(autojacvec = false)
+)
 _,
-easy_res143k = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint(autojacvec = ReverseDiffVJP(true)))
+    easy_res143k = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint(autojacvec = ReverseDiffVJP(true))
+)
 _,
-easy_res144k = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint(autojacvec = SciMLSensitivity.EnzymeVJP()))
+    easy_res144k = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint(autojacvec = SciMLSensitivity.EnzymeVJP())
+)
 _,
-easy_res145k = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res145k = adjoint_sensitivities(
+    sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     sensealg = GaussKronrodAdjoint(checkpointing = true),
-    checkpoints = sol.t[1:500:end])
+    checkpoints = sol.t[1:500:end]
+)
 _,
-easy_res146k = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint(checkpointing = true,
-        autojacvec = false),
-    checkpoints = sol.t[1:500:end])
+    easy_res146k = adjoint_sensitivities(
+    sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint(
+        checkpointing = true,
+        autojacvec = false
+    ),
+    checkpoints = sol.t[1:500:end]
+)
 _,
-easy_res147k = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP()))
-adj_prob = ODEAdjointProblem(sol,
-    QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14,
-        autojacvec = SciMLSensitivity.ReverseDiffVJP()),
+    easy_res147k = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP())
+)
+adj_prob = ODEAdjointProblem(
+    sol,
+    QuadratureAdjoint(
+        abstol = 1.0e-14, reltol = 1.0e-14,
+        autojacvec = SciMLSensitivity.ReverseDiffVJP()
+    ),
     Tsit5(),
-    t, dg)
-adj_sol = solve(adj_prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
-integrand = AdjointSensitivityIntegrand(sol, adj_sol,
-    QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14,
-        autojacvec = SciMLSensitivity.ReverseDiffVJP()))
-res, err = quadgk(integrand, 0.0, 10.0, atol = 1e-14, rtol = 1e-12)
+    t, dg
+)
+adj_sol = solve(adj_prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
+integrand = AdjointSensitivityIntegrand(
+    sol, adj_sol,
+    QuadratureAdjoint(
+        abstol = 1.0e-14, reltol = 1.0e-14,
+        autojacvec = SciMLSensitivity.ReverseDiffVJP()
+    )
+)
+res, err = quadgk(integrand, 0.0, 10.0, atol = 1.0e-14, rtol = 1.0e-12)
 
-@test isapprox(res, easy_res, rtol = 1e-10)
-@test isapprox(res, easy_res2, rtol = 1e-10)
-@test isapprox(res, easy_res22, rtol = 1e-10)
-@test isapprox(res, easy_res23, rtol = 1e-10)
-@test isapprox(res, easy_res3, rtol = 1e-10)
-@test isapprox(res, easy_res32, rtol = 1e-10)
-@test isapprox(res, easy_res4, rtol = 1e-10)
-@test isapprox(res, easy_res42, rtol = 1e-10)
-@test isapprox(res, easy_res43, rtol = 1e-10)
-@test isapprox(res, easy_res5, rtol = 1e-7)
-@test isapprox(res, easy_res6, rtol = 1e-9)
-@test isapprox(res, easy_res62, rtol = 1e-9)
-@test isapprox(easy_res6, easy_res7, rtol = 1e-9)
-@test isapprox(res, easy_res8, rtol = 1e-9)
-@test isapprox(res, easy_res9, rtol = 1e-9)
-@test isapprox(res, easy_res10, rtol = 1e-9)
-@test isapprox(res, easy_res11, rtol = 1e-9)
-@test isapprox(res, easy_res12, rtol = 1e-9)
-@test isapprox(res, easy_res13, rtol = 1e-9)
-@test isapprox(res, easy_res14, rtol = 1e-9)
-@test isapprox(res, easy_res14k, rtol = 1e-9)
-@test isapprox(res, easy_res15, rtol = 1e-9)
-@test isapprox(res, easy_res16, rtol = 1e-9)
-@test isapprox(res, easy_res142, rtol = 1e-9)
-@test isapprox(res, easy_res143, rtol = 1e-9)
-@test isapprox(res, easy_res144, rtol = 1e-9)
-@test isapprox(res, easy_res145, rtol = 1e-9)
-@test isapprox(res, easy_res146, rtol = 1e-9)
-@test isapprox(res, easy_res147, rtol = 1e-9)
-@test isapprox(res, easy_res142k, rtol = 1e-9)
-@test isapprox(res, easy_res143k, rtol = 1e-9)
-@test isapprox(res, easy_res144k, rtol = 1e-9)
-@test isapprox(res, easy_res145k, rtol = 1e-9)
-@test isapprox(res, easy_res146k, rtol = 1e-9)
-@test isapprox(res, easy_res147k, rtol = 1e-9)
+@test isapprox(res, easy_res, rtol = 1.0e-10)
+@test isapprox(res, easy_res2, rtol = 1.0e-10)
+@test isapprox(res, easy_res22, rtol = 1.0e-10)
+@test isapprox(res, easy_res23, rtol = 1.0e-10)
+@test isapprox(res, easy_res3, rtol = 1.0e-10)
+@test isapprox(res, easy_res32, rtol = 1.0e-10)
+@test isapprox(res, easy_res4, rtol = 1.0e-10)
+@test isapprox(res, easy_res42, rtol = 1.0e-10)
+@test isapprox(res, easy_res43, rtol = 1.0e-10)
+@test isapprox(res, easy_res5, rtol = 1.0e-7)
+@test isapprox(res, easy_res6, rtol = 1.0e-9)
+@test isapprox(res, easy_res62, rtol = 1.0e-9)
+@test isapprox(easy_res6, easy_res7, rtol = 1.0e-9)
+@test isapprox(res, easy_res8, rtol = 1.0e-9)
+@test isapprox(res, easy_res9, rtol = 1.0e-9)
+@test isapprox(res, easy_res10, rtol = 1.0e-9)
+@test isapprox(res, easy_res11, rtol = 1.0e-9)
+@test isapprox(res, easy_res12, rtol = 1.0e-9)
+@test isapprox(res, easy_res13, rtol = 1.0e-9)
+@test isapprox(res, easy_res14, rtol = 1.0e-9)
+@test isapprox(res, easy_res14k, rtol = 1.0e-9)
+@test isapprox(res, easy_res15, rtol = 1.0e-9)
+@test isapprox(res, easy_res16, rtol = 1.0e-9)
+@test isapprox(res, easy_res142, rtol = 1.0e-9)
+@test isapprox(res, easy_res143, rtol = 1.0e-9)
+@test isapprox(res, easy_res144, rtol = 1.0e-9)
+@test isapprox(res, easy_res145, rtol = 1.0e-9)
+@test isapprox(res, easy_res146, rtol = 1.0e-9)
+@test isapprox(res, easy_res147, rtol = 1.0e-9)
+@test isapprox(res, easy_res142k, rtol = 1.0e-9)
+@test isapprox(res, easy_res143k, rtol = 1.0e-9)
+@test isapprox(res, easy_res144k, rtol = 1.0e-9)
+@test isapprox(res, easy_res145k, rtol = 1.0e-9)
+@test isapprox(res, easy_res146k, rtol = 1.0e-9)
+@test isapprox(res, easy_res147k, rtol = 1.0e-9)
 
 println("OOP adjoint sensitivities ")
 
 _,
-easy_res = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14)
+    easy_res = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14
+)
 _,
-easy_res2 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14))
+    easy_res2 = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14)
+)
 _,
-easy_res22 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(autojacvec = false, abstol = 1e-14, reltol = 1e-14))
+    easy_res22 = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(autojacvec = false, abstol = 1.0e-14, reltol = 1.0e-14)
+)
 _,
-easy_res2 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(abstol = 1e-14,
-        reltol = 1e-14,
-        autojacvec = ReverseDiffVJP(true)))
+    easy_res2 = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        abstol = 1.0e-14,
+        reltol = 1.0e-14,
+        autojacvec = ReverseDiffVJP(true)
+    )
+)
 _,
-easy_res3 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint())
-@test easy_res32 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = false))[1] isa AbstractArray
+    easy_res3 = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint()
+)
+@test easy_res32 = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = false)
+)[1] isa AbstractArray
 _,
-easy_res4 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint())
-@test easy_res42 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint(autojacvec = false))[1] isa AbstractArray
+    easy_res4 = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint()
+)
+@test easy_res42 = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint(autojacvec = false)
+)[1] isa AbstractArray
 _,
-easy_res5 = adjoint_sensitivities(soloop,
+    easy_res5 = adjoint_sensitivities(
+    soloop,
     Kvaerno5(nlsolve = NLAnderson(), smooth_est = false),
-    t = t, dgdu_discrete = dg, abstol = 1e-12,
-    reltol = 1e-10,
-    sensealg = BacksolveAdjoint())
+    t = t, dgdu_discrete = dg, abstol = 1.0e-12,
+    reltol = 1.0e-10,
+    sensealg = BacksolveAdjoint()
+)
 _,
-easy_res6 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res6 = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     sensealg = InterpolatingAdjoint(checkpointing = true),
-    checkpoints = soloop_nodense.t[1:5:end])
+    checkpoints = soloop_nodense.t[1:5:end]
+)
 _,
-easy_res62 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t,
-    dgdu_discrete = dg, abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res62 = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t,
+    dgdu_discrete = dg, abstol = 1.0e-14,
+    reltol = 1.0e-14,
     sensealg = InterpolatingAdjoint(checkpointing = true, autojacvec = false),
-    checkpoints = soloop_nodense.t[1:5:end])
+    checkpoints = soloop_nodense.t[1:5:end]
+)
 
 _,
-easy_res8 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.TrackerVJP()))
+    easy_res8 = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.TrackerVJP())
+)
 _,
-easy_res9 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ZygoteVJP()))
+    easy_res9 = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ZygoteVJP())
+)
 _,
-easy_res10 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP()))
+    easy_res10 = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP())
+)
 _,
-easy_res11 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP(true)))
+    easy_res11 = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP(true))
+)
 #@test_broken _,easy_res12 = adjoint_sensitivities(soloop_nodense,Tsit5(),t=t,dg_discrete=dg,abstol=1e-14,
 #                                     reltol=1e-14,
 #                                     sensealg=InterpolatingAdjoint(autojacvec=SciMLSensitivity.EnzymeVJP())
@@ -371,147 +496,183 @@ easy_res11 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete
 #                                     sensealg=QuadratureAdjoint(autojacvec=SciMLSensitivity.EnzymeVJP())
 #                                     ) isa Tuple
 _,
-easy_res12 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint())
+    easy_res12 = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint()
+)
 _,
-easy_res122 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint(autojacvec = ReverseDiffVJP(true)))
+    easy_res122 = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint(autojacvec = ReverseDiffVJP(true))
+)
 _,
-easy_res123 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res123 = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     sensealg = GaussAdjoint(checkpointing = true),
-    checkpoints = soloop_nodense.t[1:5:end])
+    checkpoints = soloop_nodense.t[1:5:end]
+)
 _,
-easy_res12k = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint())
+    easy_res12k = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint()
+)
 _,
-easy_res122k = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint(autojacvec = ReverseDiffVJP(true)))
+    easy_res122k = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint(autojacvec = ReverseDiffVJP(true))
+)
 _,
-easy_res123k = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res123k = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     sensealg = GaussKronrodAdjoint(checkpointing = true),
-    checkpoints = soloop_nodense.t[1:5:end])
+    checkpoints = soloop_nodense.t[1:5:end]
+)
 
 _,
-easy_res2_mc_quad = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res2_mc_quad = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     sensealg = QuadratureAdjoint(
-        abstol = 1e-14, reltol = 1e-14, autojacvec = SciMLSensitivity.MooncakeVJP()))
+        abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = SciMLSensitivity.MooncakeVJP()
+    )
+)
 _,
-easy_res2_mc_interp = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP()))
+    easy_res2_mc_interp = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP())
+)
 _,
-easy_res2_mc_back = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP()))
+    easy_res2_mc_back = adjoint_sensitivities(
+    soloop, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP())
+)
 _,
-easy_res6_mc_quad = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t,
+    easy_res6_mc_quad = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t,
     dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     sensealg = QuadratureAdjoint(
-        abstol = 1e-14, reltol = 1e-14, autojacvec = SciMLSensitivity.MooncakeVJP()))
+        abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = SciMLSensitivity.MooncakeVJP()
+    )
+)
 _,
-easy_res6_mc_interp = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t,
+    easy_res6_mc_interp = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t,
     dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(checkpointing = true,
-        autojacvec = SciMLSensitivity.MooncakeVJP()),
-    checkpoints = soloop_nodense.t[1:5:end])
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(
+        checkpointing = true,
+        autojacvec = SciMLSensitivity.MooncakeVJP()
+    ),
+    checkpoints = soloop_nodense.t[1:5:end]
+)
 _,
-easy_res6_mc_back = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t,
+    easy_res6_mc_back = adjoint_sensitivities(
+    soloop_nodense, Tsit5(), t = t,
     dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP()))
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint(autojacvec = SciMLSensitivity.MooncakeVJP())
+)
 
-@test isapprox(res, easy_res, rtol = 1e-10)
-@test isapprox(res, easy_res2, rtol = 1e-10)
-@test isapprox(res, easy_res22, rtol = 1e-10)
-@test isapprox(res, easy_res23, rtol = 1e-10)
-@test isapprox(res, easy_res3, rtol = 1e-10)
-@test isapprox(res, easy_res32, rtol = 1e-10)
-@test isapprox(res, easy_res4, rtol = 1e-10)
-@test isapprox(res, easy_res42, rtol = 1e-10)
-@test isapprox(res, easy_res5, rtol = 1e-9)
-@test isapprox(res, easy_res6, rtol = 1e-10)
-@test isapprox(res, easy_res62, rtol = 1e-9)
-@test isapprox(res, easy_res8, rtol = 1e-9)
-@test isapprox(res, easy_res9, rtol = 1e-9)
-@test isapprox(res, easy_res10, rtol = 1e-9)
-@test isapprox(res, easy_res11, rtol = 1e-9)
+@test isapprox(res, easy_res, rtol = 1.0e-10)
+@test isapprox(res, easy_res2, rtol = 1.0e-10)
+@test isapprox(res, easy_res22, rtol = 1.0e-10)
+@test isapprox(res, easy_res23, rtol = 1.0e-10)
+@test isapprox(res, easy_res3, rtol = 1.0e-10)
+@test isapprox(res, easy_res32, rtol = 1.0e-10)
+@test isapprox(res, easy_res4, rtol = 1.0e-10)
+@test isapprox(res, easy_res42, rtol = 1.0e-10)
+@test isapprox(res, easy_res5, rtol = 1.0e-9)
+@test isapprox(res, easy_res6, rtol = 1.0e-10)
+@test isapprox(res, easy_res62, rtol = 1.0e-9)
+@test isapprox(res, easy_res8, rtol = 1.0e-9)
+@test isapprox(res, easy_res9, rtol = 1.0e-9)
+@test isapprox(res, easy_res10, rtol = 1.0e-9)
+@test isapprox(res, easy_res11, rtol = 1.0e-9)
 #@test isapprox(res, easy_res12, rtol = 1e-9)
 #@test isapprox(res, easy_res13, rtol = 1e-9)
-@test isapprox(res, easy_res12, rtol = 1e-9)
-@test isapprox(res, easy_res122, rtol = 1e-9)
-@test isapprox(res, easy_res123, rtol = 1e-4)
-@test isapprox(res, easy_res12k, rtol = 1e-9)
-@test isapprox(res, easy_res122k, rtol = 1e-9)
-@test isapprox(res, easy_res123k, rtol = 1e-4)
-@test isapprox(res, easy_res2_mc_quad, rtol = 1e-9)
-@test isapprox(res, easy_res2_mc_interp, rtol = 1e-9)
-@test isapprox(res, easy_res2_mc_back, rtol = 1e-9)
-@test isapprox(res, easy_res6_mc_quad, rtol = 1e-4)
-@test isapprox(res, easy_res6_mc_interp, rtol = 1e-9)
-@test isapprox(res, easy_res6_mc_back, rtol = 1e-9)
+@test isapprox(res, easy_res12, rtol = 1.0e-9)
+@test isapprox(res, easy_res122, rtol = 1.0e-9)
+@test isapprox(res, easy_res123, rtol = 1.0e-4)
+@test isapprox(res, easy_res12k, rtol = 1.0e-9)
+@test isapprox(res, easy_res122k, rtol = 1.0e-9)
+@test isapprox(res, easy_res123k, rtol = 1.0e-4)
+@test isapprox(res, easy_res2_mc_quad, rtol = 1.0e-9)
+@test isapprox(res, easy_res2_mc_interp, rtol = 1.0e-9)
+@test isapprox(res, easy_res2_mc_back, rtol = 1.0e-9)
+@test isapprox(res, easy_res6_mc_quad, rtol = 1.0e-4)
+@test isapprox(res, easy_res6_mc_interp, rtol = 1.0e-9)
+@test isapprox(res, easy_res6_mc_back, rtol = 1.0e-9)
 
 println("Calculate adjoint sensitivities ")
 
 _,
-easy_res8 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res8 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     save_everystep = false, save_start = false,
-    sensealg = BacksolveAdjoint())
+    sensealg = BacksolveAdjoint()
+)
 _,
-easy_res82 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res82 = adjoint_sensitivities(
+    solb, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     save_everystep = false, save_start = false,
-    sensealg = BacksolveAdjoint(checkpointing = false))
+    sensealg = BacksolveAdjoint(checkpointing = false)
+)
 
-@test isapprox(res, easy_res8, rtol = 1e-9)
-@test isapprox(res, easy_res82, rtol = 1e-9)
+@test isapprox(res, easy_res8, rtol = 1.0e-9)
+@test isapprox(res, easy_res82, rtol = 1.0e-9)
 
 _,
-end_only_res = adjoint_sensitivities(sol_end, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    end_only_res = adjoint_sensitivities(
+    sol_end, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     save_everystep = false, save_start = false,
-    sensealg = BacksolveAdjoint())
+    sensealg = BacksolveAdjoint()
+)
 
-@test isapprox(res, end_only_res, rtol = 1e-9)
+@test isapprox(res, end_only_res, rtol = 1.0e-9)
 
 println("Calculate adjoint sensitivities from autodiff & numerical diff")
 function G(p)
     tmp_prob = remake(prob, u0 = convert.(eltype(p), prob.u0), p = p)
-    sol = solve(tmp_prob, Tsit5(), abstol = 1e-14, reltol = 1e-14,
-        sensealg = DiffEqBase.SensitivityADPassThrough(), saveat = t)
+    sol = solve(
+        tmp_prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14,
+        sensealg = DiffEqBase.SensitivityADPassThrough(), saveat = t
+    )
     A = Array(sol)
-    sum(((2 .- A) .^ 2) ./ 2)
+    return sum(((2 .- A) .^ 2) ./ 2)
 end
 G([1.5, 1.0, 3.0, 1.0])
 res2 = ForwardDiff.gradient(G, [1.5, 1.0, 3.0, 1.0])
 res3 = Calculus.gradient(G, [1.5, 1.0, 3.0, 1.0])
 
-@test norm(res' .- res2) < 1e-7
-@test norm(res' .- res3) < 1e-5
+@test norm(res' .- res2) < 1.0e-7
+@test norm(res' .- res3) < 1.0e-5
 
 # check other t handling
 
@@ -520,205 +681,262 @@ t3 = [0.0, 0.5, 1.0]
 t4 = [0.5, 1.0, 10.0]
 
 _,
-easy_res2 = adjoint_sensitivities(sol, Tsit5(), t = t2, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14)
+    easy_res2 = adjoint_sensitivities(
+    sol, Tsit5(), t = t2, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14
+)
 _,
-easy_res3 = adjoint_sensitivities(sol, Tsit5(), t = t3, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14)
+    easy_res3 = adjoint_sensitivities(
+    sol, Tsit5(), t = t3, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14
+)
 _,
-easy_res4 = adjoint_sensitivities(sol, Tsit5(), t = t4, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14)
+    easy_res4 = adjoint_sensitivities(
+    sol, Tsit5(), t = t4, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14
+)
 
 function G(p, ts)
     tmp_prob = remake(prob, u0 = convert.(eltype(p), prob.u0), p = p)
-    sol = solve(tmp_prob, Tsit5(), abstol = 1e-10, reltol = 1e-10,
-        sensealg = DiffEqBase.SensitivityADPassThrough(), saveat = ts)
+    sol = solve(
+        tmp_prob, Tsit5(), abstol = 1.0e-10, reltol = 1.0e-10,
+        sensealg = DiffEqBase.SensitivityADPassThrough(), saveat = ts
+    )
     A = convert(Array, sol)
-    sum(((2 .- A) .^ 2) ./ 2)
+    return sum(((2 .- A) .^ 2) ./ 2)
 end
 res2 = ForwardDiff.gradient(p -> G(p, t2), [1.5, 1.0, 3.0, 1.0])
 res3 = ForwardDiff.gradient(p -> G(p, t3), [1.5, 1.0, 3.0, 1.0])
 res4 = ForwardDiff.gradient(p -> G(p, t4), [1.5, 1.0, 3.0, 1.0])
 
-@test easy_res2'≈res2 rtol=1e-10
-@test easy_res3'≈res3 rtol=1e-10
-@test easy_res4'≈res4 rtol=1e-10
+@test easy_res2' ≈ res2 rtol = 1.0e-10
+@test easy_res3' ≈ res3 rtol = 1.0e-10
+@test easy_res4' ≈ res4 rtol = 1.0e-10
 
 println("Adjoints of u0")
 
 function dg(out, u, p, t, i)
-    out .= -1 .+ u
+    return out .= -1 .+ u
 end
 
 ū0,
-adj = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
-    reltol = 1e-14)
+    adj = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
+    reltol = 1.0e-14
+)
 
 _,
-adjnou0 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
-    reltol = 1e-14)
+    adjnou0 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
+    reltol = 1.0e-14
+)
 
 ū02,
-adj2 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
+    adj2 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
     sensealg = BacksolveAdjoint(),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
 ū022,
-adj22 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
+    adj22 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
     sensealg = BacksolveAdjoint(autojacvec = false),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
 ū023,
-adj23 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    sensealg = BacksolveAdjoint(autojacvec = false,
-        checkpointing = false),
-    reltol = 1e-14)
+    adj23 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    sensealg = BacksolveAdjoint(
+        autojacvec = false,
+        checkpointing = false
+    ),
+    reltol = 1.0e-14
+)
 
 ū03,
-adj3 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
+    adj3 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
     sensealg = InterpolatingAdjoint(),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
 ū032,
-adj32 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
+    adj32 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
     sensealg = InterpolatingAdjoint(autojacvec = false),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
 ū04,
-adj4 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
+    adj4 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
     sensealg = InterpolatingAdjoint(checkpointing = true),
     checkpoints = sol.t[1:500:end],
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
-@test_nowarn adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
+@test_nowarn adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
     sensealg = InterpolatingAdjoint(checkpointing = true),
     checkpoints = sol.t[1:5:end],
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
 ū042,
-adj42 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    sensealg = InterpolatingAdjoint(checkpointing = true,
-        autojacvec = false),
+    adj42 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(
+        checkpointing = true,
+        autojacvec = false
+    ),
     checkpoints = sol.t[1:500:end],
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
 ū05,
-adj5 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
-    sensealg = QuadratureAdjoint(abstol = 1e-14,
-        reltol = 1e-14),
-    reltol = 1e-14)
+    adj5 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        abstol = 1.0e-14,
+        reltol = 1.0e-14
+    ),
+    reltol = 1.0e-14
+)
 
 ū052,
-adj52 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    sensealg = QuadratureAdjoint(autojacvec = false,
-        abstol = 1e-14,
-        reltol = 1e-14),
-    reltol = 1e-14)
+    adj52 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        autojacvec = false,
+        abstol = 1.0e-14,
+        reltol = 1.0e-14
+    ),
+    reltol = 1.0e-14
+)
 
 ū05,
-adj53 = adjoint_sensitivities(
-    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
-    sensealg = QuadratureAdjoint(abstol = 1e-14,
-        reltol = 1e-14,
-        autojacvec = ReverseDiffVJP(true)),
-    reltol = 1e-14)
+    adj53 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        abstol = 1.0e-14,
+        reltol = 1.0e-14,
+        autojacvec = ReverseDiffVJP(true)
+    ),
+    reltol = 1.0e-14
+)
 
 ū06,
-adj6 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
+    adj6 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
     sensealg = GaussAdjoint(),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 ū062,
-adj62 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
+    adj62 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
     sensealg = GaussAdjoint(autojacvec = false),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 ū06,
-adj63 = adjoint_sensitivities(
-    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
+    adj63 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
     sensealg = GaussAdjoint(autojacvec = ReverseDiffVJP(true)),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
 ū06k,
-adj6k = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
+    adj6k = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
     sensealg = GaussKronrodAdjoint(),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 ū062k,
-adj62k = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
+    adj62k = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
     sensealg = GaussKronrodAdjoint(autojacvec = false),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 ū06k,
-adj63k = adjoint_sensitivities(
-    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
+    adj63k = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1.0e-14,
     sensealg = GaussKronrodAdjoint(autojacvec = ReverseDiffVJP(true)),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
 ū0args,
-adjargs = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
+    adjargs = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
     save_everystep = false, save_start = false,
     sensealg = BacksolveAdjoint(),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
 ū0args2,
-adjargs2 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
+    adjargs2 = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
     save_everystep = false, save_start = false,
     sensealg = InterpolatingAdjoint(),
-    reltol = 1e-14)
+    reltol = 1.0e-14
+)
 
 res = ForwardDiff.gradient(prob.u0) do u0
     tmp_prob = remake(prob, u0 = u0)
-    sol = solve(tmp_prob, Tsit5(), abstol = 1e-14, reltol = 1e-14, saveat = t)
+    sol = solve(tmp_prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14, saveat = t)
     A = convert(Array, sol)
     sum(((1 .- A) .^ 2) ./ 2)
 end
 
-@test ū0≈res rtol=1e-10
-@test ū02≈res rtol=1e-10
-@test ū022≈res rtol=1e-10
-@test ū023≈res rtol=1e-10
-@test ū03≈res rtol=1e-10
-@test ū032≈res rtol=1e-10
-@test ū04≈res rtol=1e-10
-@test ū042≈res rtol=1e-10
-@test ū05≈res rtol=1e-10
-@test ū052≈res rtol=1e-10
-@test ū06≈res rtol=1e-10
-@test ū062≈res rtol=1e-10
-@test ū06k≈res rtol=1e-10
-@test ū062k≈res rtol=1e-10
-@test adj≈adjnou0 rtol=1e-10
-@test adj≈adj2 rtol=1e-10
-@test adj≈adj22 rtol=1e-10
-@test adj≈adj23 rtol=1e-10
-@test adj≈adj3 rtol=1e-10
-@test adj≈adj32 rtol=1e-10
-@test adj≈adj4 rtol=1e-10
-@test adj≈adj42 rtol=1e-10
-@test adj≈adj5 rtol=1e-10
-@test adj≈adj52 rtol=1e-10
-@test adj≈adj53 rtol=1e-10
-@test adj≈adj6 rtol=1e-10
-@test adj≈adj62 rtol=1e-10
-@test adj≈adj63 rtol=1e-10
+@test ū0 ≈ res rtol = 1.0e-10
+@test ū02 ≈ res rtol = 1.0e-10
+@test ū022 ≈ res rtol = 1.0e-10
+@test ū023 ≈ res rtol = 1.0e-10
+@test ū03 ≈ res rtol = 1.0e-10
+@test ū032 ≈ res rtol = 1.0e-10
+@test ū04 ≈ res rtol = 1.0e-10
+@test ū042 ≈ res rtol = 1.0e-10
+@test ū05 ≈ res rtol = 1.0e-10
+@test ū052 ≈ res rtol = 1.0e-10
+@test ū06 ≈ res rtol = 1.0e-10
+@test ū062 ≈ res rtol = 1.0e-10
+@test ū06k ≈ res rtol = 1.0e-10
+@test ū062k ≈ res rtol = 1.0e-10
+@test adj ≈ adjnou0 rtol = 1.0e-10
+@test adj ≈ adj2 rtol = 1.0e-10
+@test adj ≈ adj22 rtol = 1.0e-10
+@test adj ≈ adj23 rtol = 1.0e-10
+@test adj ≈ adj3 rtol = 1.0e-10
+@test adj ≈ adj32 rtol = 1.0e-10
+@test adj ≈ adj4 rtol = 1.0e-10
+@test adj ≈ adj42 rtol = 1.0e-10
+@test adj ≈ adj5 rtol = 1.0e-10
+@test adj ≈ adj52 rtol = 1.0e-10
+@test adj ≈ adj53 rtol = 1.0e-10
+@test adj ≈ adj6 rtol = 1.0e-10
+@test adj ≈ adj62 rtol = 1.0e-10
+@test adj ≈ adj63 rtol = 1.0e-10
 
-@test adj≈adj6k rtol=1e-10
-@test adj≈adj62k rtol=1e-10
-@test adj≈adj63k rtol=1e-10
+@test adj ≈ adj6k rtol = 1.0e-10
+@test adj ≈ adj62k rtol = 1.0e-10
+@test adj ≈ adj63k rtol = 1.0e-10
 
-@test ū0args≈res rtol=1e-10
-@test adjargs≈adj rtol=1e-10
-@test ū0args2≈res rtol=1e-10
-@test adjargs2≈adj rtol=1e-10
+@test ū0args ≈ res rtol = 1.0e-10
+@test adjargs ≈ adj rtol = 1.0e-10
+@test ū0args2 ≈ res rtol = 1.0e-10
+@test adjargs2 ≈ adj rtol = 1.0e-10
 
 println("Do a continuous adjoint problem")
 
@@ -727,234 +945,320 @@ g(u, p, t) = (sum(u) .^ 2) ./ 2
 # Gradient of (u1 + u2)^2 / 2
 function dg(out, u, p, t)
     out[1] = u[1] + u[2]
-    out[2] = u[1] + u[2]
+    return out[2] = u[1] + u[2]
 end
 
-adj_prob = ODEAdjointProblem(sol,
-    QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14,
-        autojacvec = SciMLSensitivity.ReverseDiffVJP()),
+adj_prob = ODEAdjointProblem(
+    sol,
+    QuadratureAdjoint(
+        abstol = 1.0e-14, reltol = 1.0e-14,
+        autojacvec = SciMLSensitivity.ReverseDiffVJP()
+    ),
     Tsit5(),
-    nothing, nothing, nothing, dg, nothing, g)
-adj_sol = solve(adj_prob, Tsit5(), abstol = 1e-14, reltol = 1e-10)
-integrand = AdjointSensitivityIntegrand(sol, adj_sol,
-    QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14,
-        autojacvec = SciMLSensitivity.ReverseDiffVJP()))
-res, err = quadgk(integrand, 0.0, 10.0, atol = 1e-14, rtol = 1e-10)
+    nothing, nothing, nothing, dg, nothing, g
+)
+adj_sol = solve(adj_prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-10)
+integrand = AdjointSensitivityIntegrand(
+    sol, adj_sol,
+    QuadratureAdjoint(
+        abstol = 1.0e-14, reltol = 1.0e-14,
+        autojacvec = SciMLSensitivity.ReverseDiffVJP()
+    )
+)
+res, err = quadgk(integrand, 0.0, 10.0, atol = 1.0e-14, rtol = 1.0e-10)
 
 println("Test the `adjoint_sensitivities` utility function")
 _,
-easy_res = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14)
+    easy_res = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14
+)
 println("2")
 _,
-easy_res2 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint())
+    easy_res2 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint()
+)
 _,
-easy_res22 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = false))
+    easy_res22 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = false)
+)
 println("23")
 _,
-easy_res23 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(abstol = 1e-14,
-        reltol = 1e-14))
+    easy_res23 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        abstol = 1.0e-14,
+        reltol = 1.0e-14
+    )
+)
 _,
-easy_res232 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(abstol = 1e-14,
-        reltol = 1e-14,
-        autojacvec = ReverseDiffVJP(false)))
+    easy_res232 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        abstol = 1.0e-14,
+        reltol = 1.0e-14,
+        autojacvec = ReverseDiffVJP(false)
+    )
+)
 _,
-easy_res24 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(autojacvec = false,
-        abstol = 1e-14,
-        reltol = 1e-14))
+    easy_res24 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        autojacvec = false,
+        abstol = 1.0e-14,
+        reltol = 1.0e-14
+    )
+)
 println("25")
 _,
-easy_res25 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint())
+    easy_res25 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint()
+)
 _,
-easy_res26 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint(autojacvec = false))
+    easy_res26 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint(autojacvec = false)
+)
 _,
-easy_res262 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint(autojacvec = false,
-        checkpointing = false))
+    easy_res262 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint(
+        autojacvec = false,
+        checkpointing = false
+    )
+)
 println("27")
 _,
-easy_res27 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res27 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     checkpoints = sol.t[1:500:end],
-    sensealg = InterpolatingAdjoint(checkpointing = true))
+    sensealg = InterpolatingAdjoint(checkpointing = true)
+)
 _,
-easy_res28 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res28 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
     checkpoints = sol.t[1:500:end],
-    sensealg = InterpolatingAdjoint(checkpointing = true,
-        autojacvec = false))
+    sensealg = InterpolatingAdjoint(
+        checkpointing = true,
+        autojacvec = false
+    )
+)
 println("3")
 _,
-easy_res3 = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint())
+    easy_res3 = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint()
+)
 _,
-easy_res32 = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = InterpolatingAdjoint(autojacvec = false))
+    easy_res32 = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint(autojacvec = false)
+)
 println("33")
 _,
-easy_res33 = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(abstol = 1e-14,
-        reltol = 1e-14))
+    easy_res33 = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        abstol = 1.0e-14,
+        reltol = 1.0e-14
+    )
+)
 _,
-easy_res34 = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = QuadratureAdjoint(autojacvec = false,
-        abstol = 1e-14,
-        reltol = 1e-14))
+    easy_res34 = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint(
+        autojacvec = false,
+        abstol = 1.0e-14,
+        reltol = 1.0e-14
+    )
+)
 println("35")
 _,
-easy_res35 = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint())
+    easy_res35 = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint()
+)
 _,
-easy_res36 = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = BacksolveAdjoint(autojacvec = false))
+    easy_res36 = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint(autojacvec = false)
+)
 println("37")
 _,
-easy_res37 = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res37 = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
     checkpoints = sol.t[1:500:end],
-    sensealg = InterpolatingAdjoint(checkpointing = true))
+    sensealg = InterpolatingAdjoint(checkpointing = true)
+)
 _,
-easy_res38 = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
+    easy_res38 = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
     checkpoints = sol.t[1:500:end],
-    sensealg = InterpolatingAdjoint(checkpointing = true,
-        autojacvec = false))
+    sensealg = InterpolatingAdjoint(
+        checkpointing = true,
+        autojacvec = false
+    )
+)
 println("40")
 _,
-easy_res40 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint())
+    easy_res40 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint()
+)
 _,
-easy_res41 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint(autojacvec = ReverseDiffVJP(false)))
+    easy_res41 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint(autojacvec = ReverseDiffVJP(false))
+)
 _,
-easy_res42 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint(autojacvec = false))
+    easy_res42 = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint(autojacvec = false)
+)
 println("43")
 _,
-easy_res43 = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint())
+    easy_res43 = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint()
+)
 _,
-easy_res44 = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussAdjoint(autojacvec = false))
+    easy_res44 = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussAdjoint(autojacvec = false)
+)
 
 _,
-easy_res40k = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint())
+    easy_res40k = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint()
+)
 _,
-easy_res41k = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint(autojacvec = ReverseDiffVJP(false)))
+    easy_res41k = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint(autojacvec = ReverseDiffVJP(false))
+)
 _,
-easy_res42k = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
-    abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint(autojacvec = false))
+    easy_res42k = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dg, g = g,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint(autojacvec = false)
+)
 _,
-easy_res43k = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint())
+    easy_res43k = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint()
+)
 _,
-easy_res44k = adjoint_sensitivities(sol, Tsit5(), g = g, abstol = 1e-14,
-    reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint(autojacvec = false))
+    easy_res44k = adjoint_sensitivities(
+    sol, Tsit5(), g = g, abstol = 1.0e-14,
+    reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint(autojacvec = false)
+)
 
-@test norm(easy_res .- res) < 1e-8
-@test norm(easy_res2 .- res) < 1e-8
-@test norm(easy_res22 .- res) < 1e-8
-@test norm(easy_res23 .- res) < 1e-8
-@test norm(easy_res232 .- res) < 1e-8
-@test norm(easy_res24 .- res) < 1e-8
-@test norm(easy_res25 .- res) < 1e-8
-@test norm(easy_res26 .- res) < 1e-8
-@test norm(easy_res262 .- res) < 1e-8
-@test norm(easy_res27 .- res) < 1e-8
-@test norm(easy_res28 .- res) < 1e-8
-@test norm(easy_res3 .- res) < 1e-8
-@test norm(easy_res32 .- res) < 1e-8
-@test norm(easy_res33 .- res) < 1e-8
-@test norm(easy_res34 .- res) < 1e-8
-@test norm(easy_res35 .- res) < 1e-8
-@test norm(easy_res36 .- res) < 1e-8
-@test norm(easy_res37 .- res) < 1e-8
-@test norm(easy_res38 .- res) < 1e-8
-@test norm(easy_res40 .- res) < 1e-8
-@test norm(easy_res41 .- res) < 1e-8
-@test norm(easy_res42 .- res) < 1e-8
-@test norm(easy_res43 .- res) < 1e-8
-@test norm(easy_res44 .- res) < 1e-8
-@test norm(easy_res40k .- res) < 1e-8
-@test norm(easy_res41k .- res) < 1e-8
-@test norm(easy_res42k .- res) < 1e-8
-@test norm(easy_res43k .- res) < 1e-8
-@test norm(easy_res44k .- res) < 1e-8
+@test norm(easy_res .- res) < 1.0e-8
+@test norm(easy_res2 .- res) < 1.0e-8
+@test norm(easy_res22 .- res) < 1.0e-8
+@test norm(easy_res23 .- res) < 1.0e-8
+@test norm(easy_res232 .- res) < 1.0e-8
+@test norm(easy_res24 .- res) < 1.0e-8
+@test norm(easy_res25 .- res) < 1.0e-8
+@test norm(easy_res26 .- res) < 1.0e-8
+@test norm(easy_res262 .- res) < 1.0e-8
+@test norm(easy_res27 .- res) < 1.0e-8
+@test norm(easy_res28 .- res) < 1.0e-8
+@test norm(easy_res3 .- res) < 1.0e-8
+@test norm(easy_res32 .- res) < 1.0e-8
+@test norm(easy_res33 .- res) < 1.0e-8
+@test norm(easy_res34 .- res) < 1.0e-8
+@test norm(easy_res35 .- res) < 1.0e-8
+@test norm(easy_res36 .- res) < 1.0e-8
+@test norm(easy_res37 .- res) < 1.0e-8
+@test norm(easy_res38 .- res) < 1.0e-8
+@test norm(easy_res40 .- res) < 1.0e-8
+@test norm(easy_res41 .- res) < 1.0e-8
+@test norm(easy_res42 .- res) < 1.0e-8
+@test norm(easy_res43 .- res) < 1.0e-8
+@test norm(easy_res44 .- res) < 1.0e-8
+@test norm(easy_res40k .- res) < 1.0e-8
+@test norm(easy_res41k .- res) < 1.0e-8
+@test norm(easy_res42k .- res) < 1.0e-8
+@test norm(easy_res43k .- res) < 1.0e-8
+@test norm(easy_res44k .- res) < 1.0e-8
 
 println("Calculate adjoint sensitivities from autodiff & numerical diff")
 function G(p)
-    tmp_prob = remake(prob, u0 = eltype(p).(prob.u0), p = p,
-        tspan = eltype(p).(prob.tspan))
-    sol = solve(tmp_prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
-    res, err = quadgk((t) -> (sum(sol(t)) .^ 2) ./ 2, 0.0, 10.0, atol = 1e-14, rtol = 1e-10)
-    res
+    tmp_prob = remake(
+        prob, u0 = eltype(p).(prob.u0), p = p,
+        tspan = eltype(p).(prob.tspan)
+    )
+    sol = solve(tmp_prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
+    res, err = quadgk((t) -> (sum(sol(t)) .^ 2) ./ 2, 0.0, 10.0, atol = 1.0e-14, rtol = 1.0e-10)
+    return res
 end
 res2 = ForwardDiff.gradient(G, [1.5, 1.0, 3.0, 1.0])
 res3 = Calculus.gradient(G, [1.5, 1.0, 3.0, 1.0])
 
-@test norm(res' .- res2) < 1e-8
-@test norm(res' .- res3) < 1e-6
+@test norm(res' .- res2) < 1.0e-8
+@test norm(res' .- res3) < 1.0e-6
 
 # Buffer length test
 f = (du, u, p, t) -> du .= 0
 p = zeros(3);
 u = zeros(50);
 prob = ODEProblem(f, u, (0.0, 10.0), p)
-sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
+sol = solve(prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
 @test_nowarn _,
-res = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-14,
-    reltol = 1e-14)
+    res = adjoint_sensitivities(
+    sol, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-14,
+    reltol = 1.0e-14
+)
 
 @info "Checkpointed backsolve"
 using SciMLSensitivity, OrdinaryDiffEq
@@ -967,75 +1271,95 @@ function lorenz(du, u, p, t)
     return nothing
 end
 prob_lorenz = ODEProblem(lorenz, [1.0, 0.0, 0.0], (0, tf), [10, 28, 8 / 3])
-sol_lorenz = solve(prob_lorenz, Tsit5(), reltol = 1e-6, abstol = 1e-9)
+sol_lorenz = solve(prob_lorenz, Tsit5(), reltol = 1.0e-6, abstol = 1.0e-9)
 function dg(out, u, p, t, i)
-    (out .= -2.0 .+ u)
+    return (out .= -2.0 .+ u)
 end
 t = 0:0.1:tf
 _,
-easy_res1 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-6,
-    reltol = 1e-9,
-    sensealg = BacksolveAdjoint())
+    easy_res1 = adjoint_sensitivities(
+    sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-6,
+    reltol = 1.0e-9,
+    sensealg = BacksolveAdjoint()
+)
 _,
-easy_res2 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-6,
-    reltol = 1e-9,
-    sensealg = InterpolatingAdjoint())
+    easy_res2 = adjoint_sensitivities(
+    sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-6,
+    reltol = 1.0e-9,
+    sensealg = InterpolatingAdjoint()
+)
 _,
-easy_res3 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-6,
-    reltol = 1e-9,
+    easy_res3 = adjoint_sensitivities(
+    sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-6,
+    reltol = 1.0e-9,
     sensealg = BacksolveAdjoint(),
-    checkpoints = sol_lorenz.t[1:10:end])
+    checkpoints = sol_lorenz.t[1:10:end]
+)
 _,
-easy_res4 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-6,
-    reltol = 1e-9,
+    easy_res4 = adjoint_sensitivities(
+    sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-6,
+    reltol = 1.0e-9,
     sensealg = BacksolveAdjoint(),
-    checkpoints = sol_lorenz.t[1:20:end])
+    checkpoints = sol_lorenz.t[1:20:end]
+)
 # cannot finish in a reasonable amount of time
-@test_skip adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-6,
-    reltol = 1e-9,
-    sensealg = BacksolveAdjoint(checkpointing = false))
-@test easy_res2≈easy_res1 rtol=1e-5
-@test easy_res2≈easy_res3 rtol=1e-5
-@test easy_res2≈easy_res4 rtol=1e-4
+@test_skip adjoint_sensitivities(
+    sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-6,
+    reltol = 1.0e-9,
+    sensealg = BacksolveAdjoint(checkpointing = false)
+)
+@test easy_res2 ≈ easy_res1 rtol = 1.0e-5
+@test easy_res2 ≈ easy_res3 rtol = 1.0e-5
+@test easy_res2 ≈ easy_res4 rtol = 1.0e-4
 
 ū1,
-adj1 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-6,
-    reltol = 1e-9,
-    sensealg = BacksolveAdjoint())
+    adj1 = adjoint_sensitivities(
+    sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-6,
+    reltol = 1.0e-9,
+    sensealg = BacksolveAdjoint()
+)
 ū2,
-adj2 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-6,
-    reltol = 1e-9,
-    sensealg = InterpolatingAdjoint())
+    adj2 = adjoint_sensitivities(
+    sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-6,
+    reltol = 1.0e-9,
+    sensealg = InterpolatingAdjoint()
+)
 ū3,
-adj3 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-6,
-    reltol = 1e-9,
+    adj3 = adjoint_sensitivities(
+    sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-6,
+    reltol = 1.0e-9,
     sensealg = BacksolveAdjoint(),
-    checkpoints = sol_lorenz.t[1:10:end])
+    checkpoints = sol_lorenz.t[1:10:end]
+)
 ū4,
-adj4 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-6,
-    reltol = 1e-9,
+    adj4 = adjoint_sensitivities(
+    sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-6,
+    reltol = 1.0e-9,
     sensealg = BacksolveAdjoint(),
-    checkpoints = sol_lorenz.t[1:20:end])
+    checkpoints = sol_lorenz.t[1:20:end]
+)
 # cannot finish in a reasonable amount of time
-@test_skip adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
-    abstol = 1e-6,
-    reltol = 1e-9,
-    sensealg = BacksolveAdjoint(checkpointing = false))
-@test ū2≈ū1 rtol=1e-5
-@test adj2≈adj1 rtol=1e-5
-@test ū2≈ū3 rtol=1e-5
-@test adj2≈adj3 rtol=1e-5
-@test ū2≈ū4 rtol=1e-4
-@test adj2≈adj4 rtol=1e-4
+@test_skip adjoint_sensitivities(
+    sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
+    abstol = 1.0e-6,
+    reltol = 1.0e-9,
+    sensealg = BacksolveAdjoint(checkpointing = false)
+)
+@test ū2 ≈ ū1 rtol = 1.0e-5
+@test adj2 ≈ adj1 rtol = 1.0e-5
+@test ū2 ≈ ū3 rtol = 1.0e-5
+@test adj2 ≈ adj3 rtol = 1.0e-5
+@test ū2 ≈ ū4 rtol = 1.0e-4
+@test adj2 ≈ adj4 rtol = 1.0e-4
 
 # LQR Tests from issue https://github.com/SciML/SciMLSensitivity.jl/issues/300
 x_dim = 2
@@ -1046,32 +1370,39 @@ params = [-0.4142135623730951, 0.0, -0.0, -0.4142135623730951, 0.0, 0.0]
 
 function dynamics!(du, u, p, t)
     du[1] = -u[1] + tanh(p[1] * u[1] + p[2] * u[2])
-    du[2] = -u[2] + tanh(p[3] * u[1] + p[4] * u[2])
+    return du[2] = -u[2] + tanh(p[3] * u[1] + p[4] * u[2])
 end
 
 function backsolve_grad(sol, lqr_params, checkpointing)
     bwd_sol = solve(
-        ODEAdjointProblem(sol,
-            BacksolveAdjoint(autojacvec = EnzymeVJP(),
-                checkpointing = checkpointing),
+        ODEAdjointProblem(
+            sol,
+            BacksolveAdjoint(
+                autojacvec = EnzymeVJP(),
+                checkpointing = checkpointing
+            ),
             Tsit5(),
             nothing, nothing, nothing, nothing, nothing,
-            (x, lqr_params, t) -> cost(x, lqr_params)),
+            (x, lqr_params, t) -> cost(x, lqr_params)
+        ),
         Tsit5(),
         dense = false,
-        save_everystep = false)
+        save_everystep = false
+    )
 
-    bwd_sol.u[end][1:(end - x_dim)]
+    return bwd_sol.u[end][1:(end - x_dim)]
     #fwd_sol, bwd_sol
 end
 
 x0 = ones(x_dim)
-fwd_sol = solve(ODEProblem(dynamics!, x0, (0, T), params),
-    Tsit5(), abstol = 1e-9, reltol = 1e-9,
+fwd_sol = solve(
+    ODEProblem(dynamics!, x0, (0, T), params),
+    Tsit5(), abstol = 1.0e-9, reltol = 1.0e-9,
     u0 = x0,
     p = params,
     dense = false,
-    save_everystep = true)
+    save_everystep = true
+)
 
 backsolve_results = backsolve_grad(fwd_sol, params, false)
 backsolve_checkpointing_results = backsolve_grad(fwd_sol, params, true)
@@ -1079,22 +1410,28 @@ backsolve_checkpointing_results = backsolve_grad(fwd_sol, params, true)
 @test backsolve_results != backsolve_checkpointing_results
 
 int_u0,
-int_p = adjoint_sensitivities(fwd_sol, Tsit5(),
+    int_p = adjoint_sensitivities(
+    fwd_sol, Tsit5(),
     g = (x, params, t) -> cost(x, params),
-    sensealg = InterpolatingAdjoint())
+    sensealg = InterpolatingAdjoint()
+)
 
-@test isapprox(backsolve_checkpointing_results[1:length(x0)], int_u0, rtol = 1e-10)
-@test isapprox(backsolve_checkpointing_results[(1:length(params)) .+ length(x0)],
-    int_p', rtol = 1e-10)
+@test isapprox(backsolve_checkpointing_results[1:length(x0)], int_u0, rtol = 1.0e-10)
+@test isapprox(
+    backsolve_checkpointing_results[(1:length(params)) .+ length(x0)],
+    int_p', rtol = 1.0e-10
+)
 
 @info "Mass matrix tests"
 using Test
 using LinearAlgebra, SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, QuadGK
 function G(p, prob, ts, cost)
     tmp_prob_mm = remake(prob, u0 = convert.(eltype(p), prob.u0), p = p)
-    sol = solve(tmp_prob_mm, Rodas4(autodiff = false), abstol = 1e-14, reltol = 1e-14,
-        saveat = ts)
-    cost(sol)
+    sol = solve(
+        tmp_prob_mm, Rodas4(autodiff = false), abstol = 1.0e-14, reltol = 1.0e-14,
+        saveat = ts
+    )
+    return cost(sol)
 end
 alg = Rodas4(autodiff = false)
 @info "discrete cost"
@@ -1109,87 +1446,113 @@ mm = -[1 2 4; 2 3 7; 1 3 41]
 u0 = [1, 2.0, 3]
 p = [1.0, 2.0, 3]
 prob_mm = ODEProblem(ODEFunction(foo, mass_matrix = mm), u0, (0, 1.0), p)
-sol_mm = solve(prob_mm, Rodas4(), reltol = 1e-14, abstol = 1e-14)
+sol_mm = solve(prob_mm, Rodas4(), reltol = 1.0e-14, abstol = 1.0e-14)
 
 ts = 0:0.01:1
 dg(out, u, p, t, i) = out .= 1
 _,
-res = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
-    abstol = 1e-14, reltol = 1e-14,
-    sensealg = QuadratureAdjoint())
+    res = adjoint_sensitivities(
+    sol_mm, alg, t = ts, dgdu_discrete = dg,
+    abstol = 1.0e-14, reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint()
+)
 reference_sol = ForwardDiff.gradient(p -> G(p, prob_mm, ts, sum), vec(p))
-@test res'≈reference_sol rtol=1e-11
+@test res' ≈ reference_sol rtol = 1.0e-11
 
 _,
-res_gauss = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
-    abstol = 1e-14, reltol = 1e-14,
-    sensealg = GaussAdjoint())
-@test res_gauss≈res rtol=1e-11
+    res_gauss = adjoint_sensitivities(
+    sol_mm, alg, t = ts, dgdu_discrete = dg,
+    abstol = 1.0e-14, reltol = 1.0e-14,
+    sensealg = GaussAdjoint()
+)
+@test res_gauss ≈ res rtol = 1.0e-11
 
 _,
-res_gausskron = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
-    abstol = 1e-14, reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint())
-@test res_gausskron≈res rtol=1e-11
+    res_gausskron = adjoint_sensitivities(
+    sol_mm, alg, t = ts, dgdu_discrete = dg,
+    abstol = 1.0e-14, reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint()
+)
+@test res_gausskron ≈ res rtol = 1.0e-11
 
 _,
-res_interp = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
-    abstol = 1e-14, reltol = 1e-14,
-    sensealg = InterpolatingAdjoint())
-@test res_interp≈res rtol=1e-11
+    res_interp = adjoint_sensitivities(
+    sol_mm, alg, t = ts, dgdu_discrete = dg,
+    abstol = 1.0e-14, reltol = 1.0e-14,
+    sensealg = InterpolatingAdjoint()
+)
+@test res_interp ≈ res rtol = 1.0e-11
 _,
-res_interp2 = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
-    abstol = 1e-14, reltol = 1e-14,
+    res_interp2 = adjoint_sensitivities(
+    sol_mm, alg, t = ts, dgdu_discrete = dg,
+    abstol = 1.0e-14, reltol = 1.0e-14,
     sensealg = InterpolatingAdjoint(checkpointing = true),
-    checkpoints = sol_mm.t[1:10:end])
-@test res_interp2≈res rtol=1e-11
+    checkpoints = sol_mm.t[1:10:end]
+)
+@test res_interp2 ≈ res rtol = 1.0e-11
 
 _,
-res_bs = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
-    abstol = 1e-14, reltol = 1e-14,
-    sensealg = BacksolveAdjoint(checkpointing = false))
-@test res_bs≈res rtol=1e-11
+    res_bs = adjoint_sensitivities(
+    sol_mm, alg, t = ts, dgdu_discrete = dg,
+    abstol = 1.0e-14, reltol = 1.0e-14,
+    sensealg = BacksolveAdjoint(checkpointing = false)
+)
+@test res_bs ≈ res rtol = 1.0e-11
 _,
-res_bs2 = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
-    abstol = 1e-14, reltol = 1e-14,
+    res_bs2 = adjoint_sensitivities(
+    sol_mm, alg, t = ts, dgdu_discrete = dg,
+    abstol = 1.0e-14, reltol = 1.0e-14,
     sensealg = BacksolveAdjoint(checkpointing = true),
-    checkpoints = sol_mm.t)
-@test res_bs2≈res rtol=1e-11
+    checkpoints = sol_mm.t
+)
+@test res_bs2 ≈ res rtol = 1.0e-11
 
 @info "continuous cost"
 g_cont(u, p, t) = (sum(u) .^ 2) ./ 2
 dg_cont(out, u, p, t) = out .= sum(u)
 _,
-easy_res_cont = adjoint_sensitivities(sol_mm, alg, dgdu_continuous = dg_cont,
+    easy_res_cont = adjoint_sensitivities(
+    sol_mm, alg, dgdu_continuous = dg_cont,
     g = g_cont,
-    abstol = 1e-14, reltol = 1e-14,
-    sensealg = QuadratureAdjoint())
+    abstol = 1.0e-14, reltol = 1.0e-14,
+    sensealg = QuadratureAdjoint()
+)
 
 _,
-easy_res_cont_gauss = adjoint_sensitivities(sol_mm, alg, dgdu_continuous = dg_cont,
+    easy_res_cont_gauss = adjoint_sensitivities(
+    sol_mm, alg, dgdu_continuous = dg_cont,
     g = g_cont,
-    abstol = 1e-14, reltol = 1e-14,
-    sensealg = GaussAdjoint())
+    abstol = 1.0e-14, reltol = 1.0e-14,
+    sensealg = GaussAdjoint()
+)
 _,
-easy_res_cont_gauss_kron = adjoint_sensitivities(sol_mm, alg, dgdu_continuous = dg_cont,
+    easy_res_cont_gauss_kron = adjoint_sensitivities(
+    sol_mm, alg, dgdu_continuous = dg_cont,
     g = g_cont,
-    abstol = 1e-14, reltol = 1e-14,
-    sensealg = GaussKronrodAdjoint())
+    abstol = 1.0e-14, reltol = 1.0e-14,
+    sensealg = GaussKronrodAdjoint()
+)
 
 function G_cont(p)
-    tmp_prob_mm = remake(prob_mm, u0 = eltype(p).(prob_mm.u0), p = p,
-        tspan = eltype(p).(prob_mm.tspan))
-    sol = solve(tmp_prob_mm, Rodas4(autodiff = false), abstol = 1e-14,
-        reltol = 1e-14)
+    tmp_prob_mm = remake(
+        prob_mm, u0 = eltype(p).(prob_mm.u0), p = p,
+        tspan = eltype(p).(prob_mm.tspan)
+    )
+    sol = solve(
+        tmp_prob_mm, Rodas4(autodiff = false), abstol = 1.0e-14,
+        reltol = 1.0e-14
+    )
     res,
-    err = quadgk((t) -> (sum(sol(t)) .^ 2) ./ 2, prob_mm.tspan...,
-        atol = 1e-14, rtol = 1e-10)
-    res
+        err = quadgk(
+        (t) -> (sum(sol(t)) .^ 2) ./ 2, prob_mm.tspan...,
+        atol = 1.0e-14, rtol = 1.0e-10
+    )
+    return res
 end
 reference_sol_cont = ForwardDiff.gradient(G_cont, p)
-@test easy_res_cont'≈reference_sol_cont rtol=1e-11
-@test easy_res_cont_gauss'≈reference_sol_cont rtol=1e-11
-@test easy_res_cont_gauss_kron'≈reference_sol_cont rtol=1e-11
+@test easy_res_cont' ≈ reference_sol_cont rtol = 1.0e-11
+@test easy_res_cont_gauss' ≈ reference_sol_cont rtol = 1.0e-11
+@test easy_res_cont_gauss_kron' ≈ reference_sol_cont rtol = 1.0e-11
 
 @info "Singular mass matrix"
 function rober(du, u, p, t)
@@ -1198,150 +1561,195 @@ function rober(du, u, p, t)
     du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
     du[2] = k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃
     du[3] = y₁ + y₂ + y₃ - 1
-    nothing
+    return nothing
 end
 function rober(u, p, t)
     y₁, y₂, y₃ = u
     k₁, k₂, k₃ = p
-    return [-k₁ * y₁ + k₃ * y₂ * y₃,
+    return [
+        -k₁ * y₁ + k₃ * y₂ * y₃,
         k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃,
-        y₁ + y₂ + y₃ - 1]
+        y₁ + y₂ + y₃ - 1,
+    ]
 end
-M = [1.0 0 0
-     0 1.0 0
-     0 0 0]
+M = [
+    1.0 0 0
+    0 1.0 0
+    0 0 0
+]
 for iip in [true, false]
     f = ODEFunction{iip}(rober, mass_matrix = M)
-    p = [0.04, 3e7, 1e4]
+    p = [0.04, 3.0e7, 1.0e4]
 
     prob_singular_mm = ODEProblem(f, [1.0, 0.0, 1.0], (0.0, 100), p)
-    sol_singular_mm = solve(prob_singular_mm, FBDF(autodiff = false),
-        reltol = 1e-12, abstol = 1e-12, initializealg = BrownFullBasicInit())
+    sol_singular_mm = solve(
+        prob_singular_mm, FBDF(autodiff = false),
+        reltol = 1.0e-12, abstol = 1.0e-12, initializealg = BrownFullBasicInit()
+    )
     ts = [50, sol_singular_mm.t[end]]
     dg_singular(out, u, p, t, i) = (fill!(out, 0); out[end] = 1)
     _,
-    res = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-        dgdu_discrete = dg_singular, abstol = 1e-8,
-        reltol = 1e-8, sensealg = QuadratureAdjoint(),
-        maxiters = Int(1e6))
+        res = adjoint_sensitivities(
+        sol_singular_mm, alg, t = ts,
+        dgdu_discrete = dg_singular, abstol = 1.0e-8,
+        reltol = 1.0e-8, sensealg = QuadratureAdjoint(),
+        maxiters = Int(1.0e6)
+    )
     reference_sol = ForwardDiff.gradient(
-        p -> G(p, prob_singular_mm, ts,
-            sol -> sum(last, sol.u)), vec(p))
-    @test res'≈reference_sol rtol=1e-5
+        p -> G(
+            p, prob_singular_mm, ts,
+            sol -> sum(last, sol.u)
+        ), vec(p)
+    )
+    @test res' ≈ reference_sol rtol = 1.0e-5
 
     _,
-    res_gauss = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-        dgdu_discrete = dg_singular, abstol = 1e-8,
-        reltol = 1e-8, sensealg = GaussAdjoint(),
-        maxiters = Int(1e6))
-    @test res_gauss≈res rtol=1e-5
+        res_gauss = adjoint_sensitivities(
+        sol_singular_mm, alg, t = ts,
+        dgdu_discrete = dg_singular, abstol = 1.0e-8,
+        reltol = 1.0e-8, sensealg = GaussAdjoint(),
+        maxiters = Int(1.0e6)
+    )
+    @test res_gauss ≈ res rtol = 1.0e-5
 
     _,
-    res_gausskron = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-        dgdu_discrete = dg_singular, abstol = 1e-8,
-        reltol = 1e-8, sensealg = GaussKronrodAdjoint(),
-        maxiters = Int(1e6))
-    @test res_gausskron≈res rtol=1e-5
+        res_gausskron = adjoint_sensitivities(
+        sol_singular_mm, alg, t = ts,
+        dgdu_discrete = dg_singular, abstol = 1.0e-8,
+        reltol = 1.0e-8, sensealg = GaussKronrodAdjoint(),
+        maxiters = Int(1.0e6)
+    )
+    @test res_gausskron ≈ res rtol = 1.0e-5
 
     _,
-    res_interp = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
+        res_interp = adjoint_sensitivities(
+        sol_singular_mm, alg, t = ts,
         dgdu_discrete = dg_singular,
-        abstol = 1e-8,
-        reltol = 1e-8,
+        abstol = 1.0e-8,
+        reltol = 1.0e-8,
         sensealg = InterpolatingAdjoint(),
-        maxiters = Int(1e6))
-    @test res_interp≈res rtol=1e-5
+        maxiters = Int(1.0e6)
+    )
+    @test res_interp ≈ res rtol = 1.0e-5
     _,
-    res_interp2 = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
+        res_interp2 = adjoint_sensitivities(
+        sol_singular_mm, alg, t = ts,
         dgdu_discrete = dg_singular,
-        abstol = 1e-8,
-        reltol = 1e-8,
+        abstol = 1.0e-8,
+        reltol = 1.0e-8,
         sensealg = InterpolatingAdjoint(checkpointing = true),
-        checkpoints = sol_singular_mm.t[1:10:end])
-    @test res_interp2≈res rtol=1e-5
+        checkpoints = sol_singular_mm.t[1:10:end]
+    )
+    @test res_interp2 ≈ res rtol = 1.0e-5
 
     # backsolve doesn't work
     _,
-    res_bs = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-        dgdu_discrete = dg_singular, abstol = 1e-8,
-        reltol = 1e-8,
-        sensealg = BacksolveAdjoint(checkpointing = false))
-    @test_broken res_bs≈res rtol=1e-5
+        res_bs = adjoint_sensitivities(
+        sol_singular_mm, alg, t = ts,
+        dgdu_discrete = dg_singular, abstol = 1.0e-8,
+        reltol = 1.0e-8,
+        sensealg = BacksolveAdjoint(checkpointing = false)
+    )
+    @test_broken res_bs ≈ res rtol = 1.0e-5
     _,
-    res_bs2 = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-        dgdu_discrete = dg_singular, abstol = 1e-8,
-        reltol = 1e-8,
+        res_bs2 = adjoint_sensitivities(
+        sol_singular_mm, alg, t = ts,
+        dgdu_discrete = dg_singular, abstol = 1.0e-8,
+        reltol = 1.0e-8,
         sensealg = BacksolveAdjoint(checkpointing = true),
-        checkpoints = sol_singular_mm.t)
-    @test_broken res_bs2≈res rtol=1e-5
+        checkpoints = sol_singular_mm.t
+    )
+    @test_broken res_bs2 ≈ res rtol = 1.0e-5
 end
 
 # u' = x = p * u
 function simple_linear_dae(du, u, p, t)
     du[1] = u[2]
-    du[2] = u[2] - p[1] * u[1]
+    return du[2] = u[2] - p[1] * u[1]
 end
 p = [0.5]
 prob_singular_mm = ODEProblem(
-    ODEFunction(simple_linear_dae,
-        mass_matrix = Diagonal([1, 0])),
-    [2.2, 1.1], (0.0, 1.5), p)
-sol_singular_mm = solve(prob_singular_mm, Rodas4(autodiff = false),
-    reltol = 1e-14, abstol = 1e-14)
+    ODEFunction(
+        simple_linear_dae,
+        mass_matrix = Diagonal([1, 0])
+    ),
+    [2.2, 1.1], (0.0, 1.5), p
+)
+sol_singular_mm = solve(
+    prob_singular_mm, Rodas4(autodiff = false),
+    reltol = 1.0e-14, abstol = 1.0e-14
+)
 ts = [0.01, 0.25, 0.5, 1.0, 1.5]
 dg_singular(out, u, p, t, i) = fill!(out, 1)
 reference_sol = ForwardDiff.gradient(
-    p -> G(p, prob_singular_mm, ts,
-        sol -> sum(sum, sol.u)), vec(p))
+    p -> G(
+        p, prob_singular_mm, ts,
+        sol -> sum(sum, sol.u)
+    ), vec(p)
+)
 for salg in [
-    QuadratureAdjoint(),
-    InterpolatingAdjoint(),
-    BacksolveAdjoint(),
-    GaussAdjoint(),
-    GaussKronrodAdjoint()
-]
+        QuadratureAdjoint(),
+        InterpolatingAdjoint(),
+        BacksolveAdjoint(),
+        GaussAdjoint(),
+        GaussKronrodAdjoint(),
+    ]
     _,
-    res = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-        dgdu_discrete = dg_singular, abstol = 1e-14,
-        reltol = 1e-14, sensealg = salg,
-        maxiters = Int(1e6))
-    @test res'≈reference_sol rtol=1e-5
+        res = adjoint_sensitivities(
+        sol_singular_mm, alg, t = ts,
+        dgdu_discrete = dg_singular, abstol = 1.0e-14,
+        reltol = 1.0e-14, sensealg = salg,
+        maxiters = Int(1.0e6)
+    )
+    @test res' ≈ reference_sol rtol = 1.0e-5
 end
 
 # u' = x = p * u^2
 function simple_nonlinear_dae(du, u, p, t)
     du[1] = u[2]
-    du[2] = u[2] - p[1] * u[1]^2
+    return du[2] = u[2] - p[1] * u[1]^2
 end
 p = [0.5]
 prob_singular_mm = ODEProblem(
-    ODEFunction(simple_nonlinear_dae,
-        mass_matrix = Diagonal([1, 0])),
-    [1.0, 1.0], (0.0, 1), p)
-sol_singular_mm = solve(prob_singular_mm, Rodas4(autodiff = false),
-    reltol = 1e-12, abstol = 1e-12)
+    ODEFunction(
+        simple_nonlinear_dae,
+        mass_matrix = Diagonal([1, 0])
+    ),
+    [1.0, 1.0], (0.0, 1), p
+)
+sol_singular_mm = solve(
+    prob_singular_mm, Rodas4(autodiff = false),
+    reltol = 1.0e-12, abstol = 1.0e-12
+)
 ts = [0.5, 1.0]
 _,
-res = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-    dgdu_discrete = dg_singular, abstol = 1e-8,
-    reltol = 1e-8, sensealg = QuadratureAdjoint(),
-    maxiters = Int(1e6))
+    res = adjoint_sensitivities(
+    sol_singular_mm, alg, t = ts,
+    dgdu_discrete = dg_singular, abstol = 1.0e-8,
+    reltol = 1.0e-8, sensealg = QuadratureAdjoint(),
+    maxiters = Int(1.0e6)
+)
 reference_sol = ForwardDiff.gradient(
-    p -> G(p, prob_singular_mm, ts,
-        sol -> sum(sum, sol.u)), vec(p))
+    p -> G(
+        p, prob_singular_mm, ts,
+        sol -> sum(sum, sol.u)
+    ), vec(p)
+)
 for salg in [
-    QuadratureAdjoint(),
-    InterpolatingAdjoint(),
-    BacksolveAdjoint(),
-    GaussAdjoint(),
-    GaussKronrodAdjoint()
-]
+        QuadratureAdjoint(),
+        InterpolatingAdjoint(),
+        BacksolveAdjoint(),
+        GaussAdjoint(),
+        GaussKronrodAdjoint(),
+    ]
     _,
-    res = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-        dgdu_discrete = dg_singular, abstol = 1e-14,
-        reltol = 1e-14, sensealg = salg,
-        maxiters = Int(1e6))
-    @test res'≈reference_sol rtol=1e-7
+        res = adjoint_sensitivities(
+        sol_singular_mm, alg, t = ts,
+        dgdu_discrete = dg_singular, abstol = 1.0e-14,
+        reltol = 1.0e-14, sensealg = salg,
+        maxiters = Int(1.0e6)
+    )
+    @test res' ≈ reference_sol rtol = 1.0e-7
 end
 
 function pend(du, u, p, t)
@@ -1351,7 +1759,7 @@ function pend(du, u, p, t)
     du[2] = T * x
     du[3] = dy
     du[4] = T * y - g
-    du[5] = 2 * (dx^2 + dy^2 + y * (y * T - g) + T * x^2)
+    return du[5] = 2 * (dx^2 + dy^2 + y * (y * T - g) + T * x^2)
 end
 
 x0 = [1.0, 0, 0, 0, 0]
@@ -1359,34 +1767,45 @@ tspan = (0.0, 1.0)
 p = [9.8]
 f_singular_mm = ODEFunction{true}(pend, mass_matrix = Diagonal([1, 1, 1, 1, 0]))
 prob_singular_mm = ODEProblem{true}(f_singular_mm, x0, tspan, p)
-sol_singular_mm = solve(prob_singular_mm, Rodas5P(),
-    reltol = 1e-12, abstol = 1e-12)
+sol_singular_mm = solve(
+    prob_singular_mm, Rodas5P(),
+    reltol = 1.0e-12, abstol = 1.0e-12
+)
 ts = 0:0.1:1.0
 dg_singular(out, u, p, t, i) = (fill!(out, 0); out[end] = 1)
 _,
-res = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-    dgdu_discrete = dg_singular, abstol = 1e-8,
-    reltol = 1e-8, sensealg = QuadratureAdjoint(),
-    maxiters = Int(1e6))
+    res = adjoint_sensitivities(
+    sol_singular_mm, alg, t = ts,
+    dgdu_discrete = dg_singular, abstol = 1.0e-8,
+    reltol = 1.0e-8, sensealg = QuadratureAdjoint(),
+    maxiters = Int(1.0e6)
+)
 reference_sol = ForwardDiff.gradient(
-    p -> G(p, prob_singular_mm, ts,
-        sol -> sum(last, sol.u)), vec(p))
-@test res'≈reference_sol rtol=1e-6
+    p -> G(
+        p, prob_singular_mm, ts,
+        sol -> sum(last, sol.u)
+    ), vec(p)
+)
+@test res' ≈ reference_sol rtol = 1.0e-6
 
 for salg in [
-    QuadratureAdjoint(),
-    InterpolatingAdjoint(),
-    BacksolveAdjoint(),
-    GaussAdjoint(),
-    GaussKronrodAdjoint()
-]
-    sol_singular_mm = solve(prob_singular_mm, Rodas5P(),
-        reltol = 1e-12, abstol = 1e-12)
+        QuadratureAdjoint(),
+        InterpolatingAdjoint(),
+        BacksolveAdjoint(),
+        GaussAdjoint(),
+        GaussKronrodAdjoint(),
+    ]
+    sol_singular_mm = solve(
+        prob_singular_mm, Rodas5P(),
+        reltol = 1.0e-12, abstol = 1.0e-12
+    )
     _,
-    res = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-        dgdu_discrete = dg_singular, abstol = 1e-8,
-        reltol = 1e-8, sensealg = salg,
-        maxiters = Int(1e6))
+        res = adjoint_sensitivities(
+        sol_singular_mm, alg, t = ts,
+        dgdu_discrete = dg_singular, abstol = 1.0e-8,
+        reltol = 1.0e-8, sensealg = salg,
+        maxiters = Int(1.0e6)
+    )
     @show salg
-    @test res'≈reference_sol rtol=1e-6
+    @test res' ≈ reference_sol rtol = 1.0e-6
 end

--- a/test/adjoint_oop.jl
+++ b/test/adjoint_oop.jl
@@ -8,7 +8,7 @@ p = @SVector rand(4)
 function lotka(u, p, svec = true)
     du1 = p[1] * u[1] - p[2] * u[1] * u[2]
     du2 = -p[3] * u[2] + p[4] * u[1] * u[2]
-    if svec
+    return if svec
         @SVector [du1, du2]
     else
         @SMatrix [du1 du2 du1; du2 du1 du1]
@@ -18,24 +18,24 @@ end
 #SVector constructor adjoint
 function loss(p)
     u = lotka(u0, p)
-    sum(1 .- u)
+    return sum(1 .- u)
 end
 
 grad = Zygote.gradient(loss, p)
 @test grad[1] isa SArray
 grad2 = ForwardDiff.gradient(loss, p)
-@test grad[1]≈grad2 rtol=1e-12
+@test grad[1] ≈ grad2 rtol = 1.0e-12
 
 #SMatrix constructor adjoint
 function loss_mat(p)
     u = lotka(u0, p, false)
-    sum(1 .- u)
+    return sum(1 .- u)
 end
 
 grad = Zygote.gradient(loss_mat, p)
 @test grad[1] isa SArray
 grad2 = ForwardDiff.gradient(loss_mat, p)
-@test grad[1]≈grad2 rtol=1e-12
+@test grad[1] ≈ grad2 rtol = 1.0e-12
 
 ##Adjoints of StaticArrays ODE
 
@@ -48,32 +48,38 @@ tsteps = range(tspan[1], tspan[2], length = datasize)
 function lotka(u, p, t)
     du1 = p[1] * u[1] - p[2] * u[1] * u[2]
     du2 = -p[3] * u[2] + p[4] * u[1] * u[2]
-    @SVector [du1, du2]
+    return @SVector [du1, du2]
 end
 
 prob = ODEProblem(lotka, u0, tspan, p)
-sol = solve(prob, Tsit5(), saveat = tsteps, abstol = 1e-14, reltol = 1e-14)
+sol = solve(prob, Tsit5(), saveat = tsteps, abstol = 1.0e-14, reltol = 1.0e-14)
 
 ## Discrete Case
 dg_disc(u, p, t, i; outtype = nothing) = u
 
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(); t = tsteps, dgdu_discrete = dg_disc,
-    sensealg = QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14, autojacvec = ZygoteVJP()))
+    dp = adjoint_sensitivities(
+    sol, Tsit5(); t = tsteps, dgdu_discrete = dg_disc,
+    sensealg = QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = ZygoteVJP())
+)
 
 @test !iszero(du0)
 @test !iszero(dp)
 #
-adj_prob = ODEAdjointProblem(sol,
-    QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14, autojacvec = ZygoteVJP()),
-    Tsit5(), tsteps, dg_disc)
-adj_sol = solve(adj_prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
-integrand = AdjointSensitivityIntegrand(sol, adj_sol,
-    QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14, autojacvec = ZygoteVJP()))
-res, err = quadgk(integrand, 0.0, 5.0, atol = 1e-14, rtol = 1e-14)
+adj_prob = ODEAdjointProblem(
+    sol,
+    QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = ZygoteVJP()),
+    Tsit5(), tsteps, dg_disc
+)
+adj_sol = solve(adj_prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
+integrand = AdjointSensitivityIntegrand(
+    sol, adj_sol,
+    QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = ZygoteVJP())
+)
+res, err = quadgk(integrand, 0.0, 5.0, atol = 1.0e-14, rtol = 1.0e-14)
 
-@test adj_sol.u[end]≈du0 rtol=1e-12
-@test res≈dp rtol=1e-12
+@test adj_sol.u[end] ≈ du0 rtol = 1.0e-12
+@test res ≈ dp rtol = 1.0e-12
 
 ###Comparing with gradients of lotka volterra with normal arrays
 u2 = [1.0, 1.0]
@@ -82,40 +88,50 @@ p2 = [1.5, 1.0, 3.0, 1.0]
 function f(u, p, t)
     du1 = p[1] * u[1] - p[2] * u[1] * u[2]
     du2 = -p[3] * u[2] + p[4] * u[1] * u[2]
-    [du1, du2]
+    return [du1, du2]
 end
 
 prob2 = ODEProblem(f, u2, tspan, p2)
-sol2 = solve(prob, Tsit5(), saveat = tsteps, abstol = 1e-14, reltol = 1e-14)
+sol2 = solve(prob, Tsit5(), saveat = tsteps, abstol = 1.0e-14, reltol = 1.0e-14)
 
 function dg_disc(du, u, p, t, i)
-    du .= u
+    return du .= u
 end
 
 du1,
-dp1 = adjoint_sensitivities(sol, Tsit5(); t = tsteps, dgdu_discrete = dg_disc,
-    sensealg = QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14, autojacvec = ZygoteVJP()))
+    dp1 = adjoint_sensitivities(
+    sol, Tsit5(); t = tsteps, dgdu_discrete = dg_disc,
+    sensealg = QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = ZygoteVJP())
+)
 
-@test du0≈du1 rtol=1e-12
-@test dp≈dp1 rtol=1e-12
+@test du0 ≈ du1 rtol = 1.0e-12
+@test dp ≈ dp1 rtol = 1.0e-12
 
 ## with ForwardDiff and Zygote
 
 function G_p(p)
     tmp_prob = remake(prob, u0 = convert.(eltype(p), prob.u0), p = p)
-    sol = solve(tmp_prob, Tsit5(), abstol = 1e-14, reltol = 1e-14,
-        sensealg = QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14,
-            autojacvec = ZygoteVJP()), saveat = tsteps)
+    sol = solve(
+        tmp_prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14,
+        sensealg = QuadratureAdjoint(
+            abstol = 1.0e-14, reltol = 1.0e-14,
+            autojacvec = ZygoteVJP()
+        ), saveat = tsteps
+    )
     u = Array(sol)
     return sum(((1 .- u) .^ 2) ./ 2)
 end
 
 function G_u(u0)
     tmp_prob = remake(prob, u0 = u0, p = prob.p)
-    sol = solve(tmp_prob, Tsit5(), saveat = tsteps,
-        sensealg = QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14,
-            autojacvec = ZygoteVJP()), abstol = 1e-14,
-        reltol = 1e-14)
+    sol = solve(
+        tmp_prob, Tsit5(), saveat = tsteps,
+        sensealg = QuadratureAdjoint(
+            abstol = 1.0e-14, reltol = 1.0e-14,
+            autojacvec = ZygoteVJP()
+        ), abstol = 1.0e-14,
+        reltol = 1.0e-14
+    )
     u = Array(sol)
 
     return sum(((1 .- u) .^ 2) ./ 2)
@@ -129,53 +145,63 @@ f_du0 = ForwardDiff.gradient(G_u, u0)
 z_dp = Zygote.gradient(G_p, p)
 z_du0 = Zygote.gradient(G_u, u0)
 
-@test z_du0[1]≈f_du0 rtol=1e-12
-@test z_dp[1]≈f_dp rtol=1e-12
+@test z_du0[1] ≈ f_du0 rtol = 1.0e-12
+@test z_dp[1] ≈ f_dp rtol = 1.0e-12
 
 ## Continuous Case
 
 g(u, p, t) = sum((u .^ 2) ./ 2)
 
 function dg(u, p, t)
-    u
+    return u
 end
 
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(); dgdu_continuous = dg, g = g,
-    sensealg = QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14, autojacvec = ZygoteVJP()))
+    dp = adjoint_sensitivities(
+    sol, Tsit5(); dgdu_continuous = dg, g = g,
+    sensealg = QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = ZygoteVJP())
+)
 
 @test !iszero(du0)
 @test !iszero(dp)
 
-adj_prob = ODEAdjointProblem(sol,
-    QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14, autojacvec = ZygoteVJP()),
-    Tsit5(), nothing, nothing, nothing, dg, nothing, g)
-adj_sol = solve(adj_prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
-integrand = AdjointSensitivityIntegrand(sol, adj_sol,
-    QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14, autojacvec = ZygoteVJP()))
-res, err = quadgk(integrand, 0.0, 5.0, atol = 1e-14, rtol = 1e-14)
+adj_prob = ODEAdjointProblem(
+    sol,
+    QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = ZygoteVJP()),
+    Tsit5(), nothing, nothing, nothing, dg, nothing, g
+)
+adj_sol = solve(adj_prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
+integrand = AdjointSensitivityIntegrand(
+    sol, adj_sol,
+    QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = ZygoteVJP())
+)
+res, err = quadgk(integrand, 0.0, 5.0, atol = 1.0e-14, rtol = 1.0e-14)
 
-@test adj_sol.u[end]≈du0 rtol=1e-12
-@test res≈dp rtol=1e-12
+@test adj_sol.u[end] ≈ du0 rtol = 1.0e-12
+@test res ≈ dp rtol = 1.0e-12
 
 ##ForwardDiff
 
 function G_p(p)
     tmp_prob = remake(prob, p = p)
-    sol = solve(tmp_prob, Tsit5(), abstol = 1e-12, reltol = 1e-12)
+    sol = solve(tmp_prob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12)
     res,
-    err = quadgk((t) -> (sum((sol(t) .^ 2) ./ 2)), 0.0, 5.0, atol = 1e-12,
-        rtol = 1e-12)
-    res
+        err = quadgk(
+        (t) -> (sum((sol(t) .^ 2) ./ 2)), 0.0, 5.0, atol = 1.0e-12,
+        rtol = 1.0e-12
+    )
+    return res
 end
 
 function G_u(u0)
     tmp_prob = remake(prob, u0 = u0)
-    sol = solve(tmp_prob, Tsit5(), abstol = 1e-12, reltol = 1e-12)
+    sol = solve(tmp_prob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12)
     res,
-    err = quadgk((t) -> (sum((sol(t) .^ 2) ./ 2)), 0.0, 5.0, atol = 1e-12,
-        rtol = 1e-12)
-    res
+        err = quadgk(
+        (t) -> (sum((sol(t) .^ 2) ./ 2)), 0.0, 5.0, atol = 1.0e-12,
+        rtol = 1.0e-12
+    )
+    return res
 end
 
 f_du0 = ForwardDiff.gradient(G_u, u0)
@@ -187,13 +213,22 @@ f_dp = ForwardDiff.gradient(G_p, p)
 ## solve with u0, p
 
 du0,
-dp = Zygote.gradient(
-    (u0,
-        p) -> sum(solve(prob, Tsit5(); u0 = u0, p = p,
-        abstol = 1e-10, reltol = 1e-10, saveat = tsteps,
-        sensealg = QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14,
-            autojacvec = ZygoteVJP()))),
-    u0, p)
+    dp = Zygote.gradient(
+    (
+        u0,
+        p,
+    ) -> sum(
+        solve(
+            prob, Tsit5(); u0 = u0, p = p,
+            abstol = 1.0e-10, reltol = 1.0e-10, saveat = tsteps,
+            sensealg = QuadratureAdjoint(
+                abstol = 1.0e-14, reltol = 1.0e-14,
+                autojacvec = ZygoteVJP()
+            )
+        )
+    ),
+    u0, p
+)
 
 @test !iszero(du0)
 @test !iszero(dp)

--- a/test/adjoint_param.jl
+++ b/test/adjoint_param.jl
@@ -1,11 +1,11 @@
 using Test, OrdinaryDiffEq, SciMLSensitivity, ForwardDiff, QuadGK, Zygote
 
-abstol = 1e-12
-reltol = 1e-12
+abstol = 1.0e-12
+reltol = 1.0e-12
 
 function pendulum_eom(dx, x, p, t)
     dx[1] = p[1] * x[2]
-    dx[2] = -sin(x[1]) + (-p[1] * sin(x[1]) + p[2] * x[2])  # Second term is a simple controller that stabilizes π
+    return dx[2] = -sin(x[1]) + (-p[1] * sin(x[1]) + p[2] * x[2])  # Second term is a simple controller that stabilizes π
 end
 
 x0 = [0.1, 0.0]
@@ -18,32 +18,38 @@ g(x, p, t) = 1.0 * (x[1] - π)^2 + 1.0 * x[2]^2 + 5.0 * (-p[1] * sin(x[1]) + p[2
 dgdu(out, y, p, t) = ForwardDiff.gradient!(out, y -> g(y, p, t), y)
 dgdp(out, y, p, t) = ForwardDiff.gradient!(out, p -> g(y, p, t), p)
 
-res_interp = adjoint_sensitivities(sol, Vern9(), dgdu_continuous = dgdu,
+res_interp = adjoint_sensitivities(
+    sol, Vern9(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, abstol = abstol,
-    reltol = reltol, sensealg = InterpolatingAdjoint())
-res_quad = adjoint_sensitivities(sol, Vern9(), dgdu_continuous = dgdu,
+    reltol = reltol, sensealg = InterpolatingAdjoint()
+)
+res_quad = adjoint_sensitivities(
+    sol, Vern9(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, abstol = abstol,
-    reltol = reltol, sensealg = QuadratureAdjoint())
-res_back = adjoint_sensitivities(sol, Vern9(), dgdu_continuous = dgdu,
+    reltol = reltol, sensealg = QuadratureAdjoint()
+)
+res_back = adjoint_sensitivities(
+    sol, Vern9(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, abstol = abstol,
-    reltol = reltol, sensealg = BacksolveAdjoint(checkpointing = true))
+    reltol = reltol, sensealg = BacksolveAdjoint(checkpointing = true)
+)
 
 function G(p)
     tmp_prob = remake(prob, p = p, u0 = convert.(eltype(p), prob.u0))
     sol = solve(tmp_prob, Vern9(), abstol = abstol, reltol = reltol)
-    res, err = quadgk((t) -> g(sol(t), p, t), 0.0, 10.0, atol = 1e-8, rtol = 1e-8)
-    res
+    res, err = quadgk((t) -> g(sol(t), p, t), 0.0, 10.0, atol = 1.0e-8, rtol = 1.0e-8)
+    return res
 end
 res2 = ForwardDiff.gradient(G, p)
 
-@test res_interp[2]'≈res2 atol=1e-5
-@test res_quad[2]'≈res2 atol=1e-5
-@test res_back[2]'≈res2 atol=1e-5
+@test res_interp[2]' ≈ res2 atol = 1.0e-5
+@test res_quad[2]' ≈ res2 atol = 1.0e-5
+@test res_back[2]' ≈ res2 atol = 1.0e-5
 
 p = [2.0, 3.0]
 u0 = [2.0]
 function f(du, u, p, t)
-    du[1] = -u[1] * p[1] - p[2]
+    return du[1] = -u[1] * p[1] - p[2]
 end
 
 prob = ODEProblem(f, u0, (0.0, 1.0), p)
@@ -55,17 +61,19 @@ dgdu(out, y, p, t) = ForwardDiff.gradient!(out, y -> g(y, p, t), y)
 dgdp(out, y, p, t) = ForwardDiff.gradient!(out, p -> g(y, p, t), p)
 
 du0,
-dp = adjoint_sensitivities(sol, Vern9(), dgdu_continuous = dgdu,
-    dgdp_continuous = dgdp; abstol = abstol, reltol = reltol)
+    dp = adjoint_sensitivities(
+    sol, Vern9(), dgdu_continuous = dgdu,
+    dgdp_continuous = dgdp; abstol = abstol, reltol = reltol
+)
 
 function G(p)
     tmp_prob = remake(prob, p = p, u0 = convert.(eltype(p), prob.u0))
     sol = solve(tmp_prob, Vern9(), abstol = abstol, reltol = reltol)
-    res, err = quadgk((t) -> g(sol(t), p, t), 0.0, 1.0, atol = 1e-8, rtol = 1e-8)
-    res
+    res, err = quadgk((t) -> g(sol(t), p, t), 0.0, 1.0, atol = 1.0e-8, rtol = 1.0e-8)
+    return res
 end
 res2 = ForwardDiff.gradient(G, p)
-@test dp'≈res2 atol=1e-5
+@test dp' ≈ res2 atol = 1.0e-5
 
 function model(p, sensealg)
     N_oscillators = 30
@@ -82,21 +90,25 @@ function model(p, sensealg)
         return nothing
     end
 
-    output = solve(ODEProblem(du!,
+    output = solve(
+        ODEProblem(
+            du!,
             u0,
             (0.0, 10.0),
-            p),
+            p
+        ),
         Tsit5(),
         saveat = collect(0:0.1:7),
         sensealg = sensealg,
-        abstol = abstol, reltol = reltol)
+        abstol = abstol, reltol = reltol
+    )
     return Array(output[1, :, :]) # only return y, not y′
 end
 
 p = [1.5, 0.1]
 y = model(p, QuadratureAdjoint())
 function loss(p, sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP(true)))
-    sum(model(p, sensealg))
+    return sum(model(p, sensealg))
 end
 dp1 = Zygote.gradient(loss, p)[1]
 dp2 = ForwardDiff.gradient(loss, p)

--- a/test/adjoint_shapes.jl
+++ b/test/adjoint_shapes.jl
@@ -16,24 +16,32 @@ function aug_dynamics!(dz, z, K, t)
     x = @view z[2:end]
     u = -K * x
     dz[1] = x' * x + u' * u
-    dz[2:end] = x + u
+    return dz[2:end] = x + u
 end
 
 policy_params = ones(2, 2)
 z0 = zeros(3)
-fwd_sol = solve(ODEProblem(aug_dynamics!, z0, (0.0, 1.0), policy_params),
-    Tsit5(), u0 = z0, p = policy_params)
+fwd_sol = solve(
+    ODEProblem(aug_dynamics!, z0, (0.0, 1.0), policy_params),
+    Tsit5(), u0 = z0, p = policy_params
+)
 _, repack, _ = SciMLStructures.canonicalize(SciMLStructures.Tunable(), policy_params)
 
 sensealg = InterpolatingAdjoint()
-sensealg = SciMLSensitivity.setvjp(sensealg,
+sensealg = SciMLSensitivity.setvjp(
+    sensealg,
     SciMLSensitivity.inplace_vjp(
-        fwd_sol.prob, fwd_sol.prob.u0, fwd_sol.prob.p, true, repack))
+        fwd_sol.prob, fwd_sol.prob.u0, fwd_sol.prob.p, true, repack
+    )
+)
 
 solve(
-    ODEAdjointProblem(fwd_sol, sensealg, Tsit5(),
-        [1.0], (out, x, p, t, i) -> (out .= 1)),
-    Tsit5())
+    ODEAdjointProblem(
+        fwd_sol, sensealg, Tsit5(),
+        [1.0], (out, x, p, t, i) -> (out .= 1)
+    ),
+    Tsit5()
+)
 
 A = ones(2, 2)
 B = ones(2, 2)
@@ -44,30 +52,35 @@ function aug_dynamics!(dz, z, K, t)
     x = @view z[2:end]
     u = -K * x
     dz[1] = x' * Q * x + u' * R * u
-    dz[2:end] = A * x + B * u # or just `x + u`
+    return dz[2:end] = A * x + B * u # or just `x + u`
 end
 
 policy_params = ones(2, 2)
 z0 = zeros(3)
-fwd_sol = solve(ODEProblem(aug_dynamics!, z0, (0.0, 1.0), policy_params), u0 = z0,
-    p = policy_params, Tsit5())
+fwd_sol = solve(
+    ODEProblem(aug_dynamics!, z0, (0.0, 1.0), policy_params), u0 = z0,
+    p = policy_params, Tsit5()
+)
 
 solve(
-    ODEAdjointProblem(fwd_sol, sensealg, Tsit5(), [1.0],
-        (out, x, p, t, i) -> (out .= 1)),
-    Tsit5())
+    ODEAdjointProblem(
+        fwd_sol, sensealg, Tsit5(), [1.0],
+        (out, x, p, t, i) -> (out .= 1)
+    ),
+    Tsit5()
+)
 
 # https://github.com/SciML/SciMLSensitivity.jl/issues/581
 
 p = rand(1)
 
 function dudt(u, p, t)
-    u .* p
+    return u .* p
 end
 
 function loss(p)
     prob = ODEProblem(dudt, [3.0], (0.0, 1.0), p)
     sol = solve(prob, Tsit5(), dt = 0.01, sensealg = ReverseDiffAdjoint())
-    sum(abs2, Array(sol))
+    return sum(abs2, Array(sol))
 end
 Zygote.gradient(loss, p)[1][1] ≈ ForwardDiff.gradient(loss, p)[1]

--- a/test/alternative_ad_frontend.jl
+++ b/test/alternative_ad_frontend.jl
@@ -1,10 +1,10 @@
 using OrdinaryDiffEq, SciMLSensitivity, ForwardDiff, Zygote, ReverseDiff, Tracker, Enzyme,
-      FiniteDiff, Mooncake
+    FiniteDiff, Mooncake
 using Test
 Enzyme.API.typeWarning!(false)
 
 function mooncake_gradient(f, x)
-    Mooncake.value_and_gradient!!(Mooncake.build_rrule(f, x), f, x)[2][2]
+    return Mooncake.value_and_gradient!!(Mooncake.build_rrule(f, x), f, x)[2][2]
 end
 
 odef(du, u, p, t) = du .= u .* p
@@ -15,7 +15,7 @@ struct senseloss0{T}
 end
 function (f::senseloss0)(u0p)
     prob = ODEProblem{true}(odef, u0p[1:1], (0.0, 1.0), u0p[2:2])
-    sum(solve(prob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = 0.1))
+    return sum(solve(prob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = 0.1))
 end
 u0p = [2.0, 3.0]
 du0p = zeros(2)
@@ -29,12 +29,20 @@ struct senseloss{T}
     sense::T
 end
 function (f::senseloss)(u0p)
-    sum(solve(prob, Tsit5(), u0 = u0p[1:1], p = u0p[2:2], abstol = 1e-12,
-        reltol = 1e-12, saveat = 0.1, sensealg = f.sense))
+    return sum(
+        solve(
+            prob, Tsit5(), u0 = u0p[1:1], p = u0p[2:2], abstol = 1.0e-12,
+            reltol = 1.0e-12, saveat = 0.1, sensealg = f.sense
+        )
+    )
 end
 function loss(u0p)
-    sum(solve(prob, Tsit5(), u0 = u0p[1:1], p = u0p[2:2], abstol = 1e-12, reltol = 1e-12,
-        saveat = 0.1))
+    return sum(
+        solve(
+            prob, Tsit5(), u0 = u0p[1:1], p = u0p[2:2], abstol = 1.0e-12, reltol = 1.0e-12,
+            saveat = 0.1
+        )
+    )
 end
 u0p = [2.0, 3.0]
 
@@ -55,10 +63,16 @@ dup = Zygote.gradient(senseloss(InterpolatingAdjoint()), u0p)[1]
 @test ForwardDiff.gradient(senseloss(InterpolatingAdjoint()), u0p) ≈ dup
 
 @test only(Enzyme.gradient(Reverse, senseloss(InterpolatingAdjoint()), u0p)) ≈ dup
-@test_throws SciMLSensitivity.EnzymeTrackedRealError only(Enzyme.gradient(
-    Reverse, senseloss(ReverseDiffAdjoint()), u0p))≈dup
-@test_throws SciMLSensitivity.EnzymeTrackedRealError only(Enzyme.gradient(
-    Reverse, senseloss(TrackerAdjoint()), u0p))≈dup
+@test_throws SciMLSensitivity.EnzymeTrackedRealError only(
+    Enzyme.gradient(
+        Reverse, senseloss(ReverseDiffAdjoint()), u0p
+    )
+) ≈ dup
+@test_throws SciMLSensitivity.EnzymeTrackedRealError only(
+    Enzyme.gradient(
+        Reverse, senseloss(TrackerAdjoint()), u0p
+    )
+) ≈ dup
 @test only(Enzyme.gradient(Reverse, senseloss(ForwardDiffSensitivity()), u0p)) ≈ dup
 @test_broken only(Enzyme.gradient(Reverse, senseloss(ForwardSensitivity()), u0p)) ≈ dup # broken because ForwardSensitivity not compatible with perturbing u0
 
@@ -74,8 +88,12 @@ end
 prob2 = ODEProblem((du, u, p, t) -> du .= u .* p, [2.0], (0.0, 1.0), [3.0])
 
 function (f::senseloss2)(u0p)
-    sum(solve(prob2, Tsit5(), u0 = u0p[1:1], p = u0p[2:2], abstol = 1e-12,
-        reltol = 1e-12, saveat = 0.1, sensealg = f.sense))
+    return sum(
+        solve(
+            prob2, Tsit5(), u0 = u0p[1:1], p = u0p[2:2], abstol = 1.0e-12,
+            reltol = 1.0e-12, saveat = 0.1, sensealg = f.sense
+        )
+    )
 end
 
 u0p = [2.0, 3.0]
@@ -112,8 +130,12 @@ struct senseloss3{T}
     sense::T
 end
 function (f::senseloss3)(u0p)
-    sum(solve(prob2, Tsit5(), p = u0p, abstol = 1e-12,
-        reltol = 1e-12, saveat = 0.1, sensealg = f.sense))
+    return sum(
+        solve(
+            prob2, Tsit5(), p = u0p, abstol = 1.0e-12,
+            reltol = 1.0e-12, saveat = 0.1, sensealg = f.sense
+        )
+    )
 end
 
 u0p = [3.0]
@@ -150,8 +172,12 @@ struct senseloss4{T}
     sense::T
 end
 function (f::senseloss4)(u0p)
-    sum(solve(prob, Tsit5(), p = u0p, abstol = 1e-12,
-        reltol = 1e-12, saveat = 0.1, sensealg = f.sense))
+    return sum(
+        solve(
+            prob, Tsit5(), p = u0p, abstol = 1.0e-12,
+            reltol = 1.0e-12, saveat = 0.1, sensealg = f.sense
+        )
+    )
 end
 
 u0p = [3.0]
@@ -173,10 +199,16 @@ dup = Zygote.gradient(senseloss4(InterpolatingAdjoint()), u0p)[1]
 @test ForwardDiff.gradient(senseloss4(InterpolatingAdjoint()), u0p) ≈ dup
 
 @test only(Enzyme.gradient(Reverse, senseloss4(InterpolatingAdjoint()), u0p)) ≈ dup
-@test_throws SciMLSensitivity.EnzymeTrackedRealError only(Enzyme.gradient(
-    Reverse, senseloss4(ReverseDiffAdjoint()), u0p))≈dup
-@test_throws SciMLSensitivity.EnzymeTrackedRealError only(Enzyme.gradient(
-    Reverse, senseloss4(TrackerAdjoint()), u0p))≈dup
+@test_throws SciMLSensitivity.EnzymeTrackedRealError only(
+    Enzyme.gradient(
+        Reverse, senseloss4(ReverseDiffAdjoint()), u0p
+    )
+) ≈ dup
+@test_throws SciMLSensitivity.EnzymeTrackedRealError only(
+    Enzyme.gradient(
+        Reverse, senseloss4(TrackerAdjoint()), u0p
+    )
+) ≈ dup
 @test only(Enzyme.gradient(Reverse, senseloss4(ForwardDiffSensitivity()), u0p)) ≈ dup
 @test_broken only(Enzyme.gradient(Reverse, senseloss4(ForwardSensitivity()), u0p)) ≈ dup # broken because ForwardSensitivity not compatible with perturbing u0
 
@@ -198,13 +230,13 @@ f_aug(u, p, t) = reshape(p, 4, 4) * u
 function loss(p)
     prob = ODEProblem(f_aug, u0, tspan, p; alg = solvealg_test, sensealg = sensealg_test)
     sol = solve(prob)
-    sum(sol[:, :, end])
+    return sum(sol[:, :, end])
 end
 
 function loss2(p)
     prob = ODEProblem(f_aug, u0, tspan, p)
     sol = solve(prob, solvealg_test; sensealg = sensealg_test)
-    sum(sol[:, :, end])
+    return sum(sol[:, :, end])
 end
 
 res1 = loss(p0)
@@ -212,18 +244,18 @@ res2 = ReverseDiff.gradient(loss, p0)
 res3 = loss2(p0)
 res4 = ReverseDiff.gradient(loss2, p0)
 
-@test res1≈res3 atol=1e-14
-@test res2≈res4 atol=1e-14
+@test res1 ≈ res3 atol = 1.0e-14
+@test res2 ≈ res4 atol = 1.0e-14
 
-@test_broken res2≈Enzyme.gradient(Reverse, loss, p0) atol=1e-14
-@test_broken res4≈Enzyme.gradient(Reverse, loss2, p0) atol=1e-14
+@test_broken res2 ≈ Enzyme.gradient(Reverse, loss, p0) atol = 1.0e-14
+@test_broken res4 ≈ Enzyme.gradient(Reverse, loss2, p0) atol = 1.0e-14
 
 @test res2 ≈ mooncake_gradient(loss, p0)
 @test res4 ≈ mooncake_gradient(loss2, p0)
 
 # Test for recursion https://discourse.julialang.org/t/diffeqsensitivity-jl-issues-with-reversediffadjoint-sensealg/88774
 function ode!(derivative, state, parameters, t)
-    derivative .= parameters
+    return derivative .= parameters
 end
 
 function ode(state, parameters, t)
@@ -231,9 +263,11 @@ function ode(state, parameters, t)
 end
 
 function solve_euler(state, times, parameters)
-    problem = ODEProblem{true}(ode!, state, times[[1, end]], parameters; saveat = times,
-        sensealg = ReverseDiffAdjoint())
-    return solve(problem, Euler(); dt = 1e-1)
+    problem = ODEProblem{true}(
+        ode!, state, times[[1, end]], parameters; saveat = times,
+        sensealg = ReverseDiffAdjoint()
+    )
+    return solve(problem, Euler(); dt = 1.0e-1)
 end
 
 const initial_state = ones(2)
@@ -265,10 +299,12 @@ ff = ODEFunction{false}(fx)
 prob3 = ODEProblem{false}(ff, u0, (t_start, t_stop), p)
 
 function loss2(p)
-    solution = solve(prob3; p = p, alg = solver, saveat = tData,
-        sensealg = sensealg, abstol = 1e-10, reltol = 1e-10)
+    solution = solve(
+        prob3; p = p, alg = solver, saveat = tData,
+        sensealg = sensealg, abstol = 1.0e-10, reltol = 1.0e-10
+    )
     # fix for ReverseDiff
-    if !isa(solution, ReverseDiff.TrackedArray) && !isa(solution, Array)
+    return if !isa(solution, ReverseDiff.TrackedArray) && !isa(solution, Array)
         sum(abs.(collect(u[1] for u in solution.u)))
     else
         sum(abs.(solution[1, :]))
@@ -282,7 +318,7 @@ grad_fi = FiniteDiff.finite_difference_gradient(loss2, p)
 grad_fd = ForwardDiff.gradient(loss2, p)
 grad_zg = Zygote.gradient(loss2, p)[1]
 grad_rd = ReverseDiff.gradient(loss2, p)
-@test grad_fd≈grad_fi atol=1e-2
-@test grad_fd≈grad_zg atol=1e-4
-@test grad_fd≈grad_rd atol=1e-4
-@test_broken mooncake_gradient(loss2, p) ≈ grad_rd atol=1e-4
+@test grad_fd ≈ grad_fi atol = 1.0e-2
+@test grad_fd ≈ grad_zg atol = 1.0e-4
+@test grad_fd ≈ grad_rd atol = 1.0e-4
+@test_broken mooncake_gradient(loss2, p) ≈ grad_rd atol = 1.0e-4

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -4,9 +4,13 @@ using SciMLSensitivity, Aqua, SciMLBase, ExplicitImports
     Aqua.find_persistent_tasks_deps(SciMLSensitivity)
     Aqua.test_ambiguities(SciMLSensitivity, recursive = false)
     Aqua.test_deps_compat(SciMLSensitivity)
-    Aqua.test_piracies(SciMLSensitivity;
-        treat_as_own = [SciMLBase._concrete_solve_adjoint,
-            SciMLBase._concrete_solve_forward])
+    Aqua.test_piracies(
+        SciMLSensitivity;
+        treat_as_own = [
+            SciMLBase._concrete_solve_adjoint,
+            SciMLBase._concrete_solve_forward,
+        ]
+    )
     Aqua.test_project_extras(SciMLSensitivity)
     Aqua.test_stale_deps(SciMLSensitivity)
     Aqua.test_unbound_args(SciMLSensitivity)
@@ -19,5 +23,5 @@ end
     ) === nothing
     @test ExplicitImports.check_no_stale_explicit_imports(SciMLSensitivity) === nothing
     @test ExplicitImports.check_all_qualified_accesses_via_owners(SciMLSensitivity) ===
-          nothing
+        nothing
 end

--- a/test/array_partitions.jl
+++ b/test/array_partitions.jl
@@ -1,16 +1,17 @@
 import OrdinaryDiffEq
 import DiffEqBase: DynamicalODEProblem
 import SciMLSensitivity:
-                         solve,
-                         ODEProblem,
-                         ODEAdjointProblem,
-                         InterpolatingAdjoint,
-                         ZygoteVJP,
-                         ReverseDiffVJP
+    solve,
+    ODEProblem,
+    ODEAdjointProblem,
+    InterpolatingAdjoint,
+    ZygoteVJP,
+    ReverseDiffVJP
 import RecursiveArrayTools: ArrayPartition
 
 sol = solve(
-    DynamicalODEProblem((v, x, p, t) -> [0.0, 0.0],
+    DynamicalODEProblem(
+        (v, x, p, t) -> [0.0, 0.0],
 
         # ERROR: LoadError: type Nothing has no field x
         # (v, x, p, t) -> [0.0, 0.0],
@@ -18,16 +19,21 @@ sol = solve(
         # ERROR: LoadError: MethodError: no method matching ndims(::Type{Nothing})
         (v, x, p, t) -> v, [0.0, 0.0],
         [0.0, 0.0],
-        (0.0, 1.0)),
-    OrdinaryDiffEq.Tsit5())
+        (0.0, 1.0)
+    ),
+    OrdinaryDiffEq.Tsit5()
+)
 
 solve(
-    ODEAdjointProblem(sol,
+    ODEAdjointProblem(
+        sol,
         InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true)),
         OrdinaryDiffEq.Tsit5(),
         [sol.t[end]],
-        (out, x, p, t, i) -> (out .= 0)),
-    OrdinaryDiffEq.Tsit5())
+        (out, x, p, t, i) -> (out .= 0)
+    ),
+    OrdinaryDiffEq.Tsit5()
+)
 
 dyn_v(v_ap, x_ap, p, t) = ArrayPartition(zeros(), [0.0])
 # Originally, I imagined that this may be a bug in Zygote, and it still may be, but I tried doing a pullback on this
@@ -46,23 +52,29 @@ v0 = [-1.0]
 x0 = [0.75]
 
 sol = solve(
-    DynamicalODEProblem(dyn_v,
+    DynamicalODEProblem(
+        dyn_v,
         dyn_x,
         ArrayPartition(zeros(), v0),
         ArrayPartition(zeros(), x0),
         (0.0, 1.0),
-        zeros()),
+        zeros()
+    ),
     OrdinaryDiffEq.Tsit5(),
     # Without setting parameters, we end up with https://github.com/SciML/DifferentialEquations.jl/issues/679 again.
-    p = zeros())
+    p = zeros()
+)
 
 g = ArrayPartition(ArrayPartition(zeros(), zero(v0)), ArrayPartition(zeros(), zero(x0)))
 bwd_sol = solve(
-    ODEAdjointProblem(sol,
+    ODEAdjointProblem(
+        sol,
         InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true)),
         OrdinaryDiffEq.Tsit5(),
         # Also fails, but due to a different bug:
         # InterpolatingAdjoint(autojacvec=ReverseDiffVJP()),
         [sol.t[end]],
-        (out, x, p, t, i) -> (out[:] = g)),
-    OrdinaryDiffEq.Tsit5())
+        (out, x, p, t, i) -> (out[:] = g)
+    ),
+    OrdinaryDiffEq.Tsit5()
+)

--- a/test/autodiff_events.jl
+++ b/test/autodiff_events.jl
@@ -4,17 +4,17 @@ using Zygote
 
 function f(du, u, p, t)
     du[1] = u[2]
-    du[2] = -p[1]
+    return du[2] = -p[1]
 end
 
 function condition(u, t, integrator) # Event when event_f(u,t) == 0
-    u[1]
+    return u[1]
 end
 
 function affect!(integrator)
     @show integrator.t
     println("bounced.")
-    integrator.u[2] = -integrator.p[2] * integrator.u[2]
+    return integrator.u[2] = -integrator.p[2] * integrator.u[2]
 end
 
 cb = ContinuousCallback(condition, affect!)
@@ -23,8 +23,10 @@ prob = ODEProblem(f, eltype(p).([1.0, 0.0]), eltype(p).((0.0, 1.0)), copy(p))
 
 function test_f(p)
     _prob = remake(prob, p = p)
-    solve(_prob, Tsit5(), abstol = 1e-14, reltol = 1e-14, callback = cb,
-        save_everystep = false)[end]
+    return solve(
+        _prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14, callback = cb,
+        save_everystep = false
+    )[end]
 end
 findiff = Calculus.finite_difference_jacobian(test_f, p)
 findiff
@@ -35,12 +37,16 @@ ad
 
 @test ad ≈ findiff
 
-function test_f2(p, sensealg = ForwardDiffSensitivity(), controller = nothing,
-        alg = Tsit5())
+function test_f2(
+        p, sensealg = ForwardDiffSensitivity(), controller = nothing,
+        alg = Tsit5()
+    )
     _prob = remake(prob, p = p)
-    u = solve(_prob, alg, sensealg = sensealg, controller = controller,
-        abstol = 1e-14, reltol = 1e-14, callback = cb, save_everystep = false)
-    u[end][end]
+    u = solve(
+        _prob, alg, sensealg = sensealg, controller = controller,
+        abstol = 1.0e-14, reltol = 1.0e-14, callback = cb, save_everystep = false
+    )
+    return u[end][end]
 end
 
 @test test_f2(p) == test_f(p)[end]
@@ -48,21 +54,32 @@ end
 g1 = Zygote.gradient(θ -> test_f2(θ, ForwardDiffSensitivity()), p)
 g2 = Zygote.gradient(θ -> test_f2(θ, ReverseDiffAdjoint()), p)
 g3 = Zygote.gradient(θ -> test_f2(θ, ReverseDiffAdjoint(), IController()), p)
-g4 = Zygote.gradient(θ -> test_f2(θ, ReverseDiffAdjoint(), PIController(7 // 50, 2 // 25)),
-    p)
+g4 = Zygote.gradient(
+    θ -> test_f2(θ, ReverseDiffAdjoint(), PIController(7 // 50, 2 // 25)),
+    p
+)
 @test_broken g5 = Zygote.gradient(
-    θ -> test_f2(θ, ReverseDiffAdjoint(),
-        PIDController(1 / 18.0, 1 / 9.0, 1 / 18.0)),
-    p)
+    θ -> test_f2(
+        θ, ReverseDiffAdjoint(),
+        PIDController(1 / 18.0, 1 / 9.0, 1 / 18.0)
+    ),
+    p
+)
 g6 = Zygote.gradient(
-    θ -> test_f2(θ, ForwardDiffSensitivity(),
-        OrdinaryDiffEqCore.PredictiveController(), TRBDF2()),
-    p)
+    θ -> test_f2(
+        θ, ForwardDiffSensitivity(),
+        OrdinaryDiffEqCore.PredictiveController(), TRBDF2()
+    ),
+    p
+)
 @test_broken g7 = Zygote.gradient(
-    θ -> test_f2(θ, ReverseDiffAdjoint(),
+    θ -> test_f2(
+        θ, ReverseDiffAdjoint(),
         OrdinaryDiffEqCore.PredictiveController(),
-        TRBDF2()),
-    p)
+        TRBDF2()
+    ),
+    p
+)
 
 @test g1[1] ≈ findiff[2, 1:2]
 @test g2[1] ≈ findiff[2, 1:2]

--- a/test/automatic_sensealg_choice.jl
+++ b/test/automatic_sensealg_choice.jl
@@ -14,7 +14,7 @@ function dxdt_(dx, x, p, t)
     ps = ComponentArray(p, ax)
     x1, x2 = x
     dx[1] = x[2]
-    dx[2] = first(ann([t], ps, st))[1]^3
+    return dx[2] = first(ann([t], ps, st))[1]^3
 end
 x0 = [-4.0f0, 0.0f0]
 ts = Float32.(collect(0.0:0.01:tspan[2]))

--- a/test/branching_derivatives.jl
+++ b/test/branching_derivatives.jl
@@ -12,7 +12,7 @@ end
 function fiip(du, u, p, t)
     a = get_param([1.0, 2.0, 3.0], p[1:4], t)
     du[1] = dx = a * u[1] - u[1] * u[2]
-    du[2] = dy = -a * u[2] + u[1] * u[2]
+    return du[2] = dy = -a * u[2] + u[1] * u[2]
 end
 
 p = [1.0, 1.0, 1.0, 1.0];
@@ -21,34 +21,64 @@ u0 = [1.0; 1.0];
 prob = ODEProblem(fiip, u0, (0.0, 4.0), p);
 
 dp1 = Zygote.gradient(
-    p -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-        sensealg = ForwardDiffSensitivity(), saveat = 0.1,
-        abstol = 1e-12, reltol = 1e-12)),
-    p)
+    p -> sum(
+        solve(
+            prob, Tsit5(), u0 = u0, p = p,
+            sensealg = ForwardDiffSensitivity(), saveat = 0.1,
+            abstol = 1.0e-12, reltol = 1.0e-12
+        )
+    ),
+    p
+)
 dp2 = Zygote.gradient(
-    p -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-        sensealg = ForwardDiffSensitivity(convert_tspan = true),
-        saveat = 0.1, abstol = 1e-12, reltol = 1e-12)),
-    p)
+    p -> sum(
+        solve(
+            prob, Tsit5(), u0 = u0, p = p,
+            sensealg = ForwardDiffSensitivity(convert_tspan = true),
+            saveat = 0.1, abstol = 1.0e-12, reltol = 1.0e-12
+        )
+    ),
+    p
+)
 dp3 = Zygote.gradient(
-    p -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-        sensealg = ForwardSensitivity(), saveat = 0.1,
-        abstol = 1e-12, reltol = 1e-12)),
-    p)
+    p -> sum(
+        solve(
+            prob, Tsit5(), u0 = u0, p = p,
+            sensealg = ForwardSensitivity(), saveat = 0.1,
+            abstol = 1.0e-12, reltol = 1.0e-12
+        )
+    ),
+    p
+)
 dp4 = Zygote.gradient(
-    p -> sum(solve(prob, Tsit5(), u0 = u0, p = p, saveat = 0.1,
-        abstol = 1e-12, reltol = 1e-12)),
-    p)
+    p -> sum(
+        solve(
+            prob, Tsit5(), u0 = u0, p = p, saveat = 0.1,
+            abstol = 1.0e-12, reltol = 1.0e-12
+        )
+    ),
+    p
+)
 dp5 = Zygote.gradient(
-    p -> sum(solve(prob, Tsit5(), u0 = u0, p = p, saveat = 0.1,
-        abstol = 1e-12, reltol = 1e-12,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))),
-    p)
+    p -> sum(
+        solve(
+            prob, Tsit5(), u0 = u0, p = p, saveat = 0.1,
+            abstol = 1.0e-12, reltol = 1.0e-12,
+            sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+        )
+    ),
+    p
+)
 dp6 = Zygote.gradient(
-    p -> sum(solve(prob, Tsit5(), u0 = u0, p = p, saveat = 0.1,
-        abstol = 1e-12, reltol = 1e-12,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP(true)))),
-    p)
+    p -> sum(
+        solve(
+            prob, Tsit5(), u0 = u0, p = p, saveat = 0.1,
+            abstol = 1.0e-12, reltol = 1.0e-12,
+            sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP(true))
+        )
+    ),
+    p
+)
 
 @test dp1[1] ≈ dp2[1]
 @test dp1[1] ≈ dp3[1]

--- a/test/callback_reversediff.jl
+++ b/test/callback_reversediff.jl
@@ -10,7 +10,7 @@ tspan = (0.0f0, 10.5f0)
 dosetimes = [1.0, 2.0, 4.0, 8.0]
 
 function affect!(integrator)
-    integrator.u = integrator.u .+ 1
+    return integrator.u = integrator.u .+ 1
 end
 
 function functionCalling(x, t, integrator)
@@ -18,24 +18,30 @@ function functionCalling(x, t, integrator)
 end
 
 cbPreTime = PresetTimeCallback(dosetimes, affect!, save_positions = (false, false))
-cbFctCall = FunctionCallingCallback(functionCalling; func_everystep = true,
-    func_start = true)
+cbFctCall = FunctionCallingCallback(
+    functionCalling; func_everystep = true,
+    func_start = true
+)
 
 function trueODEfunc(du, u, p, t)
-    du .= -u
+    return du .= -u
 end
 t = range(tspan[1], tspan[2], length = datasize)
 
 prob = ODEProblem(trueODEfunc, u0, tspan)
-ode_data = Array(solve(prob, Tsit5(), callback = CallbackSet(cbPreTime, cbFctCall),
-    saveat = t))
+ode_data = Array(
+    solve(
+        prob, Tsit5(), callback = CallbackSet(cbPreTime, cbFctCall),
+        saveat = t
+    )
+)
 dudt2 = Chain(Dense(2, 50, tanh), Dense(50, 2))
 ps, st = Lux.setup(Random.default_rng(), dudt2)
 ps = ComponentArray(ps)
 
 function dudt(du, u, p, t)
     du[1:2] .= -u[1:2]
-    du[3:end] .= first(dudt2(u[1:2], p, st)) #re(p)(u[3:end])
+    return du[3:end] .= first(dudt2(u[1:2], p, st)) #re(p)(u[3:end])
 end
 z0 = Float32[u0; u0]
 prob = ODEProblem(dudt, z0, tspan)
@@ -44,18 +50,24 @@ affect!(integrator) = integrator.u[1:2] .= integrator.u[3:end]
 cb = PresetTimeCallback(dosetimes, affect!, save_positions = (false, false))
 
 function predict_n_ode(ps)
-    Array(solve(prob, Tsit5(), u0 = z0, p = ps, callback = cb, saveat = t,
-        sensealg = ReverseDiffAdjoint()))[1:2, :]
+    return Array(
+        solve(
+            prob, Tsit5(), u0 = z0, p = ps, callback = cb, saveat = t,
+            sensealg = ReverseDiffAdjoint()
+        )
+    )[1:2, :]
 end
 
 function loss_n_ode(ps, _)
     pred = predict_n_ode(ps)
     loss = sum(abs2, ode_data .- pred)
-    loss
+    return loss
 end
 loss_n_ode(ps, nothing)
 
-res = solve(OptimizationProblem(OptimizationFunction(loss_n_ode, AutoZygote()), ps),
-    Adam(0.005); maxiters = 250)
+res = solve(
+    OptimizationProblem(OptimizationFunction(loss_n_ode, AutoZygote()), ps),
+    Adam(0.005); maxiters = 250
+)
 
 @test loss_n_ode(res.u, nothing) < 0.4

--- a/test/callbacks/SDE_callbacks.jl
+++ b/test/callbacks/SDE_callbacks.jl
@@ -1,8 +1,8 @@
 using StochasticDiffEq, Zygote
 using SciMLSensitivity, Test, ForwardDiff
 
-abstol = 1e-12
-reltol = 1e-12
+abstol = 1.0e-12
+reltol = 1.0e-12
 savingtimes = 0.5
 
 function test_SDE_callbacks()
@@ -10,12 +10,12 @@ function test_SDE_callbacks()
         x, y = u
         α, β, δ, γ = p
         du[1] = dx = α * x - β * x * y
-        du[2] = dy = -δ * y + γ * x * y
+        return du[2] = dy = -δ * y + γ * x * y
     end
 
     function dW!(du, u, p, t)
         du[1] = 0.1u[1]
-        du[2] = 0.1u[2]
+        return du[2] = 0.1u[2]
     end
 
     u0 = [1.0, 1.0]
@@ -30,8 +30,12 @@ function test_SDE_callbacks()
     cb = DiscreteCallback(condition, affect!, save_positions = (false, false))
 
     function predict_sde(p)
-        return Array(solve(prob_sde, EM(), p = p, saveat = savingtimes,
-            sensealg = ForwardDiffSensitivity(), dt = 0.001, callback = cb))
+        return Array(
+            solve(
+                prob_sde, EM(), p = p, saveat = savingtimes,
+                sensealg = ForwardDiffSensitivity(), dt = 0.001, callback = cb
+            )
+        )
     end
 
     loss_sde(p) = sum(abs2, x - 1 for x in predict_sde(p))
@@ -41,7 +45,7 @@ function test_SDE_callbacks()
         loss_sde(p)
     end
 
-    @test !iszero(dp[1])
+    return @test !iszero(dp[1])
 end
 
 @testset "SDEs" begin

--- a/test/callbacks/continuous_vs_discrete.jl
+++ b/test/callbacks/continuous_vs_discrete.jl
@@ -1,8 +1,8 @@
 using OrdinaryDiffEq, Zygote
 using SciMLSensitivity, Test, ForwardDiff
 
-abstol = 1e-12
-reltol = 1e-12
+abstol = 1.0e-12
+reltol = 1.0e-12
 savingtimes = 0.5
 
 function test_continuous_wrt_discrete_callback()
@@ -10,7 +10,7 @@ function test_continuous_wrt_discrete_callback()
     function f(du, u, p, t)
         #Bouncing Ball
         du[1] = u[2]
-        du[2] = -p[1]
+        return du[2] = -p[1]
     end
 
     # no saving in Callbacks; prescribed vafter and vbefore; loss on the endpoint
@@ -26,10 +26,10 @@ function test_continuous_wrt_discrete_callback()
     prob = ODEProblem(f, u0, tspan, p)
 
     function condition(u, t, integrator) # Event when event_f(u,t) == 0
-        t - tstop
+        return t - tstop
     end
     function affect!(integrator)
-        integrator.u[2] += vafter - vbefore
+        return integrator.u[2] += vafter - vbefore
     end
     cb = ContinuousCallback(condition, affect!, save_positions = (false, false))
 
@@ -37,28 +37,47 @@ function test_continuous_wrt_discrete_callback()
     cb2 = DiscreteCallback(condition2, affect!, save_positions = (false, false))
 
     du01,
-    dp1 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb2, tstops = [tstop],
-            sensealg = BacksolveAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp1 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb2, tstops = [tstop],
+                sensealg = BacksolveAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     du02,
-    dp2 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb,
-            sensealg = BacksolveAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp2 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb,
+                sensealg = BacksolveAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     dstuff = ForwardDiff.gradient(
-        (θ) -> sum(solve(prob, Tsit5(), u0 = θ[1:2], p = θ[3:4],
-            callback = cb, saveat = tspan[2],
-            save_start = false)),
-        [u0; p])
+        (θ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = θ[1:2], p = θ[3:4],
+                callback = cb, saveat = tspan[2],
+                save_start = false
+            )
+        ),
+        [u0; p]
+    )
 
     @info dstuff
     @test du01 ≈ dstuff[1:2]
@@ -68,25 +87,44 @@ function test_continuous_wrt_discrete_callback()
 
     # no saving in Callbacks; prescribed vafter and vbefore; loss on the endpoint by slicing
     du01,
-    dp1 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb2, tstops = [tstop],
-            sensealg = BacksolveAdjoint())[end]),
-        u0, p)
+        dp1 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb2, tstops = [tstop],
+                sensealg = BacksolveAdjoint()
+            )[end]
+        ),
+        u0, p
+    )
 
     du02,
-    dp2 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb,
-            sensealg = BacksolveAdjoint())[end]),
-        u0, p)
+        dp2 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb,
+                sensealg = BacksolveAdjoint()
+            )[end]
+        ),
+        u0, p
+    )
 
     dstuff = ForwardDiff.gradient(
-        (θ) -> sum(solve(prob, Tsit5(), u0 = θ[1:2], p = θ[3:4],
-            callback = cb)[end]),
-        [u0; p])
+        (θ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = θ[1:2], p = θ[3:4],
+                callback = cb
+            )[end]
+        ),
+        [u0; p]
+    )
 
     @info dstuff
     @test du01 ≈ dstuff[1:2]
@@ -99,28 +137,47 @@ function test_continuous_wrt_discrete_callback()
     cb2 = DiscreteCallback(condition2, affect!, save_positions = (true, true))
 
     du01,
-    dp1 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb2, tstops = [tstop],
-            sensealg = BacksolveAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp1 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb2, tstops = [tstop],
+                sensealg = BacksolveAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     du02,
-    dp2 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb,
-            sensealg = BacksolveAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp2 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb,
+                sensealg = BacksolveAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     dstuff = ForwardDiff.gradient(
-        (θ) -> sum(solve(prob, Tsit5(), u0 = θ[1:2], p = θ[3:4],
-            callback = cb, saveat = tspan[2],
-            save_start = false)),
-        [u0; p])
+        (θ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = θ[1:2], p = θ[3:4],
+                callback = cb, saveat = tspan[2],
+                save_start = false
+            )
+        ),
+        [u0; p]
+    )
 
     @info dstuff
     @test du01 ≈ dstuff[1:2]
@@ -130,25 +187,44 @@ function test_continuous_wrt_discrete_callback()
 
     # with saving in Callbacks; prescribed vafter and vbefore; loss on the endpoint by slicing
     du01,
-    dp1 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb2, tstops = [tstop],
-            sensealg = BacksolveAdjoint())[end]),
-        u0, p)
+        dp1 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb2, tstops = [tstop],
+                sensealg = BacksolveAdjoint()
+            )[end]
+        ),
+        u0, p
+    )
 
     du02,
-    dp2 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb,
-            sensealg = BacksolveAdjoint())[end]),
-        u0, p)
+        dp2 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb,
+                sensealg = BacksolveAdjoint()
+            )[end]
+        ),
+        u0, p
+    )
 
     dstuff = ForwardDiff.gradient(
-        (θ) -> sum(solve(prob, Tsit5(), u0 = θ[1:2], p = θ[3:4],
-            callback = cb)[end]),
-        [u0; p])
+        (θ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = θ[1:2], p = θ[3:4],
+                callback = cb
+            )[end]
+        ),
+        [u0; p]
+    )
 
     @info dstuff
     @test du01 ≈ dstuff[1:2]
@@ -158,89 +234,150 @@ function test_continuous_wrt_discrete_callback()
 
     # with saving in Callbacks;  different affect function
     function affect2!(integrator)
-        integrator.u[2] = -integrator.p[2] * integrator.u[2]
+        return integrator.u[2] = -integrator.p[2] * integrator.u[2]
     end
     cb = ContinuousCallback(condition, affect2!, save_positions = (true, true))
 
     cb2 = DiscreteCallback(condition2, affect2!, save_positions = (true, true))
 
     du01,
-    dp1 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb2, tstops = [tstop],
-            sensealg = BacksolveAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp1 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb2, tstops = [tstop],
+                sensealg = BacksolveAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     du02,
-    dp2 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb,
-            sensealg = BacksolveAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp2 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb,
+                sensealg = BacksolveAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     du03,
-    dp3 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb,
-            sensealg = GaussAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp3 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb,
+                sensealg = GaussAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     du04,
-    dp4 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb,
-            sensealg = InterpolatingAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp4 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb,
+                sensealg = InterpolatingAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     du05,
-    dp5 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb,
-            sensealg = QuadratureAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp5 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb,
+                sensealg = QuadratureAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     du06,
-    dp6 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb2, tstops = [tstop],
-            sensealg = GaussAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp6 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb2, tstops = [tstop],
+                sensealg = GaussAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     du07,
-    dp7 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb2, tstops = [tstop],
-            sensealg = InterpolatingAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp7 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb2, tstops = [tstop],
+                sensealg = InterpolatingAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     du08,
-    dp8 = Zygote.gradient(
-        (u0,
-            p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb2, tstops = [tstop],
-            sensealg = QuadratureAdjoint(),
-            saveat = tspan[2], save_start = false)),
-        u0, p)
+        dp8 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb2, tstops = [tstop],
+                sensealg = QuadratureAdjoint(),
+                saveat = tspan[2], save_start = false
+            )
+        ),
+        u0, p
+    )
 
     dstuff = ForwardDiff.gradient(
-        (θ) -> sum(solve(prob, Tsit5(), u0 = θ[1:2], p = θ[3:4],
-            callback = cb, saveat = tspan[2],
-            save_start = false)),
-        [u0; p])
+        (θ) -> sum(
+            solve(
+                prob, Tsit5(), u0 = θ[1:2], p = θ[3:4],
+                callback = cb, saveat = tspan[2],
+                save_start = false
+            )
+        ),
+        [u0; p]
+    )
 
     @info dstuff
     @test du01 ≈ dstuff[1:2]
@@ -262,7 +399,7 @@ function test_continuous_wrt_discrete_callback()
     @test du01 ≈ du02
     @test dp1 ≈ dp2
     @test du01 ≈ du03
-    @test dp1 ≈ dp3
+    return @test dp1 ≈ dp3
 end
 
 @testset "Compare continuous with discrete callbacks" begin

--- a/test/callbacks/forward_sensitivity_callback.jl
+++ b/test/callbacks/forward_sensitivity_callback.jl
@@ -3,14 +3,14 @@ using SciMLSensitivity, Zygote, Test
 import ForwardDiff
 import FiniteDiff
 
-abstol = 1e-6
-reltol = 1e-6
+abstol = 1.0e-6
+reltol = 1.0e-6
 savingtimes = 0.1
 
 function test_discrete_callback(cb, tstops, g)
     function fiip(du, u, p, t)
         #du[1] = dx = p[1]*u[1]
-        du[:] .= p[1] * u
+        return du[:] .= p[1] * u
     end
 
     p = Float64[0.8123198]
@@ -18,42 +18,64 @@ function test_discrete_callback(cb, tstops, g)
 
     prob = ODEProblem(fiip, u0, (0.0, 1.0), p)
 
-    @show g(solve(prob, Tsit5(), callback = cb, tstops = tstops, abstol = abstol,
-        reltol = reltol, saveat = savingtimes))
+    @show g(
+        solve(
+            prob, Tsit5(), callback = cb, tstops = tstops, abstol = abstol,
+            reltol = reltol, saveat = savingtimes
+        )
+    )
 
     du01,
-    dp1 = Zygote.gradient(
-        (u0,
-            p) -> g(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb, tstops = tstops,
-            abstol = abstol, reltol = reltol,
-            saveat = savingtimes,
-            sensealg = ForwardDiffSensitivity(;
-                convert_tspan = true))),
-        u0, p)
+        dp1 = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> g(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb, tstops = tstops,
+                abstol = abstol, reltol = reltol,
+                saveat = savingtimes,
+                sensealg = ForwardDiffSensitivity(;
+                    convert_tspan = true
+                )
+            )
+        ),
+        u0, p
+    )
 
     dstuff1 = ForwardDiff.gradient(
-        (θ) -> g(solve(prob, Tsit5(), u0 = θ[1:1], p = θ[2:2],
-            callback = cb, tstops = tstops,
-            abstol = abstol, reltol = reltol,
-            saveat = savingtimes)),
-        [u0; p])
+        (θ) -> g(
+            solve(
+                prob, Tsit5(), u0 = θ[1:1], p = θ[2:2],
+                callback = cb, tstops = tstops,
+                abstol = abstol, reltol = reltol,
+                saveat = savingtimes
+            )
+        ),
+        [u0; p]
+    )
 
     dstuff2 = FiniteDiff.finite_difference_gradient(
-        (θ) -> g(solve(prob, Tsit5(),
-            u0 = θ[1:1], p = θ[2:2],
-            callback = cb,
-            tstops = tstops,
-            abstol = abstol,
-            reltol = reltol,
-            saveat = savingtimes)),
-        [u0; p])
+        (θ) -> g(
+            solve(
+                prob, Tsit5(),
+                u0 = θ[1:1], p = θ[2:2],
+                callback = cb,
+                tstops = tstops,
+                abstol = abstol,
+                reltol = reltol,
+                saveat = savingtimes
+            )
+        ),
+        [u0; p]
+    )
 
     @show du01 dp1 dstuff1 dstuff2
-    @test du01≈dstuff1[1:1] atol=1e-6
-    @test dp1≈dstuff1[2:2] atol=1e-6
-    @test du01≈dstuff2[1:1] atol=1e-6
-    @test dp1≈dstuff2[2:2] atol=1e-6
+    @test du01 ≈ dstuff1[1:1] atol = 1.0e-6
+    @test dp1 ≈ dstuff1[2:2] atol = 1.0e-6
+    @test du01 ≈ dstuff2[1:1] atol = 1.0e-6
+    return @test dp1 ≈ dstuff2[2:2] atol = 1.0e-6
 end
 
 @testset "ForwardDiffSensitivity: Discrete callbacks" begin

--- a/test/callbacks/non_tracked_callbacks.jl
+++ b/test/callbacks/non_tracked_callbacks.jl
@@ -2,8 +2,8 @@ using SciMLSensitivity, OrdinaryDiffEq, Zygote
 using DiffEqCallbacks
 using Test
 
-abstol = 1e-12
-reltol = 1e-12
+abstol = 1.0e-12
+reltol = 1.0e-12
 
 @testset "Non-tracked callbacks" begin
     function f(du, u, p, t)
@@ -28,12 +28,16 @@ reltol = 1e-12
     cb = SavingCallback((u, t, integrator) -> copy(u[(end - 1):end]), saved_values)
 
     _,
-    res = adjoint_sensitivities(sol, Tsit5(), sensealg = BacksolveAdjoint(), t = t,
-        dgdu_discrete = dg, callback = cb)
+        res = adjoint_sensitivities(
+        sol, Tsit5(), sensealg = BacksolveAdjoint(), t = t,
+        dgdu_discrete = dg, callback = cb
+    )
     _,
-    res2 = adjoint_sensitivities(sol, Tsit5(), sensealg = BacksolveAdjoint(), t = t,
-        dgdu_discrete = dg)
+        res2 = adjoint_sensitivities(
+        sol, Tsit5(), sensealg = BacksolveAdjoint(), t = t,
+        dgdu_discrete = dg
+    )
 
-    @test res≈res2 rtol=1e-10
-    @test sol(saved_values.t).u≈saved_values.saveval rtol=1e-10
+    @test res ≈ res2 rtol = 1.0e-10
+    @test sol(saved_values.t).u ≈ saved_values.saveval rtol = 1.0e-10
 end

--- a/test/callbacks/vector_continuous_callbacks.jl
+++ b/test/callbacks/vector_continuous_callbacks.jl
@@ -1,8 +1,8 @@
 using OrdinaryDiffEq, Zygote
 using SciMLSensitivity, Test, ForwardDiff
 
-abstol = 1e-12
-reltol = 1e-12
+abstol = 1.0e-12
+reltol = 1.0e-12
 savingtimes = 0.5
 
 # see https://docs.sciml.ai/DiffEqDocs/stable/features/callback_functions/#VectorContinuousCallback-Example
@@ -11,47 +11,68 @@ function test_vector_continuous_callback(cb, g)
         du[1] = u[2]
         du[2] = -p[1]
         du[3] = u[4]
-        du[4] = 0.0
+        return du[4] = 0.0
     end
 
     u0 = [50.0, 0.0, 0.0, 2.0]
     tspan = (0.0, 10.0)
     p = [9.8, 0.9]
     prob = ODEProblem(f, u0, tspan, p)
-    sol = solve(prob, Tsit5(), callback = cb, abstol = abstol, reltol = reltol,
-        saveat = savingtimes)
+    sol = solve(
+        prob, Tsit5(), callback = cb, abstol = abstol, reltol = reltol,
+        saveat = savingtimes
+    )
 
     du01,
-    dp1 = @time Zygote.gradient(
-        (u0,
-            p) -> g(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb, abstol = abstol,
-            reltol = reltol,
-            saveat = savingtimes,
-            sensealg = BacksolveAdjoint())),
-        u0, p)
+        dp1 = @time Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> g(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb, abstol = abstol,
+                reltol = reltol,
+                saveat = savingtimes,
+                sensealg = BacksolveAdjoint()
+            )
+        ),
+        u0, p
+    )
 
     du02,
-    dp2 = @time Zygote.gradient(
-        (u0,
-            p) -> g(solve(prob, Tsit5(), u0 = u0, p = p,
-            callback = cb, abstol = abstol,
-            reltol = reltol,
-            saveat = savingtimes,
-            sensealg = GaussAdjoint())),
-        u0, p)
+        dp2 = @time Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> g(
+            solve(
+                prob, Tsit5(), u0 = u0, p = p,
+                callback = cb, abstol = abstol,
+                reltol = reltol,
+                saveat = savingtimes,
+                sensealg = GaussAdjoint()
+            )
+        ),
+        u0, p
+    )
 
     dstuff = @time ForwardDiff.gradient(
-        (θ) -> g(solve(prob, Tsit5(), u0 = θ[1:4],
-            p = θ[5:6], callback = cb,
-            abstol = abstol, reltol = reltol,
-            saveat = savingtimes)),
-        [u0; p])
+        (θ) -> g(
+            solve(
+                prob, Tsit5(), u0 = θ[1:4],
+                p = θ[5:6], callback = cb,
+                abstol = abstol, reltol = reltol,
+                saveat = savingtimes
+            )
+        ),
+        [u0; p]
+    )
 
     @test du01 ≈ dstuff[1:4]
     @test dp1 ≈ dstuff[5:6]
     @test du02 ≈ dstuff[1:4]
-    @test dp2 ≈ dstuff[5:6]
+    return @test dp2 ≈ dstuff[5:6]
 end
 
 @testset "VectorContinuous callbacks" begin

--- a/test/complex_adjoints.jl
+++ b/test/complex_adjoints.jl
@@ -1,31 +1,37 @@
 using SciMLSensitivity, OrdinaryDiffEq, Zygote, LinearAlgebra, FiniteDiff, Test
-A = [1.0*im 2.0; 3.0 4.0]
-u0 = [1.0 0.0*im; 0.0 1.0]
+A = [1.0 * im 2.0; 3.0 4.0]
+u0 = [1.0 0.0 * im; 0.0 1.0]
 tspan = (0.0, 1.0)
 
 function f(u, p, t)
-    (A * u) * (p[1] * t + p[2] * t^2 + p[3] * t^3 + p[4] * t^4)
+    return (A * u) * (p[1] * t + p[2] * t^2 + p[3] * t^3 + p[4] * t^4)
 end
 
 p = [1.5 + im, 1.0, 3.0, 1.0]
 prob = ODEProblem{false}(f, u0, tspan, p)
 
-utarget = [0.0*im 1.0; 1.0 0.0]
+utarget = [0.0 * im 1.0; 1.0 0.0]
 
 function loss_adjoint(p)
-    ufinal = last(solve(prob, Tsit5(), p = p, abstol = 1e-12, reltol = 1e-12,
-        sensealg = InterpolatingAdjoint()))
+    ufinal = last(
+        solve(
+            prob, Tsit5(), p = p, abstol = 1.0e-12, reltol = 1.0e-12,
+            sensealg = InterpolatingAdjoint()
+        )
+    )
     loss = 1 - abs(tr(ufinal * utarget') / 2)^2
     return loss
 end
 
 grad1 = Zygote.gradient(loss_adjoint, Complex{Float64}[1.5, 1.0, 3.0, 1.0])[1]
-grad2 = FiniteDiff.finite_difference_gradient(loss_adjoint,
-    Complex{Float64}[1.5, 1.0, 3.0, 1.0])
+grad2 = FiniteDiff.finite_difference_gradient(
+    loss_adjoint,
+    Complex{Float64}[1.5, 1.0, 3.0, 1.0]
+)
 @test grad1 ≈ grad2
 
 function rhs(u, p, t)
-    p .* u
+    return p .* u
 end
 
 function loss_fun(sol)
@@ -49,16 +55,20 @@ grads = Zygote.gradient((p) -> inner_loop(prob, p, loss_fun), p)[1]
 u0 = [1.0 + 2.0 * im, 2.0 + 1.0 * im]
 prob = ODEProblem(rhs, u0, tspan, p)
 dp1 = Zygote.gradient((p) -> inner_loop(prob, p, loss_fun), p)[1]
-dp2 = Zygote.gradient((p) -> inner_loop(prob, p, loss_fun; sensealg = QuadratureAdjoint()),
-    p)[1]
-dp3 = Zygote.gradient((p) -> inner_loop(prob, p, loss_fun; sensealg = BacksolveAdjoint()),
-    p)[1]
+dp2 = Zygote.gradient(
+    (p) -> inner_loop(prob, p, loss_fun; sensealg = QuadratureAdjoint()),
+    p
+)[1]
+dp3 = Zygote.gradient(
+    (p) -> inner_loop(prob, p, loss_fun; sensealg = BacksolveAdjoint()),
+    p
+)[1]
 @test dp1 ≈ dp2 ≈ dp3
 @test eltype(dp1) <: Float64
 
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
 end
 p = [1.5, 1.0, 3.0, 1.0];
 u0 = [1.0; 1.0];
@@ -66,7 +76,7 @@ prob = ODEProblem(fiip, complex(u0), (0.0, 10.0), complex(p))
 
 function sum_of_solution(u0, p)
     _prob = remake(prob, u0 = u0, p = p)
-    real(sum(solve(_prob, Tsit5(), reltol = 1e-6, abstol = 1e-6, saveat = 0.1)))
+    return real(sum(solve(_prob, Tsit5(), reltol = 1.0e-6, abstol = 1.0e-6, saveat = 0.1)))
 end
 
 dx = Zygote.gradient(sum_of_solution, complex(u0), complex(p))

--- a/test/complex_matrix_finitediff.jl
+++ b/test/complex_matrix_finitediff.jl
@@ -22,7 +22,8 @@ prob_ode = ODEProblem(f_nn, u0, tspan, ComponentArray(ip));
 
 function loss_adjoint(p; sensealg = nothing)
     local prediction = solve(
-        prob_ode, BS5(), p = p, abstol = 1e-13, reltol = 1e-13, sensealg = sensealg)
+        prob_ode, BS5(), p = p, abstol = 1.0e-13, reltol = 1.0e-13, sensealg = sensealg
+    )
     local usol = last(prediction)
     local loss = abs(1.0 - abs(tr(usol * utarget') / 2))
     return loss
@@ -32,8 +33,10 @@ dp1 = Zygote.gradient(loss_adjoint, ComponentArray(ip))
 dp2 = ForwardDiff.gradient(loss_adjoint, ComponentArray(ip))
 dp3 = Zygote.gradient(
     x -> loss_adjoint(
-        x, sensealg = InterpolatingAdjoint(autodiff = false, autojacvec = false)),
-    ComponentArray(ip))
+        x, sensealg = InterpolatingAdjoint(autodiff = false, autojacvec = false)
+    ),
+    ComponentArray(ip)
+)
 
-@test dp1[1]≈dp2 atol=1e-2
-@test dp1[1]≈dp3[1] atol=5e-2
+@test dp1[1] ≈ dp2 atol = 1.0e-2
+@test dp1[1] ≈ dp3[1] atol = 5.0e-2

--- a/test/complex_no_u.jl
+++ b/test/complex_no_u.jl
@@ -1,20 +1,24 @@
 using OrdinaryDiffEq, ComponentArrays, Random,
-      SciMLSensitivity, LinearAlgebra, Optimization, OptimizationOptimisers, Lux
+    SciMLSensitivity, LinearAlgebra, Optimization, OptimizationOptimisers, Lux
 nn = Chain(Dense(1, 16), Dense(16, 16, tanh), Dense(16, 2)) |> f64
 ps, st = Lux.setup(Random.default_rng(), nn)
 ps = ComponentArray(ps)
 
 function ode2!(u, p, t)
     f1, f2 = first(nn([t], p, st)) .+ im
-    [-f1^2; f2]
+    return [-f1^2; f2]
 end
 
 tspan = (0.0, 10.0)
 prob = ODEProblem(ode2!, Complex{Float64}[0; 0], tspan, ps)
 
 loss = function (p)
-    sol = last(solve(prob, Tsit5(), p = p,
-        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))))
+    sol = last(
+        solve(
+            prob, Tsit5(), p = p,
+            sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+        )
+    )
     return norm(sol)
 end
 

--- a/test/default_alg_diff.jl
+++ b/test/default_alg_diff.jl
@@ -2,7 +2,7 @@ using ComponentArrays, OrdinaryDiffEq, Lux, Random, SciMLSensitivity, Zygote
 
 function f(du, u, p, t)
     du .= first(nn(u, p, st))
-    nothing
+    return nothing
 end
 
 nn = Dense(8, 8, tanh)
@@ -14,7 +14,7 @@ r = rand(Float32, 8, 64)
 function f2(x)
     prob = ODEProblem(f, r, (0.0f0, 1.0f0), x)
     sol = solve(prob, OrdinaryDiffEq.DefaultODEAlgorithm())
-    sum(last(sol.u))
+    return sum(last(sol.u))
 end
 
 f2(ps)
@@ -23,7 +23,7 @@ Zygote.gradient(f2, ps)
 function f2(x)
     prob = ODEProblem(f, r, (0.0f0, 1.0f0), x)
     sol = solve(prob)
-    sum(last(sol.u))
+    return sum(last(sol.u))
 end
 
 f2(ps)

--- a/test/derivative_shapes.jl
+++ b/test/derivative_shapes.jl
@@ -20,18 +20,24 @@ p = [1.7, 1.0, 3.0, 1.0]
 prob_ode = ODEProblem(f, u0, tspan, p);
 
 fd_ode = ForwardDiff.gradient(p) do p
-    sum(last(solve(prob_ode, Tsit5(), p = p, abstol = 1e-12, reltol = 1e-12)))
+    sum(last(solve(prob_ode, Tsit5(), p = p, abstol = 1.0e-12, reltol = 1.0e-12)))
 end
 
 grad_ode = Zygote.gradient(p) do p
-    sum(last(solve(prob_ode, Tsit5(), p = p, abstol = 1e-12, reltol = 1e-12)))
+    sum(last(solve(prob_ode, Tsit5(), p = p, abstol = 1.0e-12, reltol = 1.0e-12)))
 end[1]
 
-@test fd_ode≈grad_ode rtol=1e-6
+@test fd_ode ≈ grad_ode rtol = 1.0e-6
 
 grad_ode = Zygote.gradient(p) do p
-    sum(last(solve(prob_ode, Tsit5(), p = p, abstol = 1e-12, reltol = 1e-12,
-        sensealg = InterpolatingAdjoint())))
+    sum(
+        last(
+            solve(
+                prob_ode, Tsit5(), p = p, abstol = 1.0e-12, reltol = 1.0e-12,
+                sensealg = InterpolatingAdjoint()
+            )
+        )
+    )
 end[1]
 
-@test fd_ode≈grad_ode rtol=1e-6
+@test fd_ode ≈ grad_ode rtol = 1.0e-6

--- a/test/distributed.jl
+++ b/test/distributed.jl
@@ -14,12 +14,14 @@ function model_distributed(pu0)
     prob = ODEProblem((u, p, t) -> 1.01u .* p, u0, (0.0, 1.0), pa)
 
     function prob_func(prob, i, repeat)
-        remake(prob, u0 = 0.5 .+ i / 100 .* prob.u0)
+        return remake(prob, u0 = 0.5 .+ i / 100 .* prob.u0)
     end
 
     ensemble_prob = EnsembleProblem(prob, prob_func = prob_func)
-    sim = solve(ensemble_prob, Tsit5(), EnsembleDistributed(), saveat = 0.1,
-        trajectories = 100)
+    return sim = solve(
+        ensemble_prob, Tsit5(), EnsembleDistributed(), saveat = 0.1,
+        trajectories = 100
+    )
 end
 
 # loss function
@@ -32,8 +34,12 @@ end
 
 l1 = loss([1.0, 3.0], nothing)
 @show l1
-res = solve(OptimizationProblem(OptimizationFunction(loss, AutoZygote()),
-        [1.0, 3.0]),
-    Adam(0.1); callback = cb, maxiters = 100)
+res = solve(
+    OptimizationProblem(
+        OptimizationFunction(loss, AutoZygote()),
+        [1.0, 3.0]
+    ),
+    Adam(0.1); callback = cb, maxiters = 100
+)
 l2 = loss(res.u, nothing)
 @test 10l2 < l1

--- a/test/ensembles.jl
+++ b/test/ensembles.jl
@@ -1,7 +1,11 @@
 using SciMLSensitivity, OrdinaryDiffEq, Optimization, OptimizationOptimisers, Test, Zygote
 
-@testset "$(i): EnsembleAlg = $(alg)" for (i, alg) in enumerate((EnsembleSerial(),
-    EnsembleThreads(), EnsembleSerial()))
+@testset "$(i): EnsembleAlg = $(alg)" for (i, alg) in enumerate(
+        (
+            EnsembleSerial(),
+            EnsembleThreads(), EnsembleSerial(),
+        )
+    )
     function prob_func(prob, i, repeat)
         remake(prob, u0 = 0.5 .+ i / 100 .* prob.u0)
     end
@@ -21,15 +25,19 @@ using SciMLSensitivity, OrdinaryDiffEq, Optimization, OptimizationOptimisers, Te
     end
 
     cb = function (p, l) # callback function to observe training
-        @info alg=alg loss=l
+        @info alg = alg loss = l
         return false
     end
 
     l1 = loss([1.0, 3.0], nothing)
     @show l1
-    res = solve(OptimizationProblem(OptimizationFunction(loss, AutoZygote()),
-            [1.0, 3.0]),
-        Adam(0.1); callback = cb, maxiters = 10)
+    res = solve(
+        OptimizationProblem(
+            OptimizationFunction(loss, AutoZygote()),
+            [1.0, 3.0]
+        ),
+        Adam(0.1); callback = cb, maxiters = 10
+    )
     l2 = loss(res.u, nothing)
     @test 10l2 < l1
 end

--- a/test/error_messages.jl
+++ b/test/error_messages.jl
@@ -4,12 +4,12 @@ import Tracker, ReverseDiff, ChainRulesCore
 
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
 end
 function foop(u, p, t)
     dx = p[1] * u[1] - p[2] * u[1] * u[2]
     dy = -p[3] * u[2] + p[4] * u[1] * u[2]
-    [dx, dy]
+    return [dx, dy]
 end
 
 p = [1.5, 1.0, 3.0, 1.0];
@@ -20,13 +20,20 @@ proboop = ODEProblem(foop, u0, (0.0, 10.0), p)
 probsteady = SteadyStateProblem(proboop)
 
 @test_throws SciMLSensitivity.AdjointSteadyProblemPairingError Zygote.gradient(
-    (u0,
-        p) -> sum(solve(probsteady,
-        DynamicSS(Tsit5()),
-        u0 = u0,
-        p = p,
-        abstol = 1e-14,
-        reltol = 1e-14,
-        saveat = 0.1,
-        sensealg = QuadratureAdjoint())),
-    u0, p)
+    (
+        u0,
+        p,
+    ) -> sum(
+        solve(
+            probsteady,
+            DynamicSS(Tsit5()),
+            u0 = u0,
+            p = p,
+            abstol = 1.0e-14,
+            reltol = 1.0e-14,
+            saveat = 0.1,
+            sensealg = QuadratureAdjoint()
+        )
+    ),
+    u0, p
+)

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -2,14 +2,14 @@ using SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, Calculus
 using Test
 function fb(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    du[2] = dy = -t * p[3] * u[2] + t * u[1] * u[2]
+    return du[2] = dy = -t * p[3] * u[2] + t * u[1] * u[2]
 end
 function jac(J, u, p, t)
     (x, y, a, b, c) = (u[1], u[2], p[1], p[2], p[3])
     J[1, 1] = a + y * b * -1
     J[2, 1] = t * y
     J[1, 2] = b * x * -1
-    J[2, 2] = t * c * -1 + t * x
+    return J[2, 2] = t * c * -1 + t * x
 end
 function paramjac(pJ, u, p, t)
     (x, y, a, b, c) = (u[1], u[2], p[1], p[2], p[3])
@@ -18,46 +18,61 @@ function paramjac(pJ, u, p, t)
     pJ[1, 2] = -x * y
     pJ[2, 2] = 0.0
     pJ[1, 3] = 0.0
-    pJ[2, 3] = -t * y
+    return pJ[2, 3] = -t * y
 end
 
 f = ODEFunction(fb, jac = jac, paramjac = paramjac)
 p = [1.5, 1.0, 3.0]
 prob = ODEForwardSensitivityProblem(f, [1.0; 1.0], (0.0, 10.0), p)
 probInpl = ODEForwardSensitivityProblem(fb, [1.0; 1.0], (0.0, 10.0), p)
-probnoad = ODEForwardSensitivityProblem(fb, [1.0; 1.0], (0.0, 10.0), p,
-    sensealg = ForwardSensitivity(autodiff = false))
-probnoadjacvec = ODEForwardSensitivityProblem(fb, [1.0; 1.0], (0.0, 10.0), p,
-    sensealg = ForwardSensitivity(autodiff = false,
-        autojacvec = true))
-probnoad2 = ODEForwardSensitivityProblem(f, [1.0; 1.0], (0.0, 10.0), p,
-    sensealg = ForwardSensitivity(autodiff = false))
-probvecmat = ODEForwardSensitivityProblem(fb, [1.0; 1.0], (0.0, 10.0), p,
-    sensealg = ForwardSensitivity(autojacvec = false,
-        autojacmat = true))
+probnoad = ODEForwardSensitivityProblem(
+    fb, [1.0; 1.0], (0.0, 10.0), p,
+    sensealg = ForwardSensitivity(autodiff = false)
+)
+probnoadjacvec = ODEForwardSensitivityProblem(
+    fb, [1.0; 1.0], (0.0, 10.0), p,
+    sensealg = ForwardSensitivity(
+        autodiff = false,
+        autojacvec = true
+    )
+)
+probnoad2 = ODEForwardSensitivityProblem(
+    f, [1.0; 1.0], (0.0, 10.0), p,
+    sensealg = ForwardSensitivity(autodiff = false)
+)
+probvecmat = ODEForwardSensitivityProblem(
+    fb, [1.0; 1.0], (0.0, 10.0), p,
+    sensealg = ForwardSensitivity(
+        autojacvec = false,
+        autojacmat = true
+    )
+)
 
 # tests that the deprecated version still works
 dep_prob_const = ODEForwardSensitivityProblem(
-    fb, [1.0; 1.0], (0.0, 10.0), p, ForwardSensitivity())
+    fb, [1.0; 1.0], (0.0, 10.0), p, ForwardSensitivity()
+)
 
-sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
-@test_broken solve(probInpl, KenCarp4(), abstol = 1e-14, reltol = 1e-14).retcode == :Success
-solInpl = solve(probInpl, KenCarp4(autodiff = false), abstol = 1e-14, reltol = 1e-14)
-solInpl2 = solve(probInpl, Rodas4(autodiff = false), abstol = 1e-10, reltol = 1e-10)
-solnoad = solve(probnoad, KenCarp4(autodiff = false), abstol = 1e-14, reltol = 1e-14)
-solnoadjacvec = solve(probnoadjacvec, KenCarp4(autodiff = false), abstol = 1e-14,
-    reltol = 1e-14)
-solnoad2 = solve(probnoad, KenCarp4(autodiff = false), abstol = 1e-14, reltol = 1e-14)
-solvecmat = solve(probvecmat, Tsit5(), abstol = 1e-14, reltol = 1e-14)
-solve_dep_prob_const = solve(probvecmat, Tsit5(), abstol = 1e-14, reltol = 1e-14)
+sol = solve(prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
+@test_broken solve(probInpl, KenCarp4(), abstol = 1.0e-14, reltol = 1.0e-14).retcode == :Success
+solInpl = solve(probInpl, KenCarp4(autodiff = false), abstol = 1.0e-14, reltol = 1.0e-14)
+solInpl2 = solve(probInpl, Rodas4(autodiff = false), abstol = 1.0e-10, reltol = 1.0e-10)
+solnoad = solve(probnoad, KenCarp4(autodiff = false), abstol = 1.0e-14, reltol = 1.0e-14)
+solnoadjacvec = solve(
+    probnoadjacvec, KenCarp4(autodiff = false), abstol = 1.0e-14,
+    reltol = 1.0e-14
+)
+solnoad2 = solve(probnoad, KenCarp4(autodiff = false), abstol = 1.0e-14, reltol = 1.0e-14)
+solvecmat = solve(probvecmat, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
+solve_dep_prob_const = solve(probvecmat, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
 
 x = sol[1:(sol.prob.f.numindvar), :]
 
 @test sol(5.0) ≈ solnoad(5.0)
 @test sol(5.0) ≈ solnoad2(5.0)
-@test sol(5.0)≈solnoadjacvec(5.0) atol=1e-6 rtol=1e-6
+@test sol(5.0) ≈ solnoadjacvec(5.0) atol = 1.0e-6 rtol = 1.0e-6
 @test sol(5.0) ≈ solInpl(5.0)
-@test isapprox(solInpl(5.0), solInpl2(5.0), rtol = 1e-5)
+@test isapprox(solInpl(5.0), solInpl2(5.0), rtol = 1.0e-5)
 @test sol(5.0) ≈ solvecmat(5.0)
 
 # Get the sensitivities
@@ -68,9 +83,11 @@ dc = sol[(sol.prob.f.numindvar * 3 + 1):(sol.prob.f.numindvar * 4), :]
 
 sense_res1 = [da[:, end] db[:, end] dc[:, end]]
 
-prob = ODEForwardSensitivityProblem(f.f, [1.0; 1.0], (0.0, 10.0), p,
-    ForwardSensitivity(autojacvec = true))
-sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14, saveat = 0.01)
+prob = ODEForwardSensitivityProblem(
+    f.f, [1.0; 1.0], (0.0, 10.0), p,
+    ForwardSensitivity(autojacvec = true)
+)
+sol = solve(prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14, saveat = 0.01)
 x = sol[1:(sol.prob.f.numindvar), :]
 
 # Get the sensitivities
@@ -84,7 +101,7 @@ sense_res2 = [da[:, end] db[:, end] dc[:, end]]
 
 function test_f(p)
     prob = ODEProblem(f, eltype(p).([1.0, 1.0]), (0.0, 10.0), p)
-    solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14, save_everystep = false).u[end]
+    return solve(prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14, save_everystep = false).u[end]
 end
 
 p = [1.5, 1.0, 3.0]
@@ -130,13 +147,15 @@ _, dp_ts = extract_local_sensitivities(sol, sol.t)
 
 ### ForwardDiff version
 
-prob = ODEForwardSensitivityProblem(f.f, [1.0; 1.0], (0.0, 10.0), p,
-    sensealg = ForwardDiffSensitivity())
-sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14, saveat = 0.01)
+prob = ODEForwardSensitivityProblem(
+    f.f, [1.0; 1.0], (0.0, 10.0), p,
+    sensealg = ForwardDiffSensitivity()
+)
+sol = solve(prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14, saveat = 0.01)
 
 xall, dpall = extract_local_sensitivities(sol)
 @test xall ≈ res
-@test dpall[1]≈da atol=1e-9
+@test dpall[1] ≈ da atol = 1.0e-9
 
 _, dpall_matrix = extract_local_sensitivities(sol, Val(true))
 @test mapreduce(x -> x[:, 2], hcat, dpall) == dpall_matrix[2]
@@ -170,7 +189,7 @@ function rober_MM(du, u, p, t)
     du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
     du[2] = k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃
     du[3] = y₁ + y₂ + y₃ - 1
-    nothing
+    return nothing
 end
 function rober_no_MM(du, u, p, t)
     y₁, y₂, y₃ = u
@@ -178,45 +197,58 @@ function rober_no_MM(du, u, p, t)
     du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
     du[2] = k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃
     du[3] = k₂ * y₂^2
-    nothing
+    return nothing
 end
 
 M = [1.0 0 0; 0 1.0 0; 0 0 0]
-p = [0.04, 3e7, 1e4]
+p = [0.04, 3.0e7, 1.0e4]
 u0 = [1.0, 0.0, 0.0]
 tspan = (0.0, 12.0)
 
 f_MM = ODEFunction(rober_MM, mass_matrix = M)
 f_no_MM = ODEFunction(rober_no_MM)
 
-prob_MM_ForwardSensitivity = ODEForwardSensitivityProblem(f_MM, u0, tspan, p,
-    sensealg = ForwardSensitivity())
-sol_MM_ForwardSensitivity = solve(prob_MM_ForwardSensitivity, Rodas4(autodiff = false),
-    reltol = 1e-14, abstol = 1e-14)
+prob_MM_ForwardSensitivity = ODEForwardSensitivityProblem(
+    f_MM, u0, tspan, p,
+    sensealg = ForwardSensitivity()
+)
+sol_MM_ForwardSensitivity = solve(
+    prob_MM_ForwardSensitivity, Rodas4(autodiff = false),
+    reltol = 1.0e-14, abstol = 1.0e-14
+)
 
-prob_MM_ForwardDiffSensitivity = ODEForwardSensitivityProblem(f_MM, u0, tspan, p,
-    sensealg = ForwardDiffSensitivity())
-sol_MM_ForwardDiffSensitivity = solve(prob_MM_ForwardDiffSensitivity,
-    Rodas4(autodiff = false), reltol = 1e-14,
-    abstol = 1e-14)
+prob_MM_ForwardDiffSensitivity = ODEForwardSensitivityProblem(
+    f_MM, u0, tspan, p,
+    sensealg = ForwardDiffSensitivity()
+)
+sol_MM_ForwardDiffSensitivity = solve(
+    prob_MM_ForwardDiffSensitivity,
+    Rodas4(autodiff = false), reltol = 1.0e-14,
+    abstol = 1.0e-14
+)
 
 prob_no_MM = ODEForwardSensitivityProblem(
-    f_no_MM, u0, tspan, p, sensealg = ForwardSensitivity())
-sol_no_MM = solve(prob_no_MM, Rodas4(autodiff = false), reltol = 1e-14, abstol = 1e-14)
+    f_no_MM, u0, tspan, p, sensealg = ForwardSensitivity()
+)
+sol_no_MM = solve(prob_no_MM, Rodas4(autodiff = false), reltol = 1.0e-14, abstol = 1.0e-14)
 
-sen_MM_ForwardSensitivity = extract_local_sensitivities(sol_MM_ForwardSensitivity, 10.0,
-    true)
-sen_MM_ForwardDiffSensitivity = extract_local_sensitivities(sol_MM_ForwardDiffSensitivity,
-    10.0, true)
+sen_MM_ForwardSensitivity = extract_local_sensitivities(
+    sol_MM_ForwardSensitivity, 10.0,
+    true
+)
+sen_MM_ForwardDiffSensitivity = extract_local_sensitivities(
+    sol_MM_ForwardDiffSensitivity,
+    10.0, true
+)
 sen_no_MM = extract_local_sensitivities(sol_no_MM, 10.0, true)
 
-@test sen_MM_ForwardSensitivity[2]≈sen_MM_ForwardDiffSensitivity[2] atol=1e-10 rtol=1e-10
-@test sen_MM_ForwardSensitivity[2]≈sen_no_MM[2] atol=1e-10 rtol=1e-10
+@test sen_MM_ForwardSensitivity[2] ≈ sen_MM_ForwardDiffSensitivity[2] atol = 1.0e-10 rtol = 1.0e-10
+@test sen_MM_ForwardSensitivity[2] ≈ sen_no_MM[2] atol = 1.0e-10 rtol = 1.0e-10
 # Test Float32
 
 function f32(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    du[2] = dy = -p[3] * u[2] + u[1] * u[2]
+    return du[2] = dy = -p[3] * u[2] + u[1] * u[2]
 end
 p = [1.5f0, 1.0f0, 3.0f0]
 prob = ODEForwardSensitivityProblem(f32, [1.0f0; 1.0f0], (0.0f0, 10.0f0), p)
@@ -235,9 +267,12 @@ p = [1.5, 1.0, 3.0, 1.0]
 @test_throws SciMLSensitivity.ForwardSensitivityOutOfPlaceError ODEForwardSensitivityProblem(
     lotka_volterra_oop,
     u0,
-    (0.0,
-        10.0),
-    p)
+    (
+        0.0,
+        10.0,
+    ),
+    p
+)
 
 # Make sure original jac is actually called if it is passed and autodiff is fully off
 jac_call_count = 0
@@ -248,22 +283,26 @@ function jac_with_count(J, u, p, t)
     J[1, 1] = a + y * b * -1
     J[2, 1] = t * y
     J[1, 2] = b * x * -1
-    J[2, 2] = t * c * -1 + t * x
+    return J[2, 2] = t * c * -1 + t * x
 end
 
 f = ODEFunction(fb, jac = jac_with_count, paramjac = paramjac)
 p = [1.5, 1.0, 3.0]
-absolutely_no_ad_sensealg = ForwardSensitivity(autodiff = false,
+absolutely_no_ad_sensealg = ForwardSensitivity(
+    autodiff = false,
     autojacvec = false,
-    autojacmat = false)
-prob = ODEForwardSensitivityProblem(f,
+    autojacmat = false
+)
+prob = ODEForwardSensitivityProblem(
+    f,
     [1.0; 1.0],
     (0.0, 10.0),
     p,
-    sensealg = absolutely_no_ad_sensealg)
+    sensealg = absolutely_no_ad_sensealg
+)
 @test SciMLSensitivity.has_original_jac(prob.f)
 @assert jac_call_count == 0
-solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
+solve(prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14)
 @test jac_call_count > 0
 
 # Observed delegation

--- a/test/forward_chunking.jl
+++ b/test/forward_chunking.jl
@@ -2,12 +2,12 @@ using SciMLSensitivity, OrdinaryDiffEq, Zygote, Test, ForwardDiff
 
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * p[51] * p[75] * u[1] * u[2]
-    du[2] = dy = -p[3] * p[81] * p[25] * u[2] + (sum(@view(p[4:end])) / 100) * u[1] * u[2]
+    return du[2] = dy = -p[3] * p[81] * p[25] * u[2] + (sum(@view(p[4:end])) / 100) * u[1] * u[2]
 end
 function foop(u, p, t)
     dx = p[1] * u[1] - p[2] * p[51] * p[75] * u[1] * u[2]
     dy = -p[3] * p[81] * p[25] * u[2] + (sum(@view(p[4:end])) / 100) * p[4] * u[1] * u[2]
-    [dx, dy]
+    return [dx, dy]
 end
 
 p = [1.5, 1.0, 3.0, 1.0];
@@ -16,69 +16,105 @@ p = reshape(vcat(p, ones(100)), 4, 26)
 prob = ODEProblem(fiip, u0, (0.0, 10.0), p)
 proboop = ODEProblem(foop, u0, (0.0, 10.0), p)
 
-loss = (u0,
-    p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p, abstol = 1e-14, reltol = 1e-14,
-    saveat = 0.1, sensealg = ForwardDiffSensitivity()))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        prob, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14, reltol = 1.0e-14,
+        saveat = 0.1, sensealg = ForwardDiffSensitivity()
+    )
+)
 @time du01, dp1 = Zygote.gradient(loss, u0, p)
 
-loss = (u0,
-    p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p, abstol = 1e-14, reltol = 1e-14,
-    saveat = 0.1, sensealg = InterpolatingAdjoint()))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        prob, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14, reltol = 1.0e-14,
+        saveat = 0.1, sensealg = InterpolatingAdjoint()
+    )
+)
 @time du02, dp2 = Zygote.gradient(loss, u0, p)
 
-loss = (u0,
-    p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p, abstol = 1e-14, reltol = 1e-14,
-    saveat = 0.1,
-    sensealg = ForwardDiffSensitivity(chunk_size = 104)))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        prob, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14, reltol = 1.0e-14,
+        saveat = 0.1,
+        sensealg = ForwardDiffSensitivity(chunk_size = 104)
+    )
+)
 @time du03, dp3 = Zygote.gradient(loss, u0, p)
 
 dp = ForwardDiff.gradient(p -> loss(u0, p), p)
 du0 = ForwardDiff.gradient(u0 -> loss(u0, p), u0)
 
-@test du01≈du0 rtol=1e-12
-@test du01≈du02 rtol=1e-12
-@test du01≈du03 rtol=1e-12
-@test dp1≈dp rtol=1e-12
-@test dp1≈dp2 rtol=1e-12
-@test dp1≈dp3 rtol=1e-12
+@test du01 ≈ du0 rtol = 1.0e-12
+@test du01 ≈ du02 rtol = 1.0e-12
+@test du01 ≈ du03 rtol = 1.0e-12
+@test dp1 ≈ dp rtol = 1.0e-12
+@test dp1 ≈ dp2 rtol = 1.0e-12
+@test dp1 ≈ dp3 rtol = 1.0e-12
 
-loss = (u0,
-    p) -> sum(solve(proboop, Tsit5(), u0 = u0, p = p, abstol = 1e-14,
-    reltol = 1e-14, saveat = 0.1,
-    sensealg = ForwardDiffSensitivity()))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        proboop, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14,
+        reltol = 1.0e-14, saveat = 0.1,
+        sensealg = ForwardDiffSensitivity()
+    )
+)
 @time du01, dp1 = Zygote.gradient(loss, u0, p)
 
-loss = (u0,
-    p) -> sum(solve(proboop, Tsit5(), u0 = u0, p = p, abstol = 1e-14,
-    reltol = 1e-14, saveat = 0.1,
-    sensealg = InterpolatingAdjoint()))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        proboop, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14,
+        reltol = 1.0e-14, saveat = 0.1,
+        sensealg = InterpolatingAdjoint()
+    )
+)
 @time du02, dp2 = Zygote.gradient(loss, u0, p)
 
-loss = (u0,
-    p) -> sum(solve(proboop, Tsit5(), u0 = u0, p = p, abstol = 1e-14,
-    reltol = 1e-14, saveat = 0.1,
-    sensealg = ForwardDiffSensitivity(chunk_size = 104)))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        proboop, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14,
+        reltol = 1.0e-14, saveat = 0.1,
+        sensealg = ForwardDiffSensitivity(chunk_size = 104)
+    )
+)
 @time du03, dp3 = Zygote.gradient(loss, u0, p)
 
 dp = ForwardDiff.gradient(p -> loss(u0, p), p)
 du0 = ForwardDiff.gradient(u0 -> loss(u0, p), u0)
 
-@test du01≈du0 rtol=1e-12
-@test du01≈du02 rtol=1e-12
-@test du01≈du03 rtol=1e-12
-@test dp1≈dp rtol=1e-12
-@test dp1≈dp2 rtol=1e-12
-@test dp1≈dp3 rtol=1e-12
+@test du01 ≈ du0 rtol = 1.0e-12
+@test du01 ≈ du02 rtol = 1.0e-12
+@test du01 ≈ du03 rtol = 1.0e-12
+@test dp1 ≈ dp rtol = 1.0e-12
+@test dp1 ≈ dp2 rtol = 1.0e-12
+@test dp1 ≈ dp3 rtol = 1.0e-12
 
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
     du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
-    du[3:end] .= p[4]
+    return du[3:end] .= p[4]
 end
 function foop(u, p, t)
     dx = p[1] * u[1] - p[2] * u[1] * u[2]
     dy = -p[3] * u[2] + p[4] * u[1] * u[2]
-    reshape(vcat(dx, dy, repeat([p[4]], 100)), 2, 51)
+    return reshape(vcat(dx, dy, repeat([p[4]], 100)), 2, 51)
 end
 
 p = [1.5, 1.0, 3.0, 1.0];
@@ -87,56 +123,92 @@ u0 = reshape(vcat(u0, ones(100)), 2, 51)
 prob = ODEProblem(fiip, u0, (0.0, 10.0), p)
 proboop = ODEProblem(foop, u0, (0.0, 10.0), p)
 
-loss = (u0,
-    p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p, abstol = 1e-14, reltol = 1e-14,
-    saveat = 0.1, sensealg = ForwardDiffSensitivity()))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        prob, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14, reltol = 1.0e-14,
+        saveat = 0.1, sensealg = ForwardDiffSensitivity()
+    )
+)
 @time du01, dp1 = Zygote.gradient(loss, u0, p)
 
-loss = (u0,
-    p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p, abstol = 1e-14, reltol = 1e-14,
-    saveat = 0.1, sensealg = InterpolatingAdjoint()))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        prob, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14, reltol = 1.0e-14,
+        saveat = 0.1, sensealg = InterpolatingAdjoint()
+    )
+)
 @time du02, dp2 = Zygote.gradient(loss, u0, p)
 
-loss = (u0,
-    p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p, abstol = 1e-14, reltol = 1e-14,
-    saveat = 0.1,
-    sensealg = ForwardDiffSensitivity(chunk_size = 102)))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        prob, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14, reltol = 1.0e-14,
+        saveat = 0.1,
+        sensealg = ForwardDiffSensitivity(chunk_size = 102)
+    )
+)
 @time du03, dp3 = Zygote.gradient(loss, u0, p)
 
 dp = ForwardDiff.gradient(p -> loss(u0, p), p)
 du0 = ForwardDiff.gradient(u0 -> loss(u0, p), u0)
 
-@test du01≈du0 rtol=1e-12
-@test du01≈du02 rtol=1e-12
-@test du01≈du03 rtol=1e-12
-@test dp1≈dp rtol=1e-12
-@test dp1≈dp2 rtol=1e-12
-@test dp1≈dp3 rtol=1e-12
+@test du01 ≈ du0 rtol = 1.0e-12
+@test du01 ≈ du02 rtol = 1.0e-12
+@test du01 ≈ du03 rtol = 1.0e-12
+@test dp1 ≈ dp rtol = 1.0e-12
+@test dp1 ≈ dp2 rtol = 1.0e-12
+@test dp1 ≈ dp3 rtol = 1.0e-12
 
-loss = (u0,
-    p) -> sum(solve(proboop, Tsit5(), u0 = u0, p = p, abstol = 1e-14,
-    reltol = 1e-14, saveat = 0.1,
-    sensealg = ForwardDiffSensitivity()))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        proboop, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14,
+        reltol = 1.0e-14, saveat = 0.1,
+        sensealg = ForwardDiffSensitivity()
+    )
+)
 @time du01, dp1 = Zygote.gradient(loss, u0, p)
 
-loss = (u0,
-    p) -> sum(solve(proboop, Tsit5(), u0 = u0, p = p, abstol = 1e-14,
-    reltol = 1e-14, saveat = 0.1,
-    sensealg = InterpolatingAdjoint()))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        proboop, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14,
+        reltol = 1.0e-14, saveat = 0.1,
+        sensealg = InterpolatingAdjoint()
+    )
+)
 @time du02, dp2 = Zygote.gradient(loss, u0, p)
 
-loss = (u0,
-    p) -> sum(solve(proboop, Tsit5(), u0 = u0, p = p, abstol = 1e-14,
-    reltol = 1e-14, saveat = 0.1,
-    sensealg = ForwardDiffSensitivity(chunk_size = 102)))
+loss = (
+    u0,
+    p,
+) -> sum(
+    solve(
+        proboop, Tsit5(), u0 = u0, p = p, abstol = 1.0e-14,
+        reltol = 1.0e-14, saveat = 0.1,
+        sensealg = ForwardDiffSensitivity(chunk_size = 102)
+    )
+)
 @time du03, dp3 = Zygote.gradient(loss, u0, p)
 
 dp = ForwardDiff.gradient(p -> loss(u0, p), p)
 du0 = ForwardDiff.gradient(u0 -> loss(u0, p), u0)
 
-@test du01≈du0 rtol=1e-12
-@test du01≈du02 rtol=1e-12
-@test du01≈du03 rtol=1e-12
-@test dp1≈dp rtol=1e-12
-@test dp1≈dp2 rtol=1e-12
-@test dp1≈dp3 rtol=1e-12
+@test du01 ≈ du0 rtol = 1.0e-12
+@test du01 ≈ du02 rtol = 1.0e-12
+@test du01 ≈ du03 rtol = 1.0e-12
+@test dp1 ≈ dp rtol = 1.0e-12
+@test dp1 ≈ dp2 rtol = 1.0e-12
+@test dp1 ≈ dp3 rtol = 1.0e-12

--- a/test/forward_prob_kwargs.jl
+++ b/test/forward_prob_kwargs.jl
@@ -9,16 +9,20 @@ u0 = [1.0, 1.0]
 p = [1.5, 1.0, 3.0, 1.0]
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
 end
 
-prob = ODEProblem(fiip, u0, (0.0, 10.0), [1.5, 1.0, 3.0, 1.0], reltol = 1e-14,
-    abstol = 1e-14)
+prob = ODEProblem(
+    fiip, u0, (0.0, 10.0), [1.5, 1.0, 3.0, 1.0], reltol = 1.0e-14,
+    abstol = 1.0e-14
+)
 function cost(p1)
     _prob = remake(prob, p = vcat(p1, p[2:end]))
-    sol = solve(_prob, Tsit5(), sensealg = ForwardDiffSensitivity(),
-        saveat = 0.1, abstol = 1e-12, reltol = 1e-12)
-    sum(sol)
+    sol = solve(
+        _prob, Tsit5(), sensealg = ForwardDiffSensitivity(),
+        saveat = 0.1, abstol = 1.0e-12, reltol = 1.0e-12
+    )
+    return sum(sol)
 end
 res = FiniteDiff.finite_difference_derivative(cost, p[1]) #  8.305557728239275
 res2 = ForwardDiff.derivative(cost, p[1]) # 8.305305252400714 # only 1 dual number
@@ -26,9 +30,11 @@ res3 = Zygote.gradient(cost, p[1])[1] # (8.305266428305409,) # 4 dual numbers
 
 function cost(p1)
     _prob = remake(prob, p = vcat(p1, p[2:end]))
-    sol = solve(_prob, Tsit5(), sensealg = ForwardSensitivity(),
-        saveat = 0.1, abstol = 1e-12, reltol = 1e-12)
-    sum(sol)
+    sol = solve(
+        _prob, Tsit5(), sensealg = ForwardSensitivity(),
+        saveat = 0.1, abstol = 1.0e-12, reltol = 1.0e-12
+    )
+    return sum(sol)
 end
 res4 = Zygote.gradient(cost, p[1])[1] # (7.720368430265481,)
 

--- a/test/forward_remake.jl
+++ b/test/forward_remake.jl
@@ -2,11 +2,11 @@ using SciMLSensitivity, ForwardDiff, Distributions, OrdinaryDiffEq, LinearAlgebr
 
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
 end
 function g(sol)
     J = extract_local_sensitivities(sol, true)[2]
-    det(J' * J)
+    return det(J' * J)
 end
 
 u0 = [1.0, 1.0]
@@ -22,35 +22,39 @@ function fiip_expe_SciML_forw_sen_SciML()
     prob_func = function (prob, i, repeat)
         _prob = remake(
             prob, u0 = [isa(ui, Distribution) ? rand(ui) : ui for ui in u0_dist],
-            p = [isa(pj, Distribution) ? rand(pj) : pj for pj in p_dist])
-        _prob
+            p = [isa(pj, Distribution) ? rand(pj) : pj for pj in p_dist]
+        )
+        return _prob
     end
     output_func = function (sol, i)
-        (g(sol), false)
+        return (g(sol), false)
     end
     monte_prob = EnsembleProblem(prob; output_func = output_func, prob_func = prob_func)
     sol = solve(monte_prob, Tsit5(), EnsembleSerial(), trajectories = 100_000)
-    mean(sol.u)
+    return mean(sol.u)
 end
 
-@test fiip_expe_SciML_forw_sen_SciML()≈3.56e6 rtol=4e-2
+@test fiip_expe_SciML_forw_sen_SciML() ≈ 3.56e6 rtol = 4.0e-2
 
 # `remake`: https://github.com/SciML/SciMLSensitivity.jl/issues/1137
 
 function ff3(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    du[2] = dy = -p[3] * u[2] + u[1] * u[2]
+    return du[2] = dy = -p[3] * u[2] + u[1] * u[2]
 end
 
 p = [1.5, 1.0, 3.0]
 ts = (0, 10)
 prob = ODEForwardSensitivityProblem(
-    ff3, [1.0; 1.0], ts, p, sensealg = ForwardDiffSensitivity())
+    ff3, [1.0; 1.0], ts, p, sensealg = ForwardDiffSensitivity()
+)
 sol = solve(prob, Tsit5())
 
 # https://github.com/SciML/SciMLSensitivity.jl/issues/1143
 
-prob1 = ODEForwardSensitivityProblem(ff3, [1.0, 1.0], (0.0, 10.0), p,
-    sensealg = ForwardSensitivity())
+prob1 = ODEForwardSensitivityProblem(
+    ff3, [1.0, 1.0], (0.0, 10.0), p,
+    sensealg = ForwardSensitivity()
+)
 prob2 = remake(prob1, tspan = (0.0, 10.0))
 @test length(prob1.u0) == length(prob2.u0) == 8

--- a/test/gpu/diffeqflux_standard_gpu.jl
+++ b/test/gpu/diffeqflux_standard_gpu.jl
@@ -12,7 +12,7 @@ tspan = (0.0f0, 1.5f0)
 tsteps = range(tspan[1], tspan[2], length = datasize)
 function trueODEfunc(du, u, p, t)
     true_A = cu(Float32[-0.1 2.0; -2.0 -0.1])
-    du .= ((u .^ 3)'true_A)'
+    return du .= ((u .^ 3)'true_A)'
 end
 prob_trueode = ODEProblem(trueODEfunc, gdev(u0), tspan)
 # Make the data into a GPU-based array if the user has a GPU
@@ -26,7 +26,7 @@ ps, st = Lux.setup(Random.default_rng(), dudt2)
 ps = ComponentArray(ps) |> gdev
 
 function predict_neuralode(p)
-    first(prob_neuralode(u0, p, st))
+    return first(prob_neuralode(u0, p, st))
 end
 function loss_neuralode(p)
     pred = predict_neuralode(p)

--- a/test/hybrid_de.jl
+++ b/test/hybrid_de.jl
@@ -7,11 +7,11 @@ tspan = (0.0f0, 10.5f0)
 dosetimes = [1.0, 2.0, 4.0, 8.0]
 
 function affect!(integrator)
-    integrator.u = integrator.u .+ 1
+    return integrator.u = integrator.u .+ 1
 end
 cb_ = PresetTimeCallback(dosetimes, affect!, save_positions = (false, false))
 function trueODEfunc(du, u, p, t)
-    du .= -u
+    return du .= -u
 end
 t = range(tspan[1], tspan[2], length = datasize)
 
@@ -23,7 +23,7 @@ ps = ComponentArray(ps)
 
 function dudt(du, u, p, t)
     du[1:2] .= -u[1:2]
-    du[3:end] .= first(dudt2(u[1:2], p, st))
+    return du[3:end] .= first(dudt2(u[1:2], p, st))
 end
 z0 = Float32[u0; u0]
 prob = ODEProblem(dudt, z0, tspan)
@@ -32,14 +32,18 @@ affect!(integrator) = integrator.u[1:2] .= integrator.u[3:end]
 cb = PresetTimeCallback(dosetimes, affect!, save_positions = (false, false))
 
 function predict_n_ode(ps)
-    Array(solve(prob, Tsit5(), u0 = z0, p = ps, callback = cb, saveat = t,
-        sensealg = ReverseDiffAdjoint()))[1:2, :]
+    return Array(
+        solve(
+            prob, Tsit5(), u0 = z0, p = ps, callback = cb, saveat = t,
+            sensealg = ReverseDiffAdjoint()
+        )
+    )[1:2, :]
 end
 
 function loss_n_ode(ps, _)
     pred = predict_n_ode(ps)
     loss = sum(abs2, ode_data .- pred)
-    loss
+    return loss
 end
 loss_n_ode(ps, nothing)
 
@@ -48,7 +52,11 @@ cba = function (p, l) #callback function to observe training
     return false
 end
 
-res = solve(OptimizationProblem(OptimizationFunction(loss_n_ode, AutoZygote()),
-        ps),
-    Adam(0.05); callback = cba, maxiters = 200)
+res = solve(
+    OptimizationProblem(
+        OptimizationFunction(loss_n_ode, AutoZygote()),
+        ps
+    ),
+    Adam(0.05); callback = cba, maxiters = 200
+)
 @test loss_n_ode(res.u, nothing) < 1.0

--- a/test/layers.jl
+++ b/test/layers.jl
@@ -4,18 +4,20 @@ function lotka_volterra(du, u, p, t)
     x, y = u
     α, β, δ, γ = p
     du[1] = dx = (α - β * y)x
-    du[2] = dy = (δ * x - γ)y
+    return du[2] = dy = (δ * x - γ)y
 end
 p = [2.2, 1.0, 2.0, 0.4]
 u0 = [1.0, 1.0]
 prob = ODEProblem(lotka_volterra, u0, (0.0, 10.0), p)
 
-@testset "sensealg: $(sensealg)" for sensealg in (TrackerAdjoint(),
-    ForwardDiffSensitivity(), nothing)
+@testset "sensealg: $(sensealg)" for sensealg in (
+        TrackerAdjoint(),
+        ForwardDiffSensitivity(), nothing,
+    )
     function predict(pu0)
         p = pu0[1:4]
         u0 = pu0[5:6]
-        vec(Array(solve(prob, Tsit5(); p, u0, saveat = 0.1, reltol = 1e-4, sensealg)))
+        vec(Array(solve(prob, Tsit5(); p, u0, saveat = 0.1, reltol = 1.0e-4, sensealg)))
     end
     loss(pu0, _) = sum(abs2, x .- 1 for x in predict(pu0))
 
@@ -23,15 +25,19 @@ prob = ODEProblem(lotka_volterra, u0, (0.0, 10.0), p)
     @test !iszero(grads[1])
 
     cb = function (p, l)
-        @info sensealg loss=l
+        @info sensealg loss = l
         return false
     end
 
     l1 = loss([p; u0], nothing)
     @show l1
-    res = solve(OptimizationProblem(OptimizationFunction(loss, AutoZygote()),
-            [p; u0]),
-        Adam(0.1); callback = cb, maxiters = 100)
+    res = solve(
+        OptimizationProblem(
+            OptimizationFunction(loss, AutoZygote()),
+            [p; u0]
+        ),
+        Adam(0.1); callback = cb, maxiters = 100
+    )
     l2 = loss(res.u, nothing)
     @test 10l2 < l1
 end

--- a/test/layers_dde.jl
+++ b/test/layers_dde.jl
@@ -5,26 +5,32 @@ function delay_lotka_volterra(du, u, h, p, t)
     x, y = u
     α, β, δ, γ = p
     du[1] = dx = (α - β * y) * h(p, t - 0.1)[1]
-    du[2] = dy = (δ * x - γ) * y
+    return du[2] = dy = (δ * x - γ) * y
 end
 h(p, t) = ones(eltype(p), 2)
 prob = DDEProblem(delay_lotka_volterra, [1.0, 1.0], h, (0.0, 10.0), constant_lags = [0.1])
 p = [2.2, 1.0, 2.0, 0.4]
 function predict_fd_dde(p)
-    solve(prob, MethodOfSteps(Tsit5()), p = p, saveat = 0.0:0.1:10.0, reltol = 1e-4,
-        sensealg = ForwardDiffSensitivity())[1, :]
+    return solve(
+        prob, MethodOfSteps(Tsit5()), p = p, saveat = 0.0:0.1:10.0, reltol = 1.0e-4,
+        sensealg = ForwardDiffSensitivity()
+    )[1, :]
 end
 loss_fd_dde(p) = sum(abs2, x - 1 for x in predict_fd_dde(p))
 loss_fd_dde(p)
 @test !iszero(Zygote.gradient(loss_fd_dde, p)[1])
 
 function predict_rd_dde(p)
-    solve(prob, MethodOfSteps(Tsit5()), p = p, saveat = 0.1, reltol = 1e-4,
-        sensealg = TrackerAdjoint())[1,
-        :]
+    return solve(
+        prob, MethodOfSteps(Tsit5()), p = p, saveat = 0.1, reltol = 1.0e-4,
+        sensealg = TrackerAdjoint()
+    )[
+        1,
+        :,
+    ]
 end
 loss_rd_dde(p) = sum(abs2, x - 1 for x in predict_rd_dde(p))
 loss_rd_dde(p)
 @test !iszero(Zygote.gradient(loss_rd_dde, p)[1])
 
-@test Zygote.gradient(loss_fd_dde, p)[1]≈Zygote.gradient(loss_rd_dde, p)[1] rtol=1e-2
+@test Zygote.gradient(loss_fd_dde, p)[1] ≈ Zygote.gradient(loss_rd_dde, p)[1] rtol = 1.0e-2

--- a/test/layers_sde.jl
+++ b/test/layers_sde.jl
@@ -4,28 +4,29 @@ function lotka_volterra(du, u, p, t)
     x, y = u
     α, β, δ, γ = p
     du[1] = dx = α * x - β * x * y
-    du[2] = dy = -δ * y + γ * x * y
+    return du[2] = dy = -δ * y + γ * x * y
 end
 function lotka_volterra(u, p, t)
     x, y = u
     α, β, δ, γ = p
     dx = α * x - β * x * y
     dy = -δ * y + γ * x * y
-    [dx, dy]
+    return [dx, dy]
 end
 function lotka_volterra_noise(du, u, p, t)
     du[1] = 0.01u[1]
-    du[2] = 0.01u[2]
+    return du[2] = 0.01u[2]
 end
 function lotka_volterra_noise(u, p, t)
-    [0.01u[1], 0.01u[2]]
+    return [0.01u[1], 0.01u[2]]
 end
 prob = SDEProblem(lotka_volterra, lotka_volterra_noise, [1.0, 1.0], (0.0, 10.0))
 p = [2.2, 1.0, 2.0, 0.4]
 function predict_fd_sde(p)
-    solve(prob, SOSRI(), p = p, saveat = 0.0:0.1:0.5, sensealg = ForwardDiffSensitivity())[
+    return solve(prob, SOSRI(), p = p, saveat = 0.0:0.1:0.5, sensealg = ForwardDiffSensitivity())[
         1,
-        :]
+        :,
+    ]
 end
 loss_fd_sde(p) = sum(abs2, x - 1 for x in predict_fd_sde(p))
 loss_fd_sde(p)
@@ -33,9 +34,10 @@ loss_fd_sde(p)
 prob = SDEProblem{false}(lotka_volterra, lotka_volterra_noise, [1.0, 1.0], (0.0, 10.0))
 p = [2.2, 1.0, 2.0, 0.4]
 function predict_fd_sde(p)
-    solve(prob, SOSRI(), p = p, saveat = 0.0:0.1:0.5, sensealg = ForwardDiffSensitivity())[
+    return solve(prob, SOSRI(), p = p, saveat = 0.0:0.1:0.5, sensealg = ForwardDiffSensitivity())[
         1,
-        :]
+        :,
+    ]
 end
 loss_fd_sde(p) = sum(abs2, x - 1 for x in predict_fd_sde(p))
 loss_fd_sde(p)
@@ -44,14 +46,14 @@ loss_fd_sde(p)
 
 prob = SDEProblem(lotka_volterra, lotka_volterra_noise, [1.0, 1.0], (0.0, 0.5))
 function predict_rd_sde(p)
-    solve(prob, SOSRI(), p = p, saveat = 0.0:0.1:0.5, sensealg = TrackerAdjoint())[1, :]
+    return solve(prob, SOSRI(), p = p, saveat = 0.0:0.1:0.5, sensealg = TrackerAdjoint())[1, :]
 end
 loss_rd_sde(p) = sum(abs2, x - 1 for x in predict_rd_sde(p))
 @test !iszero(Zygote.gradient(loss_rd_sde, p)[1])
 
 prob = SDEProblem{false}(lotka_volterra, lotka_volterra_noise, [1.0, 1.0], (0.0, 0.5))
 function predict_rd_sde(p)
-    solve(prob, SOSRI(), p = p, saveat = 0.0:0.1:0.5, sensealg = TrackerAdjoint())[1, :]
+    return solve(prob, SOSRI(), p = p, saveat = 0.0:0.1:0.5, sensealg = TrackerAdjoint())[1, :]
 end
 loss_rd_sde(p) = sum(abs2, x - 1 for x in predict_rd_sde(p))
 @test !iszero(Zygote.gradient(loss_rd_sde, p)[1])

--- a/test/lazybuffer.jl
+++ b/test/lazybuffer.jl
@@ -22,8 +22,10 @@ using Random, FiniteDiff, ForwardDiff, ReverseDiff, SciMLSensitivity, Zygote
 
     function loss(u0, p; sensealg = nothing)
         _prob = remake(prob, u0 = u0, p = p)
-        _sol = solve(_prob, Tsit5(), sensealg = sensealg, saveat = 0.1, abstol = 1e-14,
-            reltol = 1e-14)
+        _sol = solve(
+            _prob, Tsit5(), sensealg = sensealg, saveat = 0.1, abstol = 1.0e-14,
+            reltol = 1.0e-14
+        )
         sum(abs2, _sol)
     end
 
@@ -33,15 +35,20 @@ using Random, FiniteDiff, ForwardDiff, ReverseDiff, SciMLSensitivity, Zygote
     dp = FiniteDiff.finite_difference_gradient(p -> loss(u0, p), p)
     Fdu0 = ForwardDiff.gradient(u0 -> loss(u0, p), u0)
     Fdp = ForwardDiff.gradient(p -> loss(u0, p), p)
-    @test du0≈Fdu0 rtol=1e-8
-    @test dp≈Fdp rtol=1e-8
+    @test du0 ≈ Fdu0 rtol = 1.0e-8
+    @test dp ≈ Fdp rtol = 1.0e-8
 
     Zdu0,
-    Zdp = Zygote.gradient(
-        (u0,
-            p) -> loss(u0, p;
-            sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())),
-        u0, p)
-    @test du0≈Zdu0 rtol=1e-8
-    @test dp≈Zdp rtol=1e-8
+        Zdp = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> loss(
+            u0, p;
+            sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+        ),
+        u0, p
+    )
+    @test du0 ≈ Zdu0 rtol = 1.0e-8
+    @test dp ≈ Zdp rtol = 1.0e-8
 end

--- a/test/literal_adjoint.jl
+++ b/test/literal_adjoint.jl
@@ -3,7 +3,7 @@ function lv!(du, u, p, t)
     x, y = u
     a, b, c, d = p
     du[1] = a * x - b * x * y
-    du[2] = -c * y + d * x * y
+    return du[2] = -c * y + d * x * y
 end
 function test(u0, p)
     tspan = [0.0, 1.0]

--- a/test/mixed_costs.jl
+++ b/test/mixed_costs.jl
@@ -4,13 +4,13 @@ using ForwardDiff, FiniteDiff, Zygote
 using QuadGK
 using Test
 
-abstol = 1e-14
-reltol = 1e-14
+abstol = 1.0e-14
+reltol = 1.0e-14
 savingtimes = collect(1.0:9.0)
 
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
 end
 
 ## Continuous cost functionals
@@ -22,9 +22,11 @@ function continuous_cost_forward(input)
     prob = ODEProblem(fiip, u0, (0.0, 10.0), p)
     sol = solve(prob, Tsit5(), abstol = abstol, reltol = reltol)
     cost,
-    err = quadgk((t) -> sol(t)[1]^2 + p[1], prob.tspan..., atol = abstol,
-        rtol = reltol)
-    cost
+        err = quadgk(
+        (t) -> sol(t)[1]^2 + p[1], prob.tspan..., atol = abstol,
+        rtol = reltol
+    )
+    return cost
 end
 p = [1.5, 1.0, 3.0, 1.0]
 u0 = [1.0; 1.0]
@@ -39,122 +41,156 @@ sol = solve(prob, Tsit5(), reltol = reltol, abstol = abstol)
 g(u, p, t) = u[1]^2 + p[1]
 function dgdu(out, u, p, t)
     out[1] = 2u[1]
-    out[2] = 0.0
+    return out[2] = 0.0
 end
 function dgdp(out, u, p, t)
     out[1] = 1.0
     out[2] = 0.0
     out[3] = 0.0
-    out[4] = 0.0
+    return out[4] = 0.0
 end
 
 # BacksolveAdjoint, all vjps
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
     sensealg = BacksolveAdjoint(autojacvec = EnzymeVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
     sensealg = BacksolveAdjoint(autojacvec = TrackerVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
     sensealg = BacksolveAdjoint(autojacvec = false),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # InterpolatingAdjoint, all vjps
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
     sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
     sensealg = InterpolatingAdjoint(autojacvec = TrackerVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
     sensealg = InterpolatingAdjoint(autojacvec = false),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # QuadratureAdjoint, all vjps
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
-    sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP(),
+    sensealg = QuadratureAdjoint(
+        autojacvec = EnzymeVJP(),
         abstol = abstol,
-        reltol = reltol),
-    abstol = abstol, reltol = reltol)
+        reltol = reltol
+    ),
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
-    sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP(),
+    sensealg = QuadratureAdjoint(
+        autojacvec = ReverseDiffVJP(),
         abstol = abstol,
-        reltol = reltol),
-    abstol = abstol, reltol = reltol)
+        reltol = reltol
+    ),
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), dgdu_continuous = dgdu,
     dgdp_continuous = dgdp, g = g,
-    sensealg = QuadratureAdjoint(autojacvec = false,
+    sensealg = QuadratureAdjoint(
+        autojacvec = false,
         abstol = abstol,
-        reltol = reltol),
-    abstol = abstol, reltol = reltol)
+        reltol = reltol
+    ),
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 # without dgdu_continuous=dgdu, dgdp_continuous=dgdp
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), g = g,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), g = g,
     sensealg = BacksolveAdjoint(),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 ##
@@ -166,14 +202,17 @@ function discrete_cost_forward(input, sensealg = nothing)
     p = input[3:end]
 
     prob = ODEProblem(fiip, u0, (0.0, 10.0), p)
-    sol = Array(solve(
-        prob, Tsit5(), abstol = abstol, reltol = reltol, saveat = savingtimes,
-        sensealg = sensealg, save_start = false, save_end = false))
+    sol = Array(
+        solve(
+            prob, Tsit5(), abstol = abstol, reltol = reltol, saveat = savingtimes,
+            sensealg = sensealg, save_start = false, save_end = false
+        )
+    )
     cost = zero(eltype(p))
     for u in eachcol(sol)
         cost += u[1]^2 + p[1]
     end
-    cost
+    return cost
 end
 dForwardDiff = ForwardDiff.gradient(discrete_cost_forward, input)
 dFiniteDiff = FiniteDiff.finite_difference_gradient(discrete_cost_forward, input)
@@ -181,131 +220,169 @@ dFiniteDiff = FiniteDiff.finite_difference_gradient(discrete_cost_forward, input
 
 function dgdu(out, u, p, t, i)
     out[1] = 2u[1]
-    out[2] = 0.0
+    return out[2] = 0.0
 end
 function dgdp(out, u, p, t, i)
     out[1] = 1.0
     out[2] = 0.0
     out[3] = 0.0
-    out[4] = 0.0
+    return out[4] = 0.0
 end
 
 # BacksolveAdjoint, all vjps
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
     sensealg = BacksolveAdjoint(autojacvec = EnzymeVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
     sensealg = BacksolveAdjoint(autojacvec = TrackerVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
     sensealg = BacksolveAdjoint(autojacvec = false),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # InterpolatingAdjoint, all vjps
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
     sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
     sensealg = InterpolatingAdjoint(autojacvec = TrackerVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
     sensealg = InterpolatingAdjoint(autojacvec = false),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # QuadratureAdjoint, all vjps
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
-    sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP(),
+    sensealg = QuadratureAdjoint(
+        autojacvec = EnzymeVJP(),
         abstol = abstol,
-        reltol = reltol),
-    abstol = abstol, reltol = reltol)
+        reltol = reltol
+    ),
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
-    sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP(),
+    sensealg = QuadratureAdjoint(
+        autojacvec = ReverseDiffVJP(),
         abstol = abstol,
-        reltol = reltol),
-    abstol = abstol, reltol = reltol)
+        reltol = reltol
+    ),
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp,
-    sensealg = QuadratureAdjoint(autojacvec = false,
+    sensealg = QuadratureAdjoint(
+        autojacvec = false,
         abstol = abstol,
-        reltol = reltol),
-    abstol = abstol, reltol = reltol)
+        reltol = reltol
+    ),
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # concrete solve interface
 dZygote = Zygote.gradient(input -> discrete_cost_forward(input, BacksolveAdjoint()), input)[1]
 @test dZygote ≈ dForwardDiff
-dZygote = Zygote.gradient(input -> discrete_cost_forward(input, InterpolatingAdjoint()),
-    input)[1]
+dZygote = Zygote.gradient(
+    input -> discrete_cost_forward(input, InterpolatingAdjoint()),
+    input
+)[1]
 @test dZygote ≈ dForwardDiff
-dZygote = Zygote.gradient(input -> discrete_cost_forward(input, QuadratureAdjoint()),
-    input)[1]
+dZygote = Zygote.gradient(
+    input -> discrete_cost_forward(input, QuadratureAdjoint()),
+    input
+)[1]
 @test dZygote ≈ dForwardDiff
 # without dg_discrete
 @test_throws ErrorException du0,
-dp=adjoint_sensitivities(sol, Tsit5(), t = savingtimes,
-    g = (u, p, t) -> u[1])
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes,
+    g = (u, p, t) -> u[1]
+)
 @test_throws ErrorException adjoint_sensitivities(sol, Tsit5(), t = savingtimes)
 ##
 
@@ -315,11 +392,15 @@ function mixed_cost_forward(input)
     p = input[3:end]
 
     prob = ODEProblem(fiip, u0, (0.0, 10.0), p)
-    sol = solve(prob, Tsit5(), abstol = abstol, reltol = reltol, save_start = false,
-        save_end = false)
+    sol = solve(
+        prob, Tsit5(), abstol = abstol, reltol = reltol, save_start = false,
+        save_end = false
+    )
     cost,
-    err = quadgk((t) -> sol(t)[1]^2 + p[1], prob.tspan..., atol = abstol,
-        rtol = reltol)
+        err = quadgk(
+        (t) -> sol(t)[1]^2 + p[1], prob.tspan..., atol = abstol,
+        rtol = reltol
+    )
     for t in savingtimes
         cost += (sol(t)[1]^2) + p[2]
     end
@@ -331,150 +412,182 @@ dFiniteDiff = FiniteDiff.finite_difference_gradient(mixed_cost_forward, input)
 
 function dgdu_discrete(out, u, p, t, i)
     out[1] = 2u[1]
-    out[2] = 0.0
+    return out[2] = 0.0
 end
 function dgdp_discrete(out, u, p, t, i)
     out[1] = 0.0
     out[2] = 1.0
     out[3] = 0.0
-    out[4] = 0.0
+    return out[4] = 0.0
 end
 function dgdu_continuous(out, u, p, t)
     out[1] = 2u[1]
-    out[2] = 0.0
+    return out[2] = 0.0
 end
 function dgdp_continuous(out, u, p, t)
     out[1] = 1.0
     out[2] = 0.0
     out[3] = 0.0
-    out[4] = 0.0
+    return out[4] = 0.0
 end
 
 # BacksolveAdjoint, all vjps
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
     sensealg = BacksolveAdjoint(autojacvec = EnzymeVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
     sensealg = BacksolveAdjoint(autojacvec = TrackerVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
     sensealg = BacksolveAdjoint(autojacvec = false),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # InterpolatingAdjoint, all vjps
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
     sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
     sensealg = InterpolatingAdjoint(autojacvec = TrackerVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
     sensealg = InterpolatingAdjoint(autojacvec = false),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
-    abstol = abstol, reltol = reltol)
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # QuadratureAdjoint, all vjps
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
-    sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP(),
+    sensealg = QuadratureAdjoint(
+        autojacvec = EnzymeVJP(),
         abstol = abstol,
-        reltol = reltol),
-    abstol = abstol, reltol = reltol)
+        reltol = reltol
+    ),
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
-    sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP(),
+    sensealg = QuadratureAdjoint(
+        autojacvec = ReverseDiffVJP(),
         abstol = abstol,
-        reltol = reltol),
-    abstol = abstol, reltol = reltol)
+        reltol = reltol
+    ),
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 du0,
-dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+    dp = adjoint_sensitivities(
+    sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
     dgdp_discrete = dgdp_discrete,
     dgdu_continuous = dgdu_continuous,
     dgdp_continuous = dgdp_continuous,
-    sensealg = QuadratureAdjoint(autojacvec = false,
+    sensealg = QuadratureAdjoint(
+        autojacvec = false,
         abstol = abstol,
-        reltol = reltol),
-    abstol = abstol, reltol = reltol)
+        reltol = reltol
+    ),
+    abstol = abstol, reltol = reltol
+)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]

--- a/test/noindex_tests.jl
+++ b/test/noindex_tests.jl
@@ -11,7 +11,7 @@ Base.ndims(::Type{<:CustomArray{T, N}}) where {T, N} = N
 Base.zero(x::CustomArray) = CustomArray(zero(x.x))
 Base.zero(::Type{<:CustomArray{T, N}}) where {T, N} = CustomArray(zero(Array{T, N}))
 function Base.similar(x::CustomArray, dims::Union{Integer, AbstractUnitRange}...)
-    CustomArray(similar(x.x, dims...))
+    return CustomArray(similar(x.x, dims...))
 end
 Base.copyto!(x::CustomArray, y::CustomArray) = CustomArray(copyto!(x.x, y.x))
 Base.copy(x::CustomArray) = CustomArray(copy(x.x))
@@ -41,20 +41,27 @@ CustomStyle(::Val{N}) where {N} = CustomStyle{N}()
 CustomStyle{M}(::Val{N}) where {N, M} = NoIndexStyle{N}()
 Base.BroadcastStyle(::Type{<:CustomArray{T, N}}) where {T, N} = CustomStyle{N}()
 function Broadcast.BroadcastStyle(
-        ::CustomStyle{N}, ::Broadcast.DefaultArrayStyle{0}) where {N}
-    CustomStyle{N}()
+        ::CustomStyle{N}, ::Broadcast.DefaultArrayStyle{0}
+    ) where {N}
+    return CustomStyle{N}()
 end
 function Base.similar(
-        bc::Base.Broadcast.Broadcasted{CustomStyle{N}}, ::Type{ElType}) where {N, ElType}
-    CustomArray(similar(Array{ElType, N}, axes(bc)))
+        bc::Base.Broadcast.Broadcasted{CustomStyle{N}}, ::Type{ElType}
+    ) where {N, ElType}
+    return CustomArray(similar(Array{ElType, N}, axes(bc)))
 end
 Base.@propagate_inbounds Base.Broadcast._broadcast_getindex(x::CustomArray, i) = x.x[i]
 Base.Broadcast.extrude(x::CustomArray) = x
 Base.Broadcast.broadcastable(x::CustomArray) = x
 
-@inline function Base.copyto!(dest::CustomArray,
-        bc::Base.Broadcast.Broadcasted{<:Union{
-            Base.Broadcast.AbstractArrayStyle, CustomStyle}})
+@inline function Base.copyto!(
+        dest::CustomArray,
+        bc::Base.Broadcast.Broadcasted{
+            <:Union{
+                Base.Broadcast.AbstractArrayStyle, CustomStyle,
+            },
+        }
+    )
     axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
     bc′ = Base.Broadcast.preprocess(dest, bc)
     dest′ = dest.x
@@ -88,7 +95,7 @@ Base.show_vector(io::IO, x::CustomArray) = Base.show_vector(io, x.x)
 Base.show(io::IO, x::CustomArray) = (print(io, "CustomArray"); show(io, x.x))
 function Base.show(io::IO, ::MIME"text/plain", x::CustomArray)
     println(io, Base.summary(x), ":")
-    Base.print_array(io, x.x)
+    return Base.print_array(io, x.x)
 end
 
 ca0 = CustomArray(ones(2))
@@ -101,7 +108,8 @@ for alg in algs
     function cost(p)
         prob = ODEProblem(
             (du, u, p, t) -> (du[1] = p[1] * u[1] + p[2] * u[2]; du[2] = p[2] * u[1]),
-            ca0, tspan, p)
+            ca0, tspan, p
+        )
         sol = solve(prob, alg; save_everystep = false)
         return 1 - norm(sol[end])^2
     end

--- a/test/null_parameters.jl
+++ b/test/null_parameters.jl
@@ -8,96 +8,118 @@ dynamics = (x, _p, _t) -> x
 function loss(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0), params)
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true)))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss2(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0), params)
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss3(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0), params)
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = InterpolatingAdjoint(autojacvec = TrackerVJP(allow_nothing = true)))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = InterpolatingAdjoint(autojacvec = TrackerVJP(allow_nothing = true))
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss4(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true)))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss5(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP()))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP())
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss6(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(allow_nothing = true)))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss7(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP(allow_nothing = true)))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss8(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP()))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP())
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss9(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP()))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP())
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss10(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP()))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP())
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss11(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params,
-        sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP()))
-    sum(Array(rollout)[:, end])
+    rollout = solve(
+        problem, Tsit5(), u0 = u0, p = params,
+        sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP())
+    )
+    return sum(Array(rollout)[:, end])
 end
 
 function loss12(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
     rollout = solve(problem, Tsit5(), u0 = u0, p = params)
-    sum(Array(rollout)[:, end])
+    return sum(Array(rollout)[:, end])
 end
 
 @test Zygote.gradient(dynamics, 0.0, nothing, nothing) == (1.0, nothing, nothing)
@@ -129,9 +151,11 @@ end
 ## OOP tests for initial condition
 function loss_oop(u0; sensealg = nothing)
     _prob = ODEProblem(dynamics, u0, (0.0, 1.0))
-    _sol = solve(_prob, Tsit5(), u0 = u0, sensealg = sensealg, abstol = 1e-12,
-        reltol = 1e-12)
-    sum(abs2, Array(_sol)[:, end])
+    _sol = solve(
+        _prob, Tsit5(), u0 = u0, sensealg = sensealg, abstol = 1.0e-12,
+        reltol = 1.0e-12
+    )
+    return sum(abs2, Array(_sol)[:, end])
 end
 
 u0 = ones(2)
@@ -139,79 +163,115 @@ Fdu0 = ForwardDiff.gradient(u0 -> loss_oop(u0), u0)
 
 # BacksolveAdjoint
 du0 = Zygote.gradient(
-    u0 -> loss_oop(u0,
-        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
-    u0)[1]
+    u0 -> loss_oop(
+        u0,
+        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+    ),
+    u0
+)[1]
 @test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(
-    u0 -> loss_oop(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_oop(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_oop(u0,
-        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
-du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = BacksolveAdjoint(autojacvec = false)),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_oop(
+        u0,
+        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
+du0 = Zygote.gradient(
+    u0 -> loss_oop(u0, sensealg = BacksolveAdjoint(autojacvec = false)),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 
 # InterpolatingAdjoint
 du0 = Zygote.gradient(
-    u0 -> loss_oop(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
-    u0)[1]
+    u0 -> loss_oop(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+    ),
+    u0
+)[1]
 @test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(
-    u0 -> loss_oop(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_oop(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_oop(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_oop(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_oop(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = false)),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_oop(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = false)
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 
 # QuadratureAdjoint
 du0 = Zygote.gradient(
-    u0 -> loss_oop(u0,
-        sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
-    u0)[1]
+    u0 -> loss_oop(
+        u0,
+        sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+    ),
+    u0
+)[1]
 @test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(
-    u0 -> loss_oop(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_oop(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_oop(u0,
-        sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
-du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = QuadratureAdjoint(autojacvec = false)),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_oop(
+        u0,
+        sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
+du0 = Zygote.gradient(
+    u0 -> loss_oop(u0, sensealg = QuadratureAdjoint(autojacvec = false)),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 
 # ForwardDiffSensitivity
 du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
-@test Fdu0≈du0 rtol=1e-6
+@test Fdu0 ≈ du0 rtol = 1.0e-6
 du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
-@test Fdu0≈du0 rtol=1e-6
+@test Fdu0 ≈ du0 rtol = 1.0e-6
 du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
-@test Fdu0≈du0 rtol=1e-6
+@test Fdu0 ≈ du0 rtol = 1.0e-6
 
 ## iip tests for initial condition
 dynamics! = (dx, x, _p, _t) -> dx .= x
 
 function loss_iip(u0; sensealg = nothing)
     _prob = ODEProblem(dynamics!, u0, (0.0, 1.0))
-    _sol = solve(_prob, Tsit5(), u0 = u0, sensealg = sensealg, abstol = 1e-12,
-        reltol = 1e-12)
-    sum(abs2, Array(_sol)[:, end])
+    _sol = solve(
+        _prob, Tsit5(), u0 = u0, sensealg = sensealg, abstol = 1.0e-12,
+        reltol = 1.0e-12
+    )
+    return sum(abs2, Array(_sol)[:, end])
 end
 
 u0 = ones(2)
@@ -219,82 +279,125 @@ Fdu0 = ForwardDiff.gradient(u0 -> loss_iip(u0), u0)
 
 # BacksolveAdjoint
 du0 = Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
-    u0)[1]
+    u0 -> loss_iip(
+        u0,
+        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+    ),
+    u0
+)[1]
 @test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_iip(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
-du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = BacksolveAdjoint(autojacvec = false)),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_iip(
+        u0,
+        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = BacksolveAdjoint(autojacvec = EnzymeVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_iip(u0, sensealg = BacksolveAdjoint(autojacvec = false)),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
+du0 = Zygote.gradient(
+    u0 -> loss_iip(
+        u0,
+        sensealg = BacksolveAdjoint(autojacvec = EnzymeVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 
 # InterpolatingAdjoint
 du0 = Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
-    u0)[1]
+    u0 -> loss_iip(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+    ),
+    u0
+)[1]
 @test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_iip(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_iip(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = false)),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_iip(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = false)
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_iip(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 
 # QuadratureAdjoint
 du0 = Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
-    u0)[1]
+    u0 -> loss_iip(
+        u0,
+        sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))
+    ),
+    u0
+)[1]
 @test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_iip(
+        u0,
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
-du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = QuadratureAdjoint(autojacvec = false)),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_iip(
+        u0,
+        sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 du0 = Zygote.gradient(
-    u0 -> loss_iip(u0,
-        sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP())),
-    u0)[1]
-@test Fdu0≈du0 rtol=1e-10
+    u0 -> loss_iip(u0, sensealg = QuadratureAdjoint(autojacvec = false)),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
+du0 = Zygote.gradient(
+    u0 -> loss_iip(
+        u0,
+        sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP())
+    ),
+    u0
+)[1]
+@test Fdu0 ≈ du0 rtol = 1.0e-10
 
 # ForwardDiffSensitivity
 du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
-@test Fdu0≈du0 rtol=1e-6
+@test Fdu0 ≈ du0 rtol = 1.0e-6
 du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
-@test Fdu0≈du0 rtol=1e-6
+@test Fdu0 ≈ du0 rtol = 1.0e-6
 du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
-@test Fdu0≈du0 rtol=1e-6
+@test Fdu0 ≈ du0 rtol = 1.0e-6

--- a/test/parameter_compatibility_errors.jl
+++ b/test/parameter_compatibility_errors.jl
@@ -35,16 +35,20 @@ p2 = [4; 5; 6]
 @test_throws SciMLSensitivity.SciMLStructuresCompatibilityError grad(p2)
 
 function loss(p1)
-    sol = solve(prob, Tsit5(), p = [p1, mystruct(-1, -2), control],
-        sensealg = InterpolatingAdjoint())
+    sol = solve(
+        prob, Tsit5(), p = [p1, mystruct(-1, -2), control],
+        sensealg = InterpolatingAdjoint()
+    )
     return sum(abs2, sol)
 end
 
 @test_throws SciMLSensitivity.AdjointSensitivityParameterCompatibilityError grad(p2)
 
 function loss(p1)
-    sol = solve(prob, Tsit5(), p = [p1, mystruct(-1, -2), control],
-        sensealg = ForwardSensitivity())
+    sol = solve(
+        prob, Tsit5(), p = [p1, mystruct(-1, -2), control],
+        sensealg = ForwardSensitivity()
+    )
     return sum(abs2, sol)
 end
 
@@ -53,4 +57,5 @@ end
     f!,
     u0,
     tspan,
-    p)
+    p
+)

--- a/test/parameter_handling.jl
+++ b/test/parameter_handling.jl
@@ -16,11 +16,13 @@ prob = NonlinearProblem(nlprob, zeros(2, 3), ca)
 
 @test_nowarn solve(prob, NewtonRaphson())
 
-gs = only(Zygote.gradient(ca) do ca
-    prob = NonlinearProblem(nlprob, zero.(x), ca)
-    sol = solve(prob, NewtonRaphson())
-    return sum(sol.u)
-end)
+gs = only(
+    Zygote.gradient(ca) do ca
+        prob = NonlinearProblem(nlprob, zero.(x), ca)
+        sol = solve(prob, NewtonRaphson())
+        return sum(sol.u)
+    end
+)
 
 @test gs.layer_1.weight !== nothing
 @test gs.layer_1.bias !== nothing
@@ -42,11 +44,13 @@ prob = ODEProblem(odeprob, ones(2, 3), (0.0f0, 1.0f0), ca)
 
 @test_nowarn solve(prob, Tsit5())
 
-gs = only(Zygote.gradient(ca) do ca
-    prob = ODEProblem(odeprob, ones(2, 3), (0.0f0, 1.0f0), ca)
-    sol = solve(prob, Tsit5(); sensealg = GaussAdjoint(; autojacvec = ZygoteVJP()))
-    return sum(last(sol.u))
-end)
+gs = only(
+    Zygote.gradient(ca) do ca
+        prob = ODEProblem(odeprob, ones(2, 3), (0.0f0, 1.0f0), ca)
+        sol = solve(prob, Tsit5(); sensealg = GaussAdjoint(; autojacvec = ZygoteVJP()))
+        return sum(last(sol.u))
+    end
+)
 
 @test gs.layer_1.weight !== nothing
 @test gs.layer_1.bias !== nothing

--- a/test/parameter_initialization.jl
+++ b/test/parameter_initialization.jl
@@ -13,21 +13,27 @@ using Test
 @parameters σ ρ β
 @variables x(t) y(t) z(t) w(t)
 
-eqs = [D(D(x)) ~ σ * (y - x),
+eqs = [
+    D(D(x)) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,
     D(z) ~ x * y - β * z,
-    w ~ x + y + z + 2 * β]
+    w ~ x + y + z + 2 * β,
+]
 
-@mtkbuild sys = ODESystem(eqs, t, defaults = [ρ => missing,], guesses = [ρ => 10.0])
+@mtkbuild sys = ODESystem(eqs, t, defaults = [ρ => missing], guesses = [ρ => 10.0])
 
-u0 = [D(x) => 2.0,
+u0 = [
+    D(x) => 2.0,
     x => 1.0,
     y => 0.0,
-    z => 0.0]
+    z => 0.0,
+]
 
-p = [σ => 28.0,
+p = [
+    σ => 28.0,
     ρ => 10.0,
-    β => 8 / 3]
+    β => 8 / 3,
+]
 
 tspan = (0.0, 100.0)
 prob = ODEProblem(sys, u0, tspan, p, jac = true)
@@ -94,7 +100,7 @@ tunables, repack, _ = SS.canonicalize(SS.Tunable(), parameter_values(prob))
 
         gs_prob, = Zygote.gradient(tunables) do tunables
             new_prob = remake(prob; p = repack(tunables))
-            sol = solve(new_prob; sensealg, initializealg = SciMLBase.OverrideInit(), abstol = 1e-6)
+            sol = solve(new_prob; sensealg, initializealg = SciMLBase.OverrideInit(), abstol = 1.0e-6)
             o = sol[w]
             o[2]
         end

--- a/test/physical_ode_regression.jl
+++ b/test/physical_ode_regression.jl
@@ -15,7 +15,7 @@ t_stop = 2.0
 u0 = [1.0, 0.0] # start state: mass position (1.0) and velocity (0.0)
 p = [GRAVITY, MASS]
 
-# setup falling mass ODE 
+# setup falling mass ODE
 function fx(u, p, t)
     g, m = p
     return [u[2], -g]
@@ -40,7 +40,7 @@ function mysolve(p; solver = nothing)
 end
 
 analyt_sol = [-27.675, 0.0]
-atol = 1e-2
+atol = 1.0e-2
 
 solvers = [Tsit5(), Rosenbrock23(autodiff = false), Rosenbrock23(autodiff = true)]
 for solver in solvers

--- a/test/prob_kwargs.jl
+++ b/test/prob_kwargs.jl
@@ -1,27 +1,31 @@
 using OrdinaryDiffEq, SciMLSensitivity
 
 function growth(du, u, p, t)
-    @. du = p * u * (1 - u)
+    return @. du = p * u * (1 - u)
 end
 u0 = [0.1]
 tspan = (0.0, 2.0)
 prob = ODEProblem(growth, u0, tspan, [1.0])
-sol = solve(prob, Tsit5(), reltol = 1e-8, abstol = 1e-8)
+sol = solve(prob, Tsit5(), reltol = 1.0e-8, abstol = 1.0e-8)
 
 savetimes = [0.0, 1.0, 1.9]
 
 function f(a)
     _prob = remake(prob, p = [a[1]], saveat = savetimes)
-    predicted = solve(_prob, Tsit5(), sensealg = InterpolatingAdjoint(), abstol = 1e-12,
-        reltol = 1e-12)
-    sum(predicted.u[end])
+    predicted = solve(
+        _prob, Tsit5(), sensealg = InterpolatingAdjoint(), abstol = 1.0e-12,
+        reltol = 1.0e-12
+    )
+    return sum(predicted.u[end])
 end
 
 function f2(a)
     _prob = remake(prob, p = [a[1]], saveat = savetimes)
-    predicted = solve(_prob, Tsit5(), sensealg = InterpolatingAdjoint(), abstol = 1e-12,
-        reltol = 1e-12)
-    sum(predicted.u[end])
+    predicted = solve(
+        _prob, Tsit5(), sensealg = InterpolatingAdjoint(), abstol = 1.0e-12,
+        reltol = 1.0e-12
+    )
+    return sum(predicted.u[end])
 end
 
 using Zygote
@@ -41,7 +45,7 @@ let callback_count1 = 0, callback_count2 = 0
         affect!(integrator) = callback_count1 += 1
         cb = DiscreteCallback(condition, affect!)
         prob = ODEProblem{true}(odef, u0p[1:1], (0.0, 1.0), u0p[2:2]; callback = cb)
-        sum(solve(prob, Tsit5(), tstops = [0.5], sensealg = adjoint_type))
+        return sum(solve(prob, Tsit5(), tstops = [0.5], sensealg = adjoint_type))
     end
 
     function f2(u0p, adjoint_type)
@@ -49,18 +53,19 @@ let callback_count1 = 0, callback_count2 = 0
         affect!(integrator) = callback_count2 += 1
         cb = DiscreteCallback(condition, affect!)
         prob = ODEProblem{true}(odef, u0p[1:1], (0.0, 1.0), u0p[2:2])
-        sum(solve(prob, Tsit5(), tstops = [0.5], callback = cb, sensealg = adjoint_type))
+        return sum(solve(prob, Tsit5(), tstops = [0.5], callback = cb, sensealg = adjoint_type))
     end
 
     @testset "Callback duplication check" begin
         u0p = [2.0, 3.0]
         for adjoint_type in [
-            ForwardDiffSensitivity(), ReverseDiffAdjoint(), TrackerAdjoint(),
-            BacksolveAdjoint(), InterpolatingAdjoint(), QuadratureAdjoint(), GaussAdjoint()]
+                ForwardDiffSensitivity(), ReverseDiffAdjoint(), TrackerAdjoint(),
+                BacksolveAdjoint(), InterpolatingAdjoint(), QuadratureAdjoint(), GaussAdjoint(),
+            ]
             count1 = 0
             count2 = 0
             @test Zygote.gradient(x -> f1(x, adjoint_type), u0p) ==
-                  Zygote.gradient(x -> f2(x, adjoint_type), u0p)
+                Zygote.gradient(x -> f2(x, adjoint_type), u0p)
             @test callback_count1 == callback_count2
         end
     end

--- a/test/reversediff_output_types.jl
+++ b/test/reversediff_output_types.jl
@@ -11,8 +11,8 @@ p = [1.5, 1.0, 3.0, 1.0]
 prob = ODEProblem(lotka_volterra, u0, tspan, p)
 
 function loss(u0; kwargs...)
-    solve(remake(prob, u0 = u0), Tsit5(); reltol = 1e-10, abstol = 1e-10, kwargs...).u |>
-    last |> sum
+    return solve(remake(prob, u0 = u0), Tsit5(); reltol = 1.0e-10, abstol = 1.0e-10, kwargs...).u |>
+        last |> sum
 end
 
 dp1 = Zygote.gradient(loss, u0)[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ const GROUP = get(ENV, "GROUP", "All")
 function activate_gpu_env()
     Pkg.activate("gpu")
     Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    Pkg.instantiate()
+    return Pkg.instantiate()
 end
 
 @time @testset "SciMLSensitivity" begin

--- a/test/save_idxs.jl
+++ b/test/save_idxs.jl
@@ -4,7 +4,7 @@ function lotka_volterra!(du, u, p, t)
     x, y = u
     α, β, δ, γ = p
     du[1] = dx = α * x - β * x * y
-    du[2] = dy = -δ * y + γ * x * y
+    return du[2] = dy = -δ * y + γ * x * y
 end
 
 # Initial condition
@@ -21,8 +21,10 @@ p = [1.5, 1.0, 3.0, 1.0]
 prob = ODEProblem(lotka_volterra!, u0, tspan, p)
 
 function loss(p)
-    sol = solve(prob, Tsit5(), p = p, save_idxs = [2], saveat = tsteps, abstol = 1e-14,
-        reltol = 1e-14)
+    sol = solve(
+        prob, Tsit5(), p = p, save_idxs = [2], saveat = tsteps, abstol = 1.0e-14,
+        reltol = 1.0e-14
+    )
     loss = sum(abs2, sol .- 1)
     return loss
 end

--- a/test/scalar_u.jl
+++ b/test/scalar_u.jl
@@ -1,18 +1,22 @@
 using OrdinaryDiffEq, SciMLSensitivity, Zygote, ForwardDiff, Test
 
 function neural_ode(u, p, t)
-    u * p[1]
+    return u * p[1]
 end
 
 p = [2.0]
 u0 = rand(1)[1]
 tspan = (0.0, 10.0)
-t = Array(range(0, 0.10, length = 100))
+t = Array(range(0, 0.1, length = 100))
 prob_neuralode = ODEProblem(neural_ode, u0, tspan)
 
 function loss_neuralode(p)
-    trial = Array(solve(prob_neuralode, AutoTsit5(Rosenbrock23()), u0 = u0, p = p,
-        saveat = t, abstol = 1e-6, reltol = 1e-6))
+    trial = Array(
+        solve(
+            prob_neuralode, AutoTsit5(Rosenbrock23()), u0 = u0, p = p,
+            saveat = t, abstol = 1.0e-6, reltol = 1.0e-6
+        )
+    )
     loss = sum(abs2, trial)
     return loss
 end
@@ -20,4 +24,4 @@ end
 dp1 = Zygote.gradient(loss_neuralode, p)[1]
 dp2 = ForwardDiff.gradient(loss_neuralode, p)
 
-@test dp1≈dp2 atol=1e-8
+@test dp1 ≈ dp2 atol = 1.0e-8

--- a/test/scimlstructures_interface.jl
+++ b/test/scimlstructures_interface.jl
@@ -46,7 +46,7 @@ function SS.canonicalize(::SS.Tunable, p::Parameters)
     # so we can use that instead.
     repack = let p = p
         function repack(newbuffer)
-            SS.replace(SS.Tunable(), p, newbuffer)
+            return SS.replace(SS.Tunable(), p, newbuffer)
         end
     end
     # the canonicalized vector, the repack function, and a boolean indicating
@@ -56,10 +56,13 @@ end
 function SS.replace(::SS.Tunable, p::Parameters, newbuffer)
     N = length(p.subparams) + length(p.coeffs)
     @assert length(newbuffer) == N
-    subparams = [SubproblemParameters(newbuffer[i], subpar.q, subpar.r)
-                 for (i, subpar) in enumerate(p.subparams)]
+    subparams = [
+        SubproblemParameters(newbuffer[i], subpar.q, subpar.r)
+            for (i, subpar) in enumerate(p.subparams)
+    ]
     coeffs = reshape(
-        view(newbuffer, (length(p.subparams) + 1):length(newbuffer)), size(p.coeffs))
+        view(newbuffer, (length(p.subparams) + 1):length(newbuffer)), size(p.coeffs)
+    )
     return Parameters(subparams, coeffs)
 end
 function SS.replace!(::SS.Tunable, p::Parameters, newbuffer)
@@ -104,7 +107,7 @@ function SS.canonicalize(::SS.Tunable, p::myparam)
     buffer = copy(p.ps)
     repack = let p = p
         function repack(newbuffer)
-            SS.replace(SS.Tunable(), p, newbuffer)
+            return SS.replace(SS.Tunable(), p, newbuffer)
         end
     end
     return buffer, repack, false
@@ -133,7 +136,7 @@ function UDE_model!(du, u, p, t)
     du[1] = o * p.α * u[1] + p.β * u[2] + p.γ * u[3]
     du[2] = -p.α * u[1] + p.β * u[2] - p.γ * u[3]
     du[3] = p.α * u[1] - p.β * u[2] + p.γ * u[3]
-    nothing
+    return nothing
 end
 
 p = initialize()

--- a/test/sde_checkpointing.jl
+++ b/test/sde_checkpointing.jl
@@ -16,11 +16,11 @@ t = tstart:dt:tend
 tarray = collect(t)
 
 function g(u, p, t)
-    sum(u .^ 2.0 / 2.0)
+    return sum(u .^ 2.0 / 2.0)
 end
 
 function dg!(out, u, p, t, i)
-    (out .= u)
+    return (out .= u)
 end
 
 p2 = [1.01, 0.87]
@@ -28,7 +28,7 @@ p2 = [1.01, 0.87]
 f_oop_linear(u, p, t) = p[1] * u
 σ_oop_linear(u, p, t) = p[2] * u
 
-dt1 = tend / 1e3
+dt1 = tend / 1.0e3
 
 Random.seed!(seed)
 prob_oop = SDEProblem(f_oop_linear, σ_oop_linear, u₀, trange, p2)
@@ -37,33 +37,38 @@ sol_oop = solve(prob_oop, EulerHeun(), dt = dt1, adaptive = false, save_noise = 
 @show length(sol_oop)
 
 res_u0,
-res_p = adjoint_sensitivities(
+    res_p = adjoint_sensitivities(
     sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
     dt = dt1, adaptive = false,
-    sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
+    sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+)
 
 res_u0a,
-res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray,
+    res_pa = adjoint_sensitivities(
+    sol_oop, EulerHeun(), t = tarray,
     dgdu_discrete = dg!,
     dt = dt1,
     adaptive = false,
     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
-    checkpoints = sol_oop.t[1:2:end])
+    checkpoints = sol_oop.t[1:2:end]
+)
 
-@test isapprox(res_u0, res_u0a, rtol = 1e-5)
-@test isapprox(res_p, res_pa, rtol = 1e-2)
+@test isapprox(res_u0, res_u0a, rtol = 1.0e-5)
+@test isapprox(res_p, res_pa, rtol = 1.0e-2)
 
 res_u0a,
-res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray,
+    res_pa = adjoint_sensitivities(
+    sol_oop, EulerHeun(), t = tarray,
     dgdu_discrete = dg!,
     dt = dt1, adaptive = false,
     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
-    checkpoints = sol_oop.t[1:10:end])
+    checkpoints = sol_oop.t[1:10:end]
+)
 
-@test isapprox(res_u0, res_u0a, rtol = 1e-5)
-@test isapprox(res_p, res_pa, rtol = 1e-1)
+@test isapprox(res_u0, res_u0a, rtol = 1.0e-5)
+@test isapprox(res_p, res_pa, rtol = 1.0e-1)
 
-dt1 = tend / 1e4
+dt1 = tend / 1.0e4
 
 Random.seed!(seed)
 prob_oop = SDEProblem(f_oop_linear, σ_oop_linear, u₀, trange, p2)
@@ -72,37 +77,44 @@ sol_oop = solve(prob_oop, EulerHeun(), dt = dt1, adaptive = false, save_noise = 
 @show length(sol_oop)
 
 res_u0,
-res_p = adjoint_sensitivities(
+    res_p = adjoint_sensitivities(
     sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
     dt = dt1, adaptive = false,
-    sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
+    sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+)
 
 res_u0a,
-res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray,
+    res_pa = adjoint_sensitivities(
+    sol_oop, EulerHeun(), t = tarray,
     dgdu_discrete = dg!,
     dt = dt1, adaptive = false,
     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
-    checkpoints = sol_oop.t[1:2:end])
+    checkpoints = sol_oop.t[1:2:end]
+)
 
-@test isapprox(res_u0, res_u0a, rtol = 1e-6)
-@test isapprox(res_p, res_pa, rtol = 1e-3)
+@test isapprox(res_u0, res_u0a, rtol = 1.0e-6)
+@test isapprox(res_p, res_pa, rtol = 1.0e-3)
 
 res_u0a,
-res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray,
+    res_pa = adjoint_sensitivities(
+    sol_oop, EulerHeun(), t = tarray,
     dgdu_discrete = dg!,
     dt = dt1, adaptive = false,
     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
-    checkpoints = sol_oop.t[1:10:end])
+    checkpoints = sol_oop.t[1:10:end]
+)
 
-@test isapprox(res_u0, res_u0a, rtol = 1e-6)
-@test isapprox(res_p, res_pa, rtol = 1e-2)
+@test isapprox(res_u0, res_u0a, rtol = 1.0e-6)
+@test isapprox(res_p, res_pa, rtol = 1.0e-2)
 
 res_u0a,
-res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray,
+    res_pa = adjoint_sensitivities(
+    sol_oop, EulerHeun(), t = tarray,
     dgdu_discrete = dg!,
     dt = dt1, adaptive = false,
     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
-    checkpoints = sol_oop.t[1:500:end])
+    checkpoints = sol_oop.t[1:500:end]
+)
 
-@test isapprox(res_u0, res_u0a, rtol = 1e-3)
-@test isapprox(res_p, res_pa, rtol = 1e-2)
+@test isapprox(res_u0, res_u0a, rtol = 1.0e-3)
+@test isapprox(res_p, res_pa, rtol = 1.0e-2)

--- a/test/sde_scalar_stratonovich.jl
+++ b/test/sde_scalar_stratonovich.jl
@@ -15,11 +15,11 @@ t = tstart:dt:tend
 tarray = collect(t)
 
 function g(u, p, t)
-    sum(u .^ 2.0 / 2.0)
+    return sum(u .^ 2.0 / 2.0)
 end
 
 function dg!(out, u, p, t, i)
-    (out .= u)
+    return (out .= u)
 end
 
 p2 = [1.01, 0.87]
@@ -28,7 +28,7 @@ p2 = [1.01, 0.87]
 @testset "SDE inplace scalar noise tests" begin
     using DiffEqNoiseProcess
 
-    dtscalar = tend / 1e3
+    dtscalar = tend / 1.0e3
 
     f!(du, u, p, t) = (du .= p[1] * u)
     σ!(du, u, p, t) = (du .= p[2] * u)
@@ -39,74 +39,87 @@ p2 = [1.01, 0.87]
     W = WienerProcess(0.0, 0.0, 0.0)
     u0 = rand(2)
 
-    linear_analytic_strat(u0, p, t, W) = @.(u0*exp(p[1] * t + p[2] * W))
+    linear_analytic_strat(u0, p, t, W) = @.(u0 * exp(p[1] * t + p[2] * W))
 
     prob = SDEProblem(
         SDEFunction(f!, σ!, analytic = linear_analytic_strat), σ!, u0, trange,
         p2,
-        noise = W)
+        noise = W
+    )
     sol = solve(prob, EulerHeun(), dt = dtscalar, save_noise = true)
 
-    @test isapprox(sol.u_analytic, sol.u, atol = 1e-4)
+    @test isapprox(sol.u_analytic, sol.u, atol = 1.0e-4)
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtscalar, adaptive = false,
-        sensealg = BacksolveAdjoint())
+        sensealg = BacksolveAdjoint()
+    )
 
     @show res_sde_u0, res_sde_p
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p2 = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtscalar, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = false))
+        sensealg = BacksolveAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u02, atol = 1e-8)
-    @test isapprox(res_sde_p, res_sde_p2, atol = 1e-8)
+    @test isapprox(res_sde_u0, res_sde_u02, atol = 1.0e-8)
+    @test isapprox(res_sde_p, res_sde_p2, atol = 1.0e-8)
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p2 = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtscalar, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u02, atol = 1e-8)
-    @test isapprox(res_sde_p, res_sde_p2, atol = 1e-8)
+    @test isapprox(res_sde_u0, res_sde_u02, atol = 1.0e-8)
+    @test isapprox(res_sde_p, res_sde_p2, atol = 1.0e-8)
 
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p2 = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
-        dt = tend / 1e2, adaptive = false,
-        sensealg = InterpolatingAdjoint())
+        dt = tend / 1.0e2, adaptive = false,
+        sensealg = InterpolatingAdjoint()
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-4)
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-4)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-4)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-4)
 
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p2 = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtscalar, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = false))
+        sensealg = InterpolatingAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-4)
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-4)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-4)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-4)
 
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p2 = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtscalar, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-4)
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-4)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-4)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-4)
 
     @show res_sde_u02, res_sde_p2
 
@@ -129,18 +142,18 @@ p2 = [1.01, 0.87]
 
     @show true_grads
 
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-4)
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-4)
-    @test isapprox(true_grads[2], res_sde_p', atol = 1e-4)
-    @test isapprox(true_grads[1], res_sde_u0, rtol = 1e-4)
-    @test isapprox(true_grads[2], res_sde_p2', atol = 1e-4)
-    @test isapprox(true_grads[1], res_sde_u02, rtol = 1e-4)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-4)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-4)
+    @test isapprox(true_grads[2], res_sde_p', atol = 1.0e-4)
+    @test isapprox(true_grads[1], res_sde_u0, rtol = 1.0e-4)
+    @test isapprox(true_grads[2], res_sde_p2', atol = 1.0e-4)
+    @test isapprox(true_grads[1], res_sde_u02, rtol = 1.0e-4)
 end
 
 @testset "SDE oop scalar noise tests" begin
     using DiffEqNoiseProcess
 
-    dtscalar = tend / 1e3
+    dtscalar = tend / 1.0e3
 
     f(u, p, t) = p[1] * u
     σ(u, p, t) = p[2] * u
@@ -149,73 +162,87 @@ end
     W = WienerProcess(0.0, 0.0, 0.0)
     u0 = rand(2)
 
-    linear_analytic_strat(u0, p, t, W) = @.(u0*exp(p[1] * t + p[2] * W))
+    linear_analytic_strat(u0, p, t, W) = @.(u0 * exp(p[1] * t + p[2] * W))
 
-    prob = SDEProblem(SDEFunction(f, σ, analytic = linear_analytic_strat), σ, u0, trange,
+    prob = SDEProblem(
+        SDEFunction(f, σ, analytic = linear_analytic_strat), σ, u0, trange,
         p2,
-        noise = W)
+        noise = W
+    )
     sol = solve(prob, EulerHeun(), dt = dtscalar, save_noise = true)
 
-    @test isapprox(sol.u_analytic, sol.u, atol = 1e-4)
+    @test isapprox(sol.u_analytic, sol.u, atol = 1.0e-4)
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtscalar, adaptive = false,
-        sensealg = BacksolveAdjoint())
+        sensealg = BacksolveAdjoint()
+    )
 
     @show res_sde_u0, res_sde_p
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p2 = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtscalar, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = false))
+        sensealg = BacksolveAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u02, atol = 1e-8)
-    @test isapprox(res_sde_p, res_sde_p2, atol = 1e-8)
+    @test isapprox(res_sde_u0, res_sde_u02, atol = 1.0e-8)
+    @test isapprox(res_sde_p, res_sde_p2, atol = 1.0e-8)
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p2 = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtscalar, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u02, atol = 1e-8)
-    @test isapprox(res_sde_p, res_sde_p2, atol = 1e-8)
+    @test isapprox(res_sde_u0, res_sde_u02, atol = 1.0e-8)
+    @test isapprox(res_sde_p, res_sde_p2, atol = 1.0e-8)
 
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p2 = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
-        dt = tend / 1e2, adaptive = false,
-        sensealg = InterpolatingAdjoint())
+        dt = tend / 1.0e2, adaptive = false,
+        sensealg = InterpolatingAdjoint()
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-4)
-    @test isapprox(res_sde_p, res_sde_p2, atol = 1e-4)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-4)
+    @test isapprox(res_sde_p, res_sde_p2, atol = 1.0e-4)
 
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p2 = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtscalar, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = false))
+        sensealg = InterpolatingAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-4)
-    @test isapprox(res_sde_p, res_sde_p2, atol = 1e-4)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-4)
+    @test isapprox(res_sde_p, res_sde_p2, atol = 1.0e-4)
 
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
+        res_sde_p2 = adjoint_sensitivities(
+        sol, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtscalar, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-4)
-    @test isapprox(res_sde_p, res_sde_p2, atol = 1e-4)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-4)
+    @test isapprox(res_sde_p, res_sde_p2, atol = 1.0e-4)
 
     @show res_sde_u02, res_sde_p2
 
@@ -238,8 +265,8 @@ end
 
     @show true_grads
 
-    @test isapprox(true_grads[2], res_sde_p', atol = 1e-4)
-    @test isapprox(true_grads[1], res_sde_u0, rtol = 1e-4)
-    @test isapprox(true_grads[2], res_sde_p2', atol = 1e-4)
-    @test isapprox(true_grads[1], res_sde_u02, rtol = 1e-4)
+    @test isapprox(true_grads[2], res_sde_p', atol = 1.0e-4)
+    @test isapprox(true_grads[1], res_sde_u0, rtol = 1.0e-4)
+    @test isapprox(true_grads[2], res_sde_p2', atol = 1.0e-4)
+    @test isapprox(true_grads[1], res_sde_u02, rtol = 1.0e-4)
 end

--- a/test/sde_stratonovich.jl
+++ b/test/sde_stratonovich.jl
@@ -9,8 +9,8 @@ import Tracker, Zygote
 
 seed = 100
 Random.seed!(seed)
-abstol = 1e-4
-reltol = 1e-4
+abstol = 1.0e-4
+reltol = 1.0e-4
 
 u₀ = [0.5]
 tstart = 0.0
@@ -21,11 +21,11 @@ t = tstart:dt:tend
 tarray = collect(t)
 
 function g(u, p, t)
-    sum(u .^ 2.0 / 2.0)
+    return sum(u .^ 2.0 / 2.0)
 end
 
 function dg!(out, u, p, t, i)
-    (out .= u)
+    return (out .= u)
 end
 
 p2 = [1.01, 0.87]
@@ -41,56 +41,70 @@ p2 = [1.01, 0.87]
     prob_oop_ode = ODEProblem(f_oop_linear, u₀, (tstart, tend), p)
     sol_oop_ode = solve(prob_oop_ode, Tsit5(), saveat = t, abstol = abstol, reltol = reltol)
     res_ode_u0,
-    res_ode_p = adjoint_sensitivities(sol_oop_ode, Tsit5(), t = t,
+        res_ode_p = adjoint_sensitivities(
+        sol_oop_ode, Tsit5(), t = t,
         dgdu_discrete = dg!, abstol = abstol,
         reltol = reltol,
-        sensealg = BacksolveAdjoint())
+        sensealg = BacksolveAdjoint()
+    )
 
     function G(p)
-        tmp_prob = remake(prob_oop_ode, u0 = eltype(p).(prob_oop_ode.u0), p = p,
+        tmp_prob = remake(
+            prob_oop_ode, u0 = eltype(p).(prob_oop_ode.u0), p = p,
             tspan = eltype(p).(prob_oop_ode.tspan), abstol = abstol,
-            reltol = reltol)
+            reltol = reltol
+        )
         sol = solve(tmp_prob, Tsit5(), saveat = tarray, abstol = abstol, reltol = reltol)
         res = g(sol, p, nothing)
     end
     res_ode_forward = ForwardDiff.gradient(G, p)
 
-    @test isapprox(res_ode_forward[1], sum(@. u₀^2 * exp(2 * p[1] * t) * t), rtol = 1e-4)
+    @test isapprox(res_ode_forward[1], sum(@. u₀^2 * exp(2 * p[1] * t) * t), rtol = 1.0e-4)
     #@test isapprox(res_ode_reverse[1], sum(@. u₀^2*exp(2*p[1]*t)*t), rtol = 1e-4)
-    @test isapprox(res_ode_p'[1], sum(@. u₀^2 * exp(2 * p[1] * t) * t), rtol = 1e-4)
+    @test isapprox(res_ode_p'[1], sum(@. u₀^2 * exp(2 * p[1] * t) * t), rtol = 1.0e-4)
     #@test isapprox(res_ode_p', res_ode_trackerp, rtol = 1e-4)
 
     # SDE adjoint results (with noise == 0, so should agree with above)
 
     Random.seed!(seed)
     prob_oop_sde = SDEProblem(f_oop_linear, σ_oop_linear, u₀, trange, p)
-    sol_oop_sde = solve(prob_oop_sde, EulerHeun(), dt = 1e-4, adaptive = false,
-        save_noise = true)
+    sol_oop_sde = solve(
+        prob_oop_sde, EulerHeun(), dt = 1.0e-4, adaptive = false,
+        save_noise = true
+    )
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_oop_sde,
+        res_sde_p = adjoint_sensitivities(
+        sol_oop_sde,
         EulerHeun(), t = t, dgdu_discrete = dg!,
-        dt = 1e-2, sensealg = BacksolveAdjoint())
+        dt = 1.0e-2, sensealg = BacksolveAdjoint()
+    )
 
     @info res_sde_p
 
     res_sde_u0a,
-    res_sde_pa = adjoint_sensitivities(sol_oop_sde,
+        res_sde_pa = adjoint_sensitivities(
+        sol_oop_sde,
         EulerHeun(), t = t, dgdu_discrete = dg!,
-        dt = 1e-2,
-        sensealg = InterpolatingAdjoint())
+        dt = 1.0e-2,
+        sensealg = InterpolatingAdjoint()
+    )
 
-    @test isapprox(res_sde_u0, res_sde_u0a, rtol = 1e-6)
-    @test isapprox(res_sde_p, res_sde_pa, rtol = 1e-6)
+    @test isapprox(res_sde_u0, res_sde_u0a, rtol = 1.0e-6)
+    @test isapprox(res_sde_p, res_sde_pa, rtol = 1.0e-6)
 
     function GSDE1(p)
         Random.seed!(seed)
-        tmp_prob = remake(prob_oop_sde, u0 = eltype(p).(prob_oop_sde.u0), p = p,
-            tspan = eltype(p).(prob_oop_sde.tspan))
-        sol = solve(tmp_prob,
+        tmp_prob = remake(
+            prob_oop_sde, u0 = eltype(p).(prob_oop_sde.u0), p = p,
+            tspan = eltype(p).(prob_oop_sde.tspan)
+        )
+        sol = solve(
+            tmp_prob,
             RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
             dt = tend / 10000,
             adaptive = false, sensealg = DiffEqBase.SensitivityADPassThrough(),
-            saveat = tarray)
+            saveat = tarray
+        )
         A = convert(Array, sol)
         res = g(A, p, nothing)
     end
@@ -98,11 +112,13 @@ p2 = [1.01, 0.87]
 
     noise = vec((@. sol_oop_sde.W(tarray)))
     Wfix = [W[1][1] for W in noise]
-    @test isapprox(res_sde_forward[1], sum(@. u₀^2 * exp(2 * p[1] * t) * t), rtol = 1e-4)
-    @test isapprox(res_sde_p'[1], sum(@. u₀^2 * exp(2 * p[1] * t) * t), rtol = 1e-4)
-    @test isapprox(res_sde_p'[2],
+    @test isapprox(res_sde_forward[1], sum(@. u₀^2 * exp(2 * p[1] * t) * t), rtol = 1.0e-4)
+    @test isapprox(res_sde_p'[1], sum(@. u₀^2 * exp(2 * p[1] * t) * t), rtol = 1.0e-4)
+    @test isapprox(
+        res_sde_p'[2],
         sum(@. (Wfix) * u₀^2 * exp(2 * (p[1]) * tarray + 2 * p[2] * Wfix)),
-        rtol = 1e-4)
+        rtol = 1.0e-4
+    )
 end
 
 @testset "SDE oop Tests (with noise)" begin
@@ -110,69 +126,79 @@ end
     σ_oop_linear(u, p, t) = p[2] * u
 
     # SDE adjoint results (with noise != 0)
-    dt1 = tend / 1e3
+    dt1 = tend / 1.0e3
 
     Random.seed!(seed)
     prob_oop_sde2 = SDEProblem(f_oop_linear, σ_oop_linear, u₀, trange, p2)
-    sol_oop_sde2 = solve(prob_oop_sde2,
+    sol_oop_sde2 = solve(
+        prob_oop_sde2,
         RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = dt1,
-        adaptive = false, save_noise = true)
+        adaptive = false, save_noise = true
+    )
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
+        res_sde_p2 = adjoint_sensitivities(
+        sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint())
+        sensealg = BacksolveAdjoint()
+    )
 
     @info res_sde_p2
 
     # test consistency for different switches for the noise Jacobian
     res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2a = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = false))
+        sensealg = BacksolveAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-6)
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-6)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1.0e-6)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1.0e-6)
 
     @info res_sde_p2a
 
     res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2a = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
+        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP())
+    )
 
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-6)
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-6)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1.0e-6)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1.0e-6)
 
     @info res_sde_p2a
 
     res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2a = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = tend / dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-6)
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-6)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1.0e-6)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1.0e-6)
 
     @info res_sde_p2a
 
     function GSDE2(p)
         Random.seed!(seed)
-        tmp_prob = remake(prob_oop_sde2, u0 = eltype(p).(prob_oop_sde2.u0), p = p,
+        tmp_prob = remake(
+            prob_oop_sde2, u0 = eltype(p).(prob_oop_sde2.u0), p = p,
             tspan = eltype(p).(prob_oop_sde2.tspan)            #,abstol=abstol, reltol=reltol
         )
-        sol = solve(tmp_prob,
+        sol = solve(
+            tmp_prob,
             RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
             dt = dt1,
             adaptive = false, sensealg = DiffEqBase.SensitivityADPassThrough(),
-            saveat = tarray)
+            saveat = tarray
+        )
         A = convert(Array, sol)
         res = g(A, p, nothing)
     end
@@ -183,10 +209,10 @@ end
     resp2 = sum(@. (Wfix) * u₀^2 * exp(2 * (p2[1]) * tarray + 2 * p2[2] * Wfix))
     resp = [resp1, resp2]
 
-    @test isapprox(res_sde_forward2, resp, rtol = 8e-4)
+    @test isapprox(res_sde_forward2, resp, rtol = 8.0e-4)
 
-    @test isapprox(res_sde_p2', res_sde_forward2, rtol = 1e-3)
-    @test isapprox(res_sde_p2', resp, rtol = 1e-3)
+    @test isapprox(res_sde_p2', res_sde_forward2, rtol = 1.0e-3)
+    @test isapprox(res_sde_p2', resp, rtol = 1.0e-3)
 
     @info "ForwardDiff" res_sde_forward2
     @info "Exact" resp
@@ -196,43 +222,50 @@ end
     @info "InterpolatingAdjoint SDE"
 
     res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2a = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint())
+        sensealg = InterpolatingAdjoint()
+    )
 
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-4)
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-3)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1.0e-4)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1.0e-3)
 
     @info res_sde_p2a
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
+        res_sde_p2 = adjoint_sensitivities(
+        sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = false))
+        sensealg = InterpolatingAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-6)
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-6)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1.0e-6)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1.0e-6)
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
+        res_sde_p2 = adjoint_sensitivities(
+        sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+    )
 
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-6)
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-6)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1.0e-6)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1.0e-6)
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
+        res_sde_p2 = adjoint_sensitivities(
+        sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-6)
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-6)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1.0e-6)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1.0e-6)
 
     # Free memory to help Travis
 
@@ -253,86 +286,97 @@ end
 
     Random.seed!(seed)
     prob_oop_sde2 = SDEProblem(f_oop_linear, σ_oop_linear, [u₀; u₀; u₀], trange, p2)
-    sol_oop_sde2 = solve(prob_oop_sde2, EulerHeun(), dt = dt1, adaptive = false,
-        save_noise = true)
+    sol_oop_sde2 = solve(
+        prob_oop_sde2, EulerHeun(), dt = dt1, adaptive = false,
+        save_noise = true
+    )
 
     @info "Diagonal Adjoint"
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-        dgdu_discrete = dg!,
-        dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint())
-
-    res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2 = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint())
-
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 5e-4)
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2e-5)
+        sensealg = BacksolveAdjoint()
+    )
 
     res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2a = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = false))
+        sensealg = InterpolatingAdjoint()
+    )
 
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 5e-4)
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2e-5)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 5.0e-4)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2.0e-5)
 
     res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2a = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
+        sensealg = InterpolatingAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 5e-4)
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2e-5)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 5.0e-4)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2.0e-5)
 
     res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2a = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+    )
 
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 5e-4)
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2e-5)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 5.0e-4)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2.0e-5)
 
     res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2a = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = false))
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-7)
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-7)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 5.0e-4)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2.0e-5)
 
     res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2a = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
+        sensealg = BacksolveAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-7)
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-7)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1.0e-7)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1.0e-7)
 
     res_sde_u02a,
-    res_sde_p2a = adjoint_sensitivities(
+        res_sde_p2a = adjoint_sensitivities(
         sol_oop_sde2, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP())
+    )
 
-    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-7)
-    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-7)
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1.0e-7)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1.0e-7)
+
+    res_sde_u02a,
+        res_sde_p2a = adjoint_sensitivities(
+        sol_oop_sde2, EulerHeun(), t = tarray,
+        dgdu_discrete = dg!,
+        dt = dt1, adaptive = false,
+        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())
+    )
+
+    @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1.0e-7)
+    @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1.0e-7)
 
     @info res_sde_p2
 
@@ -343,17 +387,19 @@ end
     res_sde_forward2 = ForwardDiff.gradient(GSDE2, p2)
 
     #@test isapprox(res_sde_forward2, res_sde_reverse2, rtol = 1e-6)
-    @test isapprox(res_sde_p2', res_sde_forward2, rtol = 1e-3)
+    @test isapprox(res_sde_p2', res_sde_forward2, rtol = 1.0e-3)
     #@test isapprox(res_sde_p2', res_sde_reverse2, rtol = 1e-3)
 
     # u0
     function GSDE3(u)
         Random.seed!(seed)
         tmp_prob = remake(prob_oop_sde2, u0 = u)
-        sol = solve(tmp_prob,
+        sol = solve(
+            tmp_prob,
             RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
             dt = dt1,
-            adaptive = false, saveat = tarray)
+            adaptive = false, saveat = tarray
+        )
         A = convert(Array, sol)
         res = g(A, nothing, nothing)
     end
@@ -361,7 +407,7 @@ end
     @info "ForwardDiff u0"
     res_sde_forward2 = ForwardDiff.gradient(GSDE3, [u₀; u₀; u₀])
 
-    @test isapprox(res_sde_u02, res_sde_forward2, rtol = 1e-4)
+    @test isapprox(res_sde_u02, res_sde_forward2, rtol = 1.0e-4)
 end
 
 ##
@@ -371,7 +417,7 @@ end
     f!(du, u, p, t) = du .= p[1] * u
     σ!(du, u, p, t) = du .= p[2] * u
 
-    dt1 = tend / 1e3
+    dt1 = tend / 1.0e3
 
     Random.seed!(seed)
     prob_sde = SDEProblem(f!, σ!, u₀, trange, p2)
@@ -379,8 +425,10 @@ end
 
     function GSDE(p)
         Random.seed!(seed)
-        tmp_prob = remake(prob_sde, u0 = eltype(p).(prob_sde.u0), p = p,
-            tspan = eltype(p).(prob_sde.tspan))
+        tmp_prob = remake(
+            prob_sde, u0 = eltype(p).(prob_sde.u0), p = p,
+            tspan = eltype(p).(prob_sde.tspan)
+        )
         sol = solve(tmp_prob, EulerHeun(), dt = dt1, adaptive = false, saveat = tarray)
         A = convert(Array, sol)
         res = g(A, p, nothing)
@@ -389,83 +437,99 @@ end
     res_sde_forward = ForwardDiff.gradient(GSDE, p2)
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint())
+        sensealg = BacksolveAdjoint()
+    )
 
-    @test isapprox(res_sde_p', res_sde_forward, rtol = 5e-4)
+    @test isapprox(res_sde_p', res_sde_forward, rtol = 5.0e-4)
 
     @info res_sde_p
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p2 = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = false))
+        sensealg = BacksolveAdjoint(autojacvec = false)
+    )
 
     @info res_sde_p2
 
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-5)
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-5)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-5)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-5)
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p2 = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
+        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP())
+    )
 
     @info res_sde_p2
 
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-5) # not broken here because it just uses the vjps
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-5)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-5) # not broken here because it just uses the vjps
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-5)
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p2 = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
     @info res_sde_p2
 
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-10)
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-10)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-10)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-10)
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p2 = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-3)
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-4)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-3)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-4)
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint())
+        sensealg = InterpolatingAdjoint()
+    )
 
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-7)
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-7)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-7)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-7)
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = false))
+        sensealg = InterpolatingAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-7)
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-7)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-7)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-7)
 
     res_sde_u02,
-    res_sde_p2 = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p2 = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+    )
 
-    @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-7)
-    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-7)
+    @test isapprox(res_sde_p, res_sde_p2, rtol = 1.0e-7)
+    @test isapprox(res_sde_u0, res_sde_u02, rtol = 1.0e-7)
 
     # diagonal noise
 
@@ -474,13 +538,17 @@ end
     σ_oop_linear(u, p, t) = p[2] * u
     Random.seed!(seed)
     prob_oop_sde = SDEProblem(f_oop_linear, σ_oop_linear, [u₀; u₀; u₀], trange, p2)
-    sol_oop_sde = solve(prob_oop_sde, EulerHeun(), dt = dt1, adaptive = false,
-        save_noise = true)
+    sol_oop_sde = solve(
+        prob_oop_sde, EulerHeun(), dt = dt1, adaptive = false,
+        save_noise = true
+    )
     res_oop_u0,
-    res_oop_p = adjoint_sensitivities(sol_oop_sde, EulerHeun(), t = tarray,
+        res_oop_p = adjoint_sensitivities(
+        sol_oop_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint())
+        sensealg = BacksolveAdjoint()
+    )
 
     @info res_oop_p
 
@@ -489,84 +557,100 @@ end
     sol_sde = solve(prob_sde, EulerHeun(), dt = dt1, adaptive = false, save_noise = true)
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint())
+        sensealg = BacksolveAdjoint()
+    )
 
-    isapprox(res_sde_p, res_oop_p, rtol = 1e-6)
-    isapprox(res_sde_u0, res_oop_u0, rtol = 1e-6)
+    isapprox(res_sde_p, res_oop_p, rtol = 1.0e-6)
+    isapprox(res_sde_u0, res_oop_u0, rtol = 1.0e-6)
 
     @info res_sde_p
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = false))
+        sensealg = BacksolveAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_p, res_oop_p, rtol = 1e-6)
-    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1e-6)
+    @test isapprox(res_sde_p, res_oop_p, rtol = 1.0e-6)
+    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1.0e-6)
 
     @info res_sde_p
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
+        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP())
+    )
 
-    @test isapprox(res_sde_p, res_oop_p, rtol = 1e-6)
-    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1e-6)
+    @test isapprox(res_sde_p, res_oop_p, rtol = 1.0e-6)
+    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1.0e-6)
 
     @info res_sde_p
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
-    @test isapprox(res_sde_p, res_oop_p, rtol = 1e-6)
-    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1e-6)
+    @test isapprox(res_sde_p, res_oop_p, rtol = 1.0e-6)
+    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1.0e-6)
 
     @info res_sde_p
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    )
 
-    @test isapprox(res_sde_p, res_oop_p, rtol = 5e-4)
-    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1e-4)
+    @test isapprox(res_sde_p, res_oop_p, rtol = 5.0e-4)
+    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1.0e-4)
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint())
+        sensealg = InterpolatingAdjoint()
+    )
 
-    @test isapprox(res_sde_p, res_oop_p, rtol = 5e-4)
-    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1e-4)
+    @test isapprox(res_sde_p, res_oop_p, rtol = 5.0e-4)
+    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1.0e-4)
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = false))
+        sensealg = InterpolatingAdjoint(autojacvec = false)
+    )
 
-    @test isapprox(res_sde_p, res_oop_p, rtol = 5e-4)
-    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1e-4)
+    @test isapprox(res_sde_p, res_oop_p, rtol = 5.0e-4)
+    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1.0e-4)
 
     res_sde_u0,
-    res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
+        res_sde_p = adjoint_sensitivities(
+        sol_sde, EulerHeun(), t = tarray,
         dgdu_discrete = dg!,
         dt = dt1, adaptive = false,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
+        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+    )
 
-    @test_broken isapprox(res_sde_p, res_oop_p, rtol = 1e-4)
-    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1e-4)
+    @test_broken isapprox(res_sde_p, res_oop_p, rtol = 1.0e-4)
+    @test isapprox(res_sde_u0, res_oop_u0, rtol = 1.0e-4)
 end
 
 @testset "SDE oop Tests (Tracker)" begin
@@ -586,13 +670,17 @@ end
 
     function GSDE1(p)
         Random.seed!(seed)
-        tmp_prob = remake(prob_oop_sde, u0 = eltype(p).(prob_oop_sde.u0), p = p,
-            tspan = eltype(p).(prob_oop_sde.tspan))
-        sol = solve(tmp_prob,
+        tmp_prob = remake(
+            prob_oop_sde, u0 = eltype(p).(prob_oop_sde.u0), p = p,
+            tspan = eltype(p).(prob_oop_sde.tspan)
+        )
+        sol = solve(
+            tmp_prob,
             RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
-            dt = 5e-4,
+            dt = 5.0e-4,
             adaptive = false, sensealg = DiffEqBase.SensitivityADPassThrough(),
-            saveat = tarray)
+            saveat = tarray
+        )
         A = convert(Array, sol)
         res = g(A, p, nothing)
     end
@@ -600,21 +688,30 @@ end
 
     Random.seed!(seed)
     res_sde_trackeru0,
-    res_sde_trackerp = Zygote.gradient(
-        (u0,
-            p) -> sum(Array(solve(prob_oop_sde,
-            RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
-            dt = 5e-4,
-            adaptive = false,
-            u0 = u0,
-            p = p,
-            saveat = tarray,
-            sensealg = TrackerAdjoint())) .^
-                      2.0 / 2.0),
+        res_sde_trackerp = Zygote.gradient(
+        (
+            u0,
+            p,
+        ) -> sum(
+            Array(
+                solve(
+                    prob_oop_sde,
+                    RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
+                    dt = 5.0e-4,
+                    adaptive = false,
+                    u0 = u0,
+                    p = p,
+                    saveat = tarray,
+                    sensealg = TrackerAdjoint()
+                )
+            ) .^
+                2.0 / 2.0
+        ),
         u₀,
-        p2)
+        p2
+    )
 
-    @test isapprox(res_sde_forward, res_sde_trackerp, rtol = 1e-5)
+    @test isapprox(res_sde_forward, res_sde_trackerp, rtol = 1.0e-5)
 end
 
 @testset "diffusion functions that do not depend on the parameters" begin
@@ -641,6 +738,6 @@ end
     Random.seed!(seed)
     Zdp, Zdu0 = Zygote.gradient(loss, p, u0)
 
-    @test Fdu0 ≈ Zdu0 rtol=1e-4
-    @test Fdp≈Zdp rtol=1e-4
+    @test Fdu0 ≈ Zdu0 rtol = 1.0e-4
+    @test Fdp ≈ Zdp rtol = 1.0e-4
 end

--- a/test/second_order.jl
+++ b/test/second_order.jl
@@ -3,7 +3,7 @@ using Test
 
 function fb(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
 end
 
 function jac(J, u, p, t)
@@ -11,7 +11,7 @@ function jac(J, u, p, t)
     J[1, 1] = a + y * b * -1
     J[2, 1] = y
     J[1, 2] = b * x * -1
-    J[2, 2] = c * -1 + x
+    return J[2, 2] = c * -1 + x
 end
 
 f = ODEFunction(fb, jac = jac)
@@ -21,13 +21,17 @@ prob = ODEProblem(f, u0, (0.0, 10.0), p)
 loss(sol) = sum(sol)
 v = ones(4)
 
-H = second_order_sensitivities(loss, prob, Vern9(), saveat = 0.1, abstol = 1e-12,
-    reltol = 1e-12)
-Hv = second_order_sensitivity_product(loss, v, prob, Vern9(), saveat = 0.1, abstol = 1e-12,
-    reltol = 1e-12)
+H = second_order_sensitivities(
+    loss, prob, Vern9(), saveat = 0.1, abstol = 1.0e-12,
+    reltol = 1.0e-12
+)
+Hv = second_order_sensitivity_product(
+    loss, v, prob, Vern9(), saveat = 0.1, abstol = 1.0e-12,
+    reltol = 1.0e-12
+)
 
 function _loss(p)
-    loss(solve(prob, Vern9(); u0 = u0, p = p, saveat = 0.1, abstol = 1e-12, reltol = 1e-12))
+    return loss(solve(prob, Vern9(); u0 = u0, p = p, saveat = 0.1, abstol = 1.0e-12, reltol = 1.0e-12))
 end
 H2 = ForwardDiff.hessian(_loss, p)
 H2v = H * v
@@ -36,8 +40,8 @@ H2v = H * v
 @test Hv ≈ H2v
 
 function lotka!(du, u, p, t)
-    du[1] = dx = p[1]*u[1] - p[2]*u[1]*u[2]
-    du[2] = dy = -p[3]*u[2] + p[4]*u[1]*u[2]
+    du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
+    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
 end
 
 p = [1.5, 1.0, 3.0, 1.0];
@@ -47,8 +51,10 @@ loss(sol) = sum(sol)
 v = ones(4)
 
 Hv = second_order_sensitivity_product(
-    loss, v, prob, Vern9(), saveat = 0.1, abstol = 1e-12, reltol = 1e-12)
+    loss, v, prob, Vern9(), saveat = 0.1, abstol = 1.0e-12, reltol = 1.0e-12
+)
 forward_Hv = ForwardDiff.hessian(
-    p -> sum(solve(prob, Vern9(), p = p, saveat = 0.1, abstol = 1e-12, reltol = 1e-12)),
-    p)*v
+    p -> sum(solve(prob, Vern9(), p = p, saveat = 0.1, abstol = 1.0e-12, reltol = 1.0e-12)),
+    p
+) * v
 @test Hv ≈ forward_Hv

--- a/test/second_order_odes.jl
+++ b/test/second_order_odes.jl
@@ -8,45 +8,89 @@ p = Float32[1.01, 0.9]
 ff(du, u, p, t) = -p .* u
 prob = SecondOrderODEProblem{false}(ff, du0, u0, tspan, p)
 ddu01, du01,
-dp1 = Zygote.gradient(
-    (du0,
+    dp1 = Zygote.gradient(
+    (
+        du0,
         u0,
-        p) -> sum(Array(solve(prob, Tsit5(),
-        u0 = ArrayPartition(du0,
-            u0),
-        p = p, saveat = t,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())))),
-    du0, u0, p)
+        p,
+    ) -> sum(
+        Array(
+            solve(
+                prob, Tsit5(),
+                u0 = ArrayPartition(
+                    du0,
+                    u0
+                ),
+                p = p, saveat = t,
+                sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+            )
+        )
+    ),
+    du0, u0, p
+)
 ddu02, du02,
-dp2 = Zygote.gradient(
-    (du0,
+    dp2 = Zygote.gradient(
+    (
+        du0,
         u0,
-        p) -> sum(Array(solve(prob, Tsit5(),
-        u0 = ArrayPartition(du0,
-            u0),
-        p = p, saveat = t,
-        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP())))),
-    du0, u0, p)
+        p,
+    ) -> sum(
+        Array(
+            solve(
+                prob, Tsit5(),
+                u0 = ArrayPartition(
+                    du0,
+                    u0
+                ),
+                p = p, saveat = t,
+                sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP())
+            )
+        )
+    ),
+    du0, u0, p
+)
 ddu03, du03,
-dp3 = Zygote.gradient(
-    (du0,
+    dp3 = Zygote.gradient(
+    (
+        du0,
         u0,
-        p) -> sum(Array(solve(prob, Tsit5(),
-        u0 = ArrayPartition(du0,
-            u0),
-        p = p, saveat = t,
-        sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP())))),
-    du0, u0, p)
+        p,
+    ) -> sum(
+        Array(
+            solve(
+                prob, Tsit5(),
+                u0 = ArrayPartition(
+                    du0,
+                    u0
+                ),
+                p = p, saveat = t,
+                sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP())
+            )
+        )
+    ),
+    du0, u0, p
+)
 ddu04, du04,
-dp4 = Zygote.gradient(
-    (du0,
+    dp4 = Zygote.gradient(
+    (
+        du0,
         u0,
-        p) -> sum(Array(solve(prob, Tsit5(),
-        u0 = ArrayPartition(du0,
-            u0),
-        p = p, saveat = t,
-        sensealg = ForwardDiffSensitivity()))),
-    du0, u0, p)
+        p,
+    ) -> sum(
+        Array(
+            solve(
+                prob, Tsit5(),
+                u0 = ArrayPartition(
+                    du0,
+                    u0
+                ),
+                p = p, saveat = t,
+                sensealg = ForwardDiffSensitivity()
+            )
+        )
+    ),
+    du0, u0, p
+)
 @test ddu01 ≈ ddu02
 @test ddu01 ≈ ddu03
 @test ddu01 ≈ ddu04

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -22,7 +22,7 @@ using Zygote
         prob_init = ODEProblem(lorenz!, u0, tspan_init, p)
         sol_init = solve(prob_init, Tsit5())
         prob_attractor = ODEProblem(lorenz!, sol_init.u[end], tspan_attractor, p)
-        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14)
+        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14)
 
         g(u, p, t) = u[end]
         function dg(out, u, p, t, i = nothing)
@@ -30,27 +30,51 @@ using Zygote
             out[end] = one(eltype(u))
         end
         lss_problem1 = ForwardLSSProblem(sol_attractor, ForwardLSS(g = g))
-        lss_problem1a = ForwardLSSProblem(sol_attractor, ForwardLSS(g = g),
-            dgdu_continuous = dg)
-        lss_problem2 = ForwardLSSProblem(sol_attractor,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.Cos2Windowing(),
-                g = g))
-        lss_problem2a = ForwardLSSProblem(sol_attractor,
+        lss_problem1a = ForwardLSSProblem(
+            sol_attractor, ForwardLSS(g = g),
+            dgdu_continuous = dg
+        )
+        lss_problem2 = ForwardLSSProblem(
+            sol_attractor,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.Cos2Windowing(),
+                g = g
+            )
+        )
+        lss_problem2a = ForwardLSSProblem(
+            sol_attractor,
             ForwardLSS(LSSregularizer = SciMLSensitivity.Cos2Windowing()),
-            dgdu_continuous = dg)
-        lss_problem3 = ForwardLSSProblem(sol_attractor,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g))
-        lss_problem3a = ForwardLSSProblem(sol_attractor,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), dgdu_continuous = dg) #ForwardLSS with time dilation requires knowledge of g
+            dgdu_continuous = dg
+        )
+        lss_problem3 = ForwardLSSProblem(
+            sol_attractor,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            )
+        )
+        lss_problem3a = ForwardLSSProblem(
+            sol_attractor,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), dgdu_continuous = dg
+        ) #ForwardLSS with time dilation requires knowledge of g
 
-        adjointlss_problem = AdjointLSSProblem(sol_attractor,
-            AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g))
-        adjointlss_problem_a = AdjointLSSProblem(sol_attractor,
-            AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), dgdu_continuous = dg)
+        adjointlss_problem = AdjointLSSProblem(
+            sol_attractor,
+            AdjointLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            )
+        )
+        adjointlss_problem_a = AdjointLSSProblem(
+            sol_attractor,
+            AdjointLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), dgdu_continuous = dg
+        )
 
         res1 = shadow_forward(lss_problem1)
         res1a = shadow_forward(lss_problem1a)
@@ -62,45 +86,73 @@ using Zygote
         res4 = shadow_adjoint(adjointlss_problem)
         res4a = shadow_adjoint(adjointlss_problem_a)
 
-        @test res1[1]≈1 atol=1e-1
-        @test res2[1]≈1 atol=2e-1
-        @test res3[1]≈1 atol=5e-2
+        @test res1[1] ≈ 1 atol = 1.0e-1
+        @test res2[1] ≈ 1 atol = 2.0e-1
+        @test res3[1] ≈ 1 atol = 5.0e-2
 
-        @test res1≈res1a atol=1e-10
-        @test res2≈res2a atol=1e-10
-        @test res3≈res3a atol=1e-10
-        @test res3≈res4 atol=1e-10
-        @test res3≈res4a atol=1e-10
+        @test res1 ≈ res1a atol = 1.0e-10
+        @test res2 ≈ res2a atol = 1.0e-10
+        @test res3 ≈ res3a atol = 1.0e-10
+        @test res3 ≈ res4 atol = 1.0e-10
+        @test res3 ≈ res4a atol = 1.0e-10
 
         # fixed saveat to compare with concrete solve
-        sol_attractor2 = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14,
-            saveat = 0.01)
-        lss_problem1 = ForwardLSSProblem(sol_attractor2, ForwardLSS(g = g),
-            t = sol_attractor2.t)
-        lss_problem1a = ForwardLSSProblem(sol_attractor2, ForwardLSS(g = g),
+        sol_attractor2 = solve(
+            prob_attractor, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14,
+            saveat = 0.01
+        )
+        lss_problem1 = ForwardLSSProblem(
+            sol_attractor2, ForwardLSS(g = g),
+            t = sol_attractor2.t
+        )
+        lss_problem1a = ForwardLSSProblem(
+            sol_attractor2, ForwardLSS(g = g),
             t = sol_attractor2.t,
-            dgdu_discrete = dg)
-        lss_problem2 = ForwardLSSProblem(sol_attractor2,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.Cos2Windowing(),
-                g = g), t = sol_attractor2.t)
-        lss_problem2a = ForwardLSSProblem(sol_attractor2,
+            dgdu_discrete = dg
+        )
+        lss_problem2 = ForwardLSSProblem(
+            sol_attractor2,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.Cos2Windowing(),
+                g = g
+            ), t = sol_attractor2.t
+        )
+        lss_problem2a = ForwardLSSProblem(
+            sol_attractor2,
             ForwardLSS(LSSregularizer = SciMLSensitivity.Cos2Windowing()),
-            t = sol_attractor2.t, dgdu_discrete = dg)
-        lss_problem3 = ForwardLSSProblem(sol_attractor2,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), t = sol_attractor2.t)
-        lss_problem3a = ForwardLSSProblem(sol_attractor2,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), t = sol_attractor2.t,
-            dgdu_discrete = dg) #ForwardLSS with time dilation requires knowledge of g
+            t = sol_attractor2.t, dgdu_discrete = dg
+        )
+        lss_problem3 = ForwardLSSProblem(
+            sol_attractor2,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), t = sol_attractor2.t
+        )
+        lss_problem3a = ForwardLSSProblem(
+            sol_attractor2,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), t = sol_attractor2.t,
+            dgdu_discrete = dg
+        ) #ForwardLSS with time dilation requires knowledge of g
 
-        adjointlss_problem = AdjointLSSProblem(sol_attractor2,
-            AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), t = sol_attractor2.t)
-        adjointlss_problem_a = AdjointLSSProblem(sol_attractor2,
-            AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), t = sol_attractor2.t,
-            dgdu_discrete = dg)
+        adjointlss_problem = AdjointLSSProblem(
+            sol_attractor2,
+            AdjointLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), t = sol_attractor2.t
+        )
+        adjointlss_problem_a = AdjointLSSProblem(
+            sol_attractor2,
+            AdjointLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), t = sol_attractor2.t,
+            dgdu_discrete = dg
+        )
 
         res1 = shadow_forward(lss_problem1)
         res1a = shadow_forward(lss_problem1a)
@@ -112,45 +164,60 @@ using Zygote
         res4 = shadow_adjoint(adjointlss_problem)
         res4a = shadow_adjoint(adjointlss_problem_a)
 
-        @test res1[1]≈1 atol=5e-2
-        @test res2[1]≈1 atol=5e-2
-        @test res3[1]≈1 atol=5e-2
+        @test res1[1] ≈ 1 atol = 5.0e-2
+        @test res2[1] ≈ 1 atol = 5.0e-2
+        @test res3[1] ≈ 1 atol = 5.0e-2
 
-        @test res1≈res1a atol=1e-10
-        @test res2≈res2a atol=1e-10
-        @test res3≈res3a atol=1e-10
-        @test res3≈res4 atol=1e-10
-        @test res3≈res4a atol=1e-10
+        @test res1 ≈ res1a atol = 1.0e-10
+        @test res2 ≈ res2a atol = 1.0e-10
+        @test res3 ≈ res3a atol = 1.0e-10
+        @test res3 ≈ res4 atol = 1.0e-10
+        @test res3 ≈ res4a atol = 1.0e-10
 
         function G(p; sensealg = ForwardLSS(g = g), dt = 0.01)
             _prob = remake(prob_attractor, p = p)
-            _sol = solve(_prob, Vern9(), abstol = 1e-14, reltol = 1e-14, saveat = dt,
-                sensealg = sensealg)
+            _sol = solve(
+                _prob, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14, saveat = dt,
+                sensealg = sensealg
+            )
             sum(getindex.(_sol.u, 3))
         end
 
         dp1 = Zygote.gradient((p) -> G(p), p)
-        @test res1≈dp1[1] atol=1e-10
+        @test res1 ≈ dp1[1] atol = 1.0e-10
 
         dp1 = Zygote.gradient(
-            (p) -> G(p,
-                sensealg = ForwardLSS(LSSregularizer = SciMLSensitivity.Cos2Windowing())),
-            p)
-        @test res2≈dp1[1] atol=1e-10
+            (p) -> G(
+                p,
+                sensealg = ForwardLSS(LSSregularizer = SciMLSensitivity.Cos2Windowing())
+            ),
+            p
+        )
+        @test res2 ≈ dp1[1] atol = 1.0e-10
 
         dp1 = Zygote.gradient(
-            (p) -> G(p,
-                sensealg = ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                    g = g)),
-            p)
-        @test res3≈dp1[1] atol=1e-10
+            (p) -> G(
+                p,
+                sensealg = ForwardLSS(
+                    LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                    g = g
+                )
+            ),
+            p
+        )
+        @test res3 ≈ dp1[1] atol = 1.0e-10
 
         dp1 = Zygote.gradient(
-            (p) -> G(p,
-                sensealg = AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                    g = g)),
-            p)
-        @test res4≈dp1[1] atol=1e-10
+            (p) -> G(
+                p,
+                sensealg = AdjointLSS(
+                    LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                    g = g
+                )
+            ),
+            p
+        )
+        @test res4 ≈ dp1[1] atol = 1.0e-10
 
         @show res1[1] res2[1] res3[1]
     end
@@ -170,7 +237,7 @@ using Zygote
         prob_init = ODEProblem(lorenz!, u0, tspan_init, p)
         sol_init = solve(prob_init, Tsit5())
         prob_attractor = ODEProblem(lorenz!, sol_init.u[end], tspan_attractor, p)
-        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14)
+        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14)
 
         g(u, p, t) = u[end] + sum(p)
         function dgu(out, u, p, t, i = nothing)
@@ -181,58 +248,92 @@ using Zygote
             fill!(out, one(eltype(p)))
         end
 
-        lss_problem = ForwardLSSProblem(sol_attractor,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g))
-        lss_problem_a = ForwardLSSProblem(sol_attractor,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), dgdu_continuous = dgu,
-            dgdp_continuous = dgp)
-        adjointlss_problem = AdjointLSSProblem(sol_attractor,
-            AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g))
-        adjointlss_problem_a = AdjointLSSProblem(sol_attractor,
-            AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g),
+        lss_problem = ForwardLSSProblem(
+            sol_attractor,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            )
+        )
+        lss_problem_a = ForwardLSSProblem(
+            sol_attractor,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), dgdu_continuous = dgu,
+            dgdp_continuous = dgp
+        )
+        adjointlss_problem = AdjointLSSProblem(
+            sol_attractor,
+            AdjointLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            )
+        )
+        adjointlss_problem_a = AdjointLSSProblem(
+            sol_attractor,
+            AdjointLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ),
             dgdu_continuous = dgu,
-            dgdp_continuous = dgp)
+            dgdp_continuous = dgp
+        )
 
         resfw = shadow_forward(lss_problem)
         resfw_a = shadow_forward(lss_problem_a)
         resadj = shadow_adjoint(adjointlss_problem)
         resadj_a = shadow_adjoint(adjointlss_problem_a)
 
-        @test resfw≈resadj rtol=1e-10
-        @test resfw≈resfw_a rtol=1e-10
-        @test resfw≈resadj_a rtol=1e-10
+        @test resfw ≈ resadj rtol = 1.0e-10
+        @test resfw ≈ resfw_a rtol = 1.0e-10
+        @test resfw ≈ resadj_a rtol = 1.0e-10
 
-        sol_attractor2 = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14,
-            saveat = 0.01)
-        lss_problem = ForwardLSSProblem(sol_attractor2,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), t = sol_attractor2.t)
+        sol_attractor2 = solve(
+            prob_attractor, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14,
+            saveat = 0.01
+        )
+        lss_problem = ForwardLSSProblem(
+            sol_attractor2,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), t = sol_attractor2.t
+        )
         resfw = shadow_forward(lss_problem)
 
         function G(p; sensealg = ForwardLSS(), dt = 0.01)
             _prob = remake(prob_attractor, p = p)
-            _sol = solve(_prob, Vern9(), abstol = 1e-14, reltol = 1e-14, saveat = dt,
-                sensealg = sensealg)
+            _sol = solve(
+                _prob, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14, saveat = dt,
+                sensealg = sensealg
+            )
             sum(getindex.(_sol.u, 3)) + sum(p)
         end
 
         dp1 = Zygote.gradient(
-            (p) -> G(p,
-                sensealg = ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                    g = g)),
-            p)
-        @test resfw≈dp1[1] atol=1e-10
+            (p) -> G(
+                p,
+                sensealg = ForwardLSS(
+                    LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                    g = g
+                )
+            ),
+            p
+        )
+        @test resfw ≈ dp1[1] atol = 1.0e-10
 
         dp1 = Zygote.gradient(
-            (p) -> G(p,
-                sensealg = AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                    g = g)),
-            p)
-        @test resfw≈dp1[1] atol=1e-10
+            (p) -> G(
+                p,
+                sensealg = AdjointLSS(
+                    LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                    g = g
+                )
+            ),
+            p
+        )
+        @test resfw ≈ dp1[1] atol = 1.0e-10
 
         @show resfw
     end
@@ -252,8 +353,10 @@ using Zygote
         prob_init = ODEProblem(lorenz!, u0, tspan_init, p)
         sol_init = solve(prob_init, Tsit5())
         prob_attractor = ODEProblem(lorenz!, sol_init.u[end], tspan_attractor, p)
-        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14,
-            saveat = 0.01)
+        sol_attractor = solve(
+            prob_attractor, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14,
+            saveat = 0.01
+        )
 
         g(u, p, t) = u[end]^2 / 2 + sum(p)
         function dgu(out, u, p, t, i = nothing)
@@ -266,112 +369,172 @@ using Zygote
 
         function G(p; sensealg = ForwardLSS(g = g), dt = 0.01)
             _prob = remake(prob_attractor, p = p)
-            _sol = solve(_prob, Vern9(), abstol = 1e-14, reltol = 1e-14, saveat = dt,
-                sensealg = sensealg)
+            _sol = solve(
+                _prob, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14, saveat = dt,
+                sensealg = sensealg
+            )
             sum(getindex.(_sol.u, 3) .^ 2) / 2 + sum(p)
         end
 
         ## ForwardLSS
 
-        lss_problem = ForwardLSSProblem(sol_attractor,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), t = sol_attractor.t)
+        lss_problem = ForwardLSSProblem(
+            sol_attractor,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), t = sol_attractor.t
+        )
         resfw = shadow_forward(lss_problem)
 
         res = deepcopy(resfw)
 
         dp1 = Zygote.gradient(
-            (p) -> G(p,
-                sensealg = ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                    g = g)),
-            p)
-        @test res≈dp1[1] atol=1e-10
+            (p) -> G(
+                p,
+                sensealg = ForwardLSS(
+                    LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                    g = g
+                )
+            ),
+            p
+        )
+        @test res ≈ dp1[1] atol = 1.0e-10
 
-        resfw = shadow_forward(lss_problem,
+        resfw = shadow_forward(
+            lss_problem,
             sensealg = ForwardLSS(
-                LSSregularizer = SciMLSensitivity.TimeDilation(10.0,
+                LSSregularizer = SciMLSensitivity.TimeDilation(
                     10.0,
-                    5.0),
-                g = g))
+                    10.0,
+                    5.0
+                ),
+                g = g
+            )
+        )
         resskip = deepcopy(resfw)
 
         dp1 = Zygote.gradient(
-            (p) -> G(p,
+            (p) -> G(
+                p,
                 sensealg = ForwardLSS(
-                    LSSregularizer = SciMLSensitivity.TimeDilation(10.0,
+                    LSSregularizer = SciMLSensitivity.TimeDilation(
                         10.0,
-                        5.0),
-                    g = g)),
-            p)
-        @test resskip≈dp1[1] atol=1e-10
+                        10.0,
+                        5.0
+                    ),
+                    g = g
+                )
+            ),
+            p
+        )
+        @test resskip ≈ dp1[1] atol = 1.0e-10
 
         @show res resskip
 
         ## ForwardLSS with dgdu and dgdp
 
-        lss_problem = ForwardLSSProblem(sol_attractor,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), t = sol_attractor.t,
+        lss_problem = ForwardLSSProblem(
+            sol_attractor,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), t = sol_attractor.t,
             dgdu_discrete = dgu,
-            dgdp_discrete = dgp)
+            dgdp_discrete = dgp
+        )
         res2 = shadow_forward(lss_problem)
-        @test res≈res2 atol=1e-10
-        res2 = shadow_forward(lss_problem,
+        @test res ≈ res2 atol = 1.0e-10
+        res2 = shadow_forward(
+            lss_problem,
             sensealg = ForwardLSS(
-                LSSregularizer = SciMLSensitivity.TimeDilation(10.0,
+                LSSregularizer = SciMLSensitivity.TimeDilation(
                     10.0,
-                    5.0),
-                g = g))
-        @test resskip≈res2 atol=1e-10
+                    10.0,
+                    5.0
+                ),
+                g = g
+            )
+        )
+        @test resskip ≈ res2 atol = 1.0e-10
 
         ## AdjointLSS
 
-        lss_problem = AdjointLSSProblem(sol_attractor,
-            AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), t = sol_attractor.t)
+        lss_problem = AdjointLSSProblem(
+            sol_attractor,
+            AdjointLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), t = sol_attractor.t
+        )
         res2 = shadow_adjoint(lss_problem)
-        @test res≈res2 atol=1e-10
-        res2 = shadow_adjoint(lss_problem,
+        @test res ≈ res2 atol = 1.0e-10
+        res2 = shadow_adjoint(
+            lss_problem,
             sensealg = AdjointLSS(
-                LSSregularizer = SciMLSensitivity.TimeDilation(10.0,
+                LSSregularizer = SciMLSensitivity.TimeDilation(
                     10.0,
-                    5.0),
-                g = g))
-        @test_broken resskip≈res2 atol=1e-10
+                    10.0,
+                    5.0
+                ),
+                g = g
+            )
+        )
+        @test_broken resskip ≈ res2 atol = 1.0e-10
 
         dp1 = Zygote.gradient(
-            (p) -> G(p,
-                sensealg = AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                    g = g)),
-            p)
-        @test res≈dp1[1] atol=1e-10
-
-        dp1 = Zygote.gradient(
-            (p) -> G(p,
+            (p) -> G(
+                p,
                 sensealg = AdjointLSS(
-                    LSSregularizer = SciMLSensitivity.TimeDilation(10.0,
+                    LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                    g = g
+                )
+            ),
+            p
+        )
+        @test res ≈ dp1[1] atol = 1.0e-10
+
+        dp1 = Zygote.gradient(
+            (p) -> G(
+                p,
+                sensealg = AdjointLSS(
+                    LSSregularizer = SciMLSensitivity.TimeDilation(
                         10.0,
-                        5.0),
-                    g = g)),
-            p)
-        @test res2≈dp1[1] atol=1e-10
+                        10.0,
+                        5.0
+                    ),
+                    g = g
+                )
+            ),
+            p
+        )
+        @test res2 ≈ dp1[1] atol = 1.0e-10
 
         ## AdjointLSS with dgdu and dgd
 
-        lss_problem = AdjointLSSProblem(sol_attractor,
-            AdjointLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), t = sol_attractor.t,
+        lss_problem = AdjointLSSProblem(
+            sol_attractor,
+            AdjointLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), t = sol_attractor.t,
             dgdu_discrete = dgu,
-            dgdp_discrete = dgp)
+            dgdp_discrete = dgp
+        )
         res2 = shadow_adjoint(lss_problem)
-        @test res≈res2 atol=1e-10
-        res2 = shadow_adjoint(lss_problem,
+        @test res ≈ res2 atol = 1.0e-10
+        res2 = shadow_adjoint(
+            lss_problem,
             sensealg = AdjointLSS(
-                LSSregularizer = SciMLSensitivity.TimeDilation(10.0,
+                LSSregularizer = SciMLSensitivity.TimeDilation(
                     10.0,
-                    5.0),
-                g = g))
-        @test_broken resskip≈res2 atol=1e-10
+                    10.0,
+                    5.0
+                ),
+                g = g
+            )
+        )
+        @test_broken resskip ≈ res2 atol = 1.0e-10
     end
 end
 
@@ -408,13 +571,15 @@ end
         res1 = SciMLSensitivity.shadow_forward(nilss_prob1, Tsit5())
 
         Random.seed!(1234)
-        nilss_prob2 = NILSSProblem(prob_attractor, NILSS(nseg, nstep, g = g),
-            dgdu_continuous = dg)
+        nilss_prob2 = NILSSProblem(
+            prob_attractor, NILSS(nseg, nstep, g = g),
+            dgdu_continuous = dg
+        )
         res2 = SciMLSensitivity.shadow_forward(nilss_prob2, Tsit5())
 
-        @test res1[1]≈1 atol=5e-2
-        @test res2[1]≈1 atol=5e-2
-        @test res1≈res2 atol=1e-10
+        @test res1[1] ≈ 1 atol = 5.0e-2
+        @test res2[1] ≈ 1 atol = 5.0e-2
+        @test res1 ≈ res2 atol = 1.0e-10
 
         function G(p; dt = nilss_prob1.dtsave)
             _prob = remake(prob_attractor, p = p)
@@ -424,7 +589,7 @@ end
 
         Random.seed!(1234)
         dp1 = Zygote.gradient((p) -> G(p), p)
-        @test res1≈dp1[1] atol=1e-10
+        @test res1 ≈ dp1[1] atol = 1.0e-10
     end
 
     @testset "Lorenz" begin
@@ -447,13 +612,17 @@ end
         sol_init = solve(prob_init, Tsit5())
 
         prob_attractor = ODEProblem(lorenz!, sol_init.u[end], tspan_attractor, p)
-        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14)
+        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14)
 
         g(u, p, t) = u[end]
 
-        lss_problem = ForwardLSSProblem(sol_attractor,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g))
+        lss_problem = ForwardLSSProblem(
+            sol_attractor,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            )
+        )
 
         resfw = shadow_forward(lss_problem)
 
@@ -465,7 +634,7 @@ end
         sol_init = solve(prob_init, Tsit5())
 
         prob_attractor = ODEProblem(lorenz!, sol_init.u[end], tspan_attractor, p)
-        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14)
+        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14)
 
         nseg = 50 # number of segments on time interval
         nstep = 2001 # number of steps on each segment
@@ -475,9 +644,9 @@ end
 
         # There is larger noise in LSS estimate of parameter 3 due to shorter timespan considered,
         # so test tolerance for parameter 3 is larger.
-        @test resfw[1]≈res[1] atol=5e-2
-        @test resfw[2]≈res[2] atol=5e-2
-        @test resfw[3]≈res[3] atol=5e-1
+        @test resfw[1] ≈ res[1] atol = 5.0e-2
+        @test resfw[2] ≈ res[2] atol = 5.0e-2
+        @test resfw[3] ≈ res[3] atol = 5.0e-1
     end
 end
 
@@ -491,10 +660,14 @@ end
         quadcache = SciMLSensitivity.QuadratureCache(u0, M, nseg, numparams)
 
         C = quadcache.C
-        C[:, :, 1] .= [1.0 0.0
-                       0.0 1.0]
-        C[:, :, 2] .= [4.0 0.0
-                       0.0 1.0]
+        C[:, :, 1] .= [
+            1.0 0.0
+            0.0 1.0
+        ]
+        C[:, :, 2] .= [
+            4.0 0.0
+            0.0 1.0
+        ]
 
         dwv = quadcache.dwv
         dwv[:, 1] .= [1.0, 0.0]
@@ -509,17 +682,23 @@ end
         dvf[2] = 2.0
 
         R = quadcache.R
-        R[:, :, 1] .= [Inf Inf
-                       Inf Inf]
-        R[:, :, 2] .= [1.0 1.0
-                       0.0 2.0]
+        R[:, :, 1] .= [
+            Inf Inf
+            Inf Inf
+        ]
+        R[:, :, 2] .= [
+            1.0 1.0
+            0.0 2.0
+        ]
 
         b = quadcache.b
         b[:, 1] = [Inf, Inf]
         b[:, 2] = [0.0, 1.0]
 
-        @test SciMLSensitivity.nilsas_min(quadcache) ≈ [-1.0 0.0
-                                                        -1.0 -1.0]
+        @test SciMLSensitivity.nilsas_min(quadcache) ≈ [
+            -1.0 0.0
+            -1.0 -1.0
+        ]
     end
     @testset "Lorenz" begin
         function lorenz!(du, u, p, t)
@@ -545,8 +724,10 @@ end
 
         tspan_attractor = (0.0, 40.0)
         prob_attractor = ODEProblem(lorenz!, u0, tspan_attractor, p)
-        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14,
-            saveat = 0.01)
+        sol_attractor = solve(
+            prob_attractor, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14,
+            saveat = 0.01
+        )
 
         g(u, p, t) = u[end]
         function dg(out, u, p, t, i = nothing)
@@ -554,9 +735,13 @@ end
             out[end] = one(eltype(u))
         end
 
-        lss_problem = ForwardLSSProblem(sol_attractor,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), dgdu_continuous = dg)
+        lss_problem = ForwardLSSProblem(
+            sol_attractor,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), dgdu_continuous = dg
+        )
         resfw = shadow_forward(lss_problem)
 
         @info resfw
@@ -566,15 +751,17 @@ end
 
         @info res
 
-        @test resfw≈res atol=1e-1
+        @test resfw ≈ res atol = 1.0e-1
 
-        nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg, nstep, M, g = g), Tsit5(),
-            dgdu_continuous = dg)
+        nilsas_prob = NILSASProblem(
+            sol_attractor, NILSAS(nseg, nstep, M, g = g), Tsit5(),
+            dgdu_continuous = dg
+        )
         res = shadow_adjoint(nilsas_prob, Tsit5())
 
         @info res
 
-        @test resfw≈res atol=1e-1
+        @test resfw ≈ res atol = 1.0e-1
     end
 
     @testset "Lorenz parameter-dependent loss function" begin
@@ -601,8 +788,10 @@ end
 
         tspan_attractor = (0.0, 50.0)
         prob_attractor = ODEProblem(lorenz!, u0, tspan_attractor, p)
-        sol_attractor = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14,
-            saveat = 0.01)
+        sol_attractor = solve(
+            prob_attractor, Vern9(), abstol = 1.0e-14, reltol = 1.0e-14,
+            saveat = 0.01
+        )
 
         g(u, p, t) = u[end]^2 / 2 + sum(p)
         function dgu(out, u, p, t, i = nothing)
@@ -613,11 +802,15 @@ end
             fill!(out, one(eltype(p)))
         end
 
-        lss_problem = ForwardLSSProblem(sol_attractor,
-            ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                g = g), t = sol_attractor.t,
+        lss_problem = ForwardLSSProblem(
+            sol_attractor,
+            ForwardLSS(
+                LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
+                g = g
+            ), t = sol_attractor.t,
             dgdu_discrete = dgu,
-            dgdp_discrete = dgp)
+            dgdp_discrete = dgp
+        )
         resfw = shadow_forward(lss_problem)
 
         @info resfw
@@ -627,14 +820,16 @@ end
 
         @info res
 
-        @test resfw≈res rtol=1e-1
+        @test resfw ≈ res rtol = 1.0e-1
 
-        @test_throws ErrorException nilsas_prob=NILSASProblem(sol_attractor,
+        @test_throws ErrorException nilsas_prob = NILSASProblem(
+            sol_attractor,
             NILSAS(nseg, nstep, M, g = g),
             Tsit5(),
             t = sol_attractor.t,
             dgdu_discrete = dgu,
-            dgdp_discrete = dgp)
+            dgdp_discrete = dgp
+        )
         # res = shadow_adjoint(nilsas_prob, Tsit5())
         # @test resfw ≈ res rtol = 1e-1
     end

--- a/test/size_handling_adjoint.jl
+++ b/test/size_handling_adjoint.jl
@@ -4,7 +4,7 @@ using Optimization, OptimizationOptimisers
 p = [1.5 1.0; 3.0 1.0]
 function lotka_volterra(du, u, p, t)
     du[1] = p[1, 1] * u[1] - p[1, 2] * u[1] * u[2]
-    du[2] = -p[2, 1] * u[2] + p[2, 2] * u[1] * u[2]
+    return du[2] = -p[2, 1] * u[2] + p[2, 2] * u[1] * u[2]
 end
 
 u0 = [1.0, 1.0]
@@ -18,13 +18,15 @@ sol = solve(prob, Tsit5())
 ps = [2.2 1.0; 2.0 0.4] # Tweaked Initial Parameter Array
 
 function predict_adjoint(p) # Our 1-layer neural network
-    Array(solve(prob, Tsit5(), p = p, saveat = 0.0:0.1:10.0))
+    return Array(solve(prob, Tsit5(), p = p, saveat = 0.0:0.1:10.0))
 end
 
 loss_adjoint(p, _) = sum(abs2, x - 1 for x in predict_adjoint(p))
 
-res = solve(OptimizationProblem(OptimizationFunction(loss_adjoint, AutoZygote()), ps),
-    Adam(0.1); maxiters = 200)
+res = solve(
+    OptimizationProblem(OptimizationFunction(loss_adjoint, AutoZygote()), ps),
+    Adam(0.1); maxiters = 200
+)
 
 @test loss_adjoint(res.u, nothing) < 1
 
@@ -44,8 +46,10 @@ end
 
 function loss(p; vjp)
     prob = ODEProblem(rhs!, f0, tspan, p)
-    sol = solve(prob, Midpoint(), saveat = tran,
-        sensealg = InterpolatingAdjoint(autojacvec = vjp)) |> Array
+    sol = solve(
+        prob, Midpoint(), saveat = tran,
+        sensealg = InterpolatingAdjoint(autojacvec = vjp)
+    ) |> Array
     l = sum(abs2, sol)
 
     return l

--- a/test/sparse_adjoint.jl
+++ b/test/sparse_adjoint.jl
@@ -7,7 +7,7 @@ jac(u, p, t) = spdiagm(0 => p)
 paramjac(u, p, t) = SparseArrays.spdiagm(0 => u)
 Zygote.@adjoint function foop(u, p, t)
     foop(u, p, t),
-    delta -> (jac(u, p, t)' * delta, paramjac(u, p, t)' * delta, zeros(length(u)))
+        delta -> (jac(u, p, t)' * delta, paramjac(u, p, t)' * delta, zeros(length(u)))
 end
 
 n = 2
@@ -17,35 +17,64 @@ tspan = [0.0, 1]
 odef = ODEFunction(foop; jac = jac, jac_prototype = jac(u0, p, 0.0), paramjac = paramjac)
 function g_helper(p; alg = Rosenbrock23(linsolve = QRFactorization()))
     prob = ODEProblem(odef, u0, tspan, p)
-    soln = Array(solve(prob, alg; u0 = prob.u0, p = prob.p, abstol = 1e-4, reltol = 1e-4,
-        sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())))[:, end]
+    soln = Array(
+        solve(
+            prob, alg; u0 = prob.u0, p = prob.p, abstol = 1.0e-4, reltol = 1.0e-4,
+            sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())
+        )
+    )[:, end]
     return soln
 end
 function g(p; kwargs...)
     soln = g_helper(p; kwargs...)
     return sum(soln)
 end
-@test isapprox(exp.(p), g_helper(p); atol = 1e-3, rtol = 1e-3)
-@test isapprox(exp.(p), Zygote.gradient(g, p)[1]; atol = 1e-3, rtol = 1e-3)
-@test isapprox(exp.(p), g_helper(p; alg = Rosenbrock23(linsolve = KLUFactorization()));
-    atol = 1e-3, rtol = 1e-3)
-@test isapprox(exp.(p),
-    Zygote.gradient(p -> g(p; alg = Rosenbrock23(linsolve = KLUFactorization())),
-        p)[1]; atol = 1e-3, rtol = 1e-3)
-@test isapprox(exp.(p), g_helper(p; alg = ImplicitEuler(linsolve = LUFactorization()));
-    atol = 1e-1, rtol = 1e-1)
-@test isapprox(exp.(p),
-    Zygote.gradient(p -> g(p; alg = ImplicitEuler(linsolve = QRFactorization())),
-        p)[1]; atol = 1e-1, rtol = 1e-1)
+@test isapprox(exp.(p), g_helper(p); atol = 1.0e-3, rtol = 1.0e-3)
+@test isapprox(exp.(p), Zygote.gradient(g, p)[1]; atol = 1.0e-3, rtol = 1.0e-3)
+@test isapprox(
+    exp.(p), g_helper(p; alg = Rosenbrock23(linsolve = KLUFactorization()));
+    atol = 1.0e-3, rtol = 1.0e-3
+)
+@test isapprox(
+    exp.(p),
+    Zygote.gradient(
+        p -> g(p; alg = Rosenbrock23(linsolve = KLUFactorization())),
+        p
+    )[1]; atol = 1.0e-3, rtol = 1.0e-3
+)
+@test isapprox(
+    exp.(p), g_helper(p; alg = ImplicitEuler(linsolve = LUFactorization()));
+    atol = 1.0e-1, rtol = 1.0e-1
+)
+@test isapprox(
+    exp.(p),
+    Zygote.gradient(
+        p -> g(p; alg = ImplicitEuler(linsolve = QRFactorization())),
+        p
+    )[1]; atol = 1.0e-1, rtol = 1.0e-1
+)
 @test isapprox(
     exp.(p), g_helper(p; alg = ImplicitEuler(linsolve = UMFPACKFactorization()));
-    atol = 1e-1, rtol = 1e-1)
-@test isapprox(exp.(p),
-    Zygote.gradient(p -> g(p;
-            alg = ImplicitEuler(linsolve = UMFPACKFactorization())),
-        p)[1]; atol = 1e-1, rtol = 1e-1)
-@test isapprox(exp.(p), g_helper(p; alg = ImplicitEuler(linsolve = KrylovJL_GMRES()));
-    atol = 1e-1, rtol = 1e-1)
-@test isapprox(exp.(p),
-    Zygote.gradient(p -> g(p; alg = ImplicitEuler(linsolve = KrylovJL_GMRES())),
-        p)[1]; atol = 1e-1, rtol = 1e-1)
+    atol = 1.0e-1, rtol = 1.0e-1
+)
+@test isapprox(
+    exp.(p),
+    Zygote.gradient(
+        p -> g(
+            p;
+            alg = ImplicitEuler(linsolve = UMFPACKFactorization())
+        ),
+        p
+    )[1]; atol = 1.0e-1, rtol = 1.0e-1
+)
+@test isapprox(
+    exp.(p), g_helper(p; alg = ImplicitEuler(linsolve = KrylovJL_GMRES()));
+    atol = 1.0e-1, rtol = 1.0e-1
+)
+@test isapprox(
+    exp.(p),
+    Zygote.gradient(
+        p -> g(p; alg = ImplicitEuler(linsolve = KrylovJL_GMRES())),
+        p
+    )[1]; atol = 1.0e-1, rtol = 1.0e-1
+)

--- a/test/steady_state.jl
+++ b/test/steady_state.jl
@@ -44,7 +44,7 @@ Random.seed!(12345)
     u0 = zeros(2)
     p = [2.0, -2.0, 1.0, -4.0]
     prob = SteadyStateProblem(f!, u0, p)
-    abstol = 1e-10
+    abstol = 1.0e-10
     @testset "for p" begin
         println("Calculate adjoint sensitivities from Jacobians")
 
@@ -64,12 +64,12 @@ Random.seed!(12345)
         res_analytical = delg_delp' - lambda' * fp # = -gx*inv(J)*fp
 
         @info "Expected result" sol_analytical, res_analytical,
-        delg_delp' - gx * inv(J) * fp
+            delg_delp' - gx * inv(J) * fp
 
         @info "Calculate adjoint sensitivities from autodiff & numerical diff"
         function G(p)
             tmp_prob = remake(prob, u0 = convert.(eltype(p), prob.u0), p = p)
-            sol = solve(tmp_prob, DynamicSS(Rodas5()); abstol = 1e-14, reltol = 1e-14)
+            sol = solve(tmp_prob, DynamicSS(Rodas5()); abstol = 1.0e-14, reltol = 1.0e-14)
             A = convert(Array, sol)
             g(A, p, nothing)
         end
@@ -77,125 +77,181 @@ Random.seed!(12345)
         res2 = Calculus.gradient(G, p)
         #@info res1, res2, res_analytical
 
-        @test res1≈res_analytical' rtol=1e-7
-        @test res2≈res_analytical' rtol=1e-7
-        @test res1≈res2 rtol=1e-7
+        @test res1 ≈ res_analytical' rtol = 1.0e-7
+        @test res2 ≈ res_analytical' rtol = 1.0e-7
+        @test res1 ≈ res2 rtol = 1.0e-7
 
         @info "Adjoint sensitivities"
 
         # with jac, param_jac
         f1 = ODEFunction(f!; jac = jac!, paramjac = paramjac!)
         prob1 = SteadyStateProblem(f1, u0, p)
-        sol1 = solve(prob1, DynamicSS(Rodas5()), reltol = 1e-14, abstol = 1e-14)
+        sol1 = solve(prob1, DynamicSS(Rodas5()), reltol = 1.0e-14, abstol = 1.0e-14)
 
-        res1a = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
+        res1a = adjoint_sensitivities(
+            sol1, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(), dgdu = dgdu!,
-            dgdp = dgdp!, g = g)
-        res1b = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(), g = g)
-        res1c = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
+            dgdp = dgdp!, g = g
+        )
+        res1b = adjoint_sensitivities(
+            sol1, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(), g = g
+        )
+        res1c = adjoint_sensitivities(
+            sol1, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autodiff = false),
-            g = g)
-        res1d = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
+            g = g
+        )
+        res1d = adjoint_sensitivities(
+            sol1, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = TrackerVJP()),
-            g = g)
-        res1e = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
+            g = g
+        )
+        res1e = adjoint_sensitivities(
+            sol1, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = ReverseDiffVJP()),
-            g = g)
-        res1f = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
+            g = g
+        )
+        res1f = adjoint_sensitivities(
+            sol1, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP()),
-            g = g)
-        res1g = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(autodiff = false,
-                autojacvec = false),
-            g = g)
-        res1h = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
+            g = g
+        )
+        res1g = adjoint_sensitivities(
+            sol1, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(
+                autodiff = false,
+                autojacvec = false
+            ),
+            g = g
+        )
+        res1h = adjoint_sensitivities(
+            sol1, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = EnzymeVJP()),
-            g = g)
+            g = g
+        )
 
         # with jac, without param_jac
         f2 = ODEFunction(f!; jac = jac!)
         prob2 = SteadyStateProblem(f2, u0, p)
-        sol2 = solve(prob2, DynamicSS(Rodas5()),
-            reltol = 1e-14, abstol = 1e-14)
-        res2a = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
+        sol2 = solve(
+            prob2, DynamicSS(Rodas5()),
+            reltol = 1.0e-14, abstol = 1.0e-14
+        )
+        res2a = adjoint_sensitivities(
+            sol2, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(), dgdu = dgdu!,
-            dgdp = dgdp!, g = g)
-        res2b = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(), g = g)
-        res2c = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
+            dgdp = dgdp!, g = g
+        )
+        res2b = adjoint_sensitivities(
+            sol2, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(), g = g
+        )
+        res2c = adjoint_sensitivities(
+            sol2, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autodiff = false),
-            g = g)
-        res2d = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
+            g = g
+        )
+        res2d = adjoint_sensitivities(
+            sol2, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = TrackerVJP()),
-            g = g)
-        res2e = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
+            g = g
+        )
+        res2e = adjoint_sensitivities(
+            sol2, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = ReverseDiffVJP()),
-            g = g)
-        res2f = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
+            g = g
+        )
+        res2f = adjoint_sensitivities(
+            sol2, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP()),
-            g = g)
-        res2g = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(autodiff = false,
-                autojacvec = false),
-            g = g)
-        res2h = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
+            g = g
+        )
+        res2g = adjoint_sensitivities(
+            sol2, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(
+                autodiff = false,
+                autojacvec = false
+            ),
+            g = g
+        )
+        res2h = adjoint_sensitivities(
+            sol2, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = EnzymeVJP()),
-            g = g)
+            g = g
+        )
 
         # without jac, without param_jac
         f3 = ODEFunction(f!)
         prob3 = SteadyStateProblem(f3, u0, p)
-        sol3 = solve(prob3, DynamicSS(Rodas5()), reltol = 1e-14, abstol = 1e-14)
-        res3a = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
+        sol3 = solve(prob3, DynamicSS(Rodas5()), reltol = 1.0e-14, abstol = 1.0e-14)
+        res3a = adjoint_sensitivities(
+            sol3, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(), dgdu = dgdu!,
-            dgdp = dgdp!, g = g)
-        res3b = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(), g = g)
-        res3c = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
+            dgdp = dgdp!, g = g
+        )
+        res3b = adjoint_sensitivities(
+            sol3, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(), g = g
+        )
+        res3c = adjoint_sensitivities(
+            sol3, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autodiff = false),
-            g = g)
-        res3d = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
+            g = g
+        )
+        res3d = adjoint_sensitivities(
+            sol3, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = TrackerVJP()),
-            g = g)
-        res3e = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
+            g = g
+        )
+        res3e = adjoint_sensitivities(
+            sol3, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = ReverseDiffVJP()),
-            g = g)
-        res3f = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
+            g = g
+        )
+        res3f = adjoint_sensitivities(
+            sol3, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP()),
-            g = g)
-        res3g = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(autodiff = false,
-                autojacvec = false),
-            g = g)
-        res3h = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
+            g = g
+        )
+        res3g = adjoint_sensitivities(
+            sol3, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(
+                autodiff = false,
+                autojacvec = false
+            ),
+            g = g
+        )
+        res3h = adjoint_sensitivities(
+            sol3, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = EnzymeVJP()),
-            g = g)
+            g = g
+        )
 
-        @test norm(res_analytical' .- res1a) < 1e-7
-        @test norm(res_analytical' .- res1b) < 1e-7
-        @test norm(res_analytical' .- res1c) < 1e-7
-        @test norm(res_analytical' .- res1d) < 1e-7
-        @test norm(res_analytical' .- res1e) < 1e-7
-        @test norm(res_analytical' .- res1f) < 1e-7
-        @test norm(res_analytical' .- res1g) < 1e-7
-        @test norm(res_analytical' .- res1h) < 1e-7
-        @test norm(res_analytical' .- res2a) < 1e-7
-        @test norm(res_analytical' .- res2b) < 1e-7
-        @test norm(res_analytical' .- res2c) < 1e-7
-        @test norm(res_analytical' .- res2d) < 1e-7
-        @test norm(res_analytical' .- res2e) < 1e-7
-        @test norm(res_analytical' .- res2f) < 1e-7
-        @test norm(res_analytical' .- res2g) < 1e-7
-        @test norm(res_analytical' .- res2h) < 1e-7
-        @test norm(res_analytical' .- res3a) < 1e-7
-        @test norm(res_analytical' .- res3b) < 1e-7
-        @test norm(res_analytical' .- res3c) < 1e-7
-        @test norm(res_analytical' .- res3d) < 1e-7
-        @test norm(res_analytical' .- res3e) < 1e-7
-        @test norm(res_analytical' .- res3f) < 1e-7
-        @test norm(res_analytical' .- res3g) < 1e-7
-        @test norm(res_analytical' .- res3h) < 1e-7
+        @test norm(res_analytical' .- res1a) < 1.0e-7
+        @test norm(res_analytical' .- res1b) < 1.0e-7
+        @test norm(res_analytical' .- res1c) < 1.0e-7
+        @test norm(res_analytical' .- res1d) < 1.0e-7
+        @test norm(res_analytical' .- res1e) < 1.0e-7
+        @test norm(res_analytical' .- res1f) < 1.0e-7
+        @test norm(res_analytical' .- res1g) < 1.0e-7
+        @test norm(res_analytical' .- res1h) < 1.0e-7
+        @test norm(res_analytical' .- res2a) < 1.0e-7
+        @test norm(res_analytical' .- res2b) < 1.0e-7
+        @test norm(res_analytical' .- res2c) < 1.0e-7
+        @test norm(res_analytical' .- res2d) < 1.0e-7
+        @test norm(res_analytical' .- res2e) < 1.0e-7
+        @test norm(res_analytical' .- res2f) < 1.0e-7
+        @test norm(res_analytical' .- res2g) < 1.0e-7
+        @test norm(res_analytical' .- res2h) < 1.0e-7
+        @test norm(res_analytical' .- res3a) < 1.0e-7
+        @test norm(res_analytical' .- res3b) < 1.0e-7
+        @test norm(res_analytical' .- res3c) < 1.0e-7
+        @test norm(res_analytical' .- res3d) < 1.0e-7
+        @test norm(res_analytical' .- res3e) < 1.0e-7
+        @test norm(res_analytical' .- res3f) < 1.0e-7
+        @test norm(res_analytical' .- res3g) < 1.0e-7
+        @test norm(res_analytical' .- res3h) < 1.0e-7
 
         @info "oop checks"
         function foop(u, p, t)
@@ -204,43 +260,65 @@ Random.seed!(12345)
             [dx, dy]
         end
         proboop = SteadyStateProblem(foop, u0, p)
-        soloop = solve(proboop, DynamicSS(Rodas5()),
-            reltol = 1e-14, abstol = 1e-14)
+        soloop = solve(
+            proboop, DynamicSS(Rodas5()),
+            reltol = 1.0e-14, abstol = 1.0e-14
+        )
 
-        res4a = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
+        res4a = adjoint_sensitivities(
+            soloop, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(), dgdu = dgdu!,
-            dgdp = dgdp!, g = g)
-        res4b = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(), g = g)
-        res4c = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
+            dgdp = dgdp!, g = g
+        )
+        res4b = adjoint_sensitivities(
+            soloop, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(), g = g
+        )
+        res4c = adjoint_sensitivities(
+            soloop, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autodiff = false),
-            g = g)
-        res4d = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
+            g = g
+        )
+        res4d = adjoint_sensitivities(
+            soloop, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = TrackerVJP()),
-            g = g)
-        res4e = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
+            g = g
+        )
+        res4e = adjoint_sensitivities(
+            soloop, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = ReverseDiffVJP()),
-            g = g)
-        res4f = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
+            g = g
+        )
+        res4f = adjoint_sensitivities(
+            soloop, DynamicSS(Rodas5()),
             sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP()),
-            g = g)
-        res4g = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(autodiff = false,
-                autojacvec = false),
-            g = g)
-        res4h = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(autodiff = true,
-                autojacvec = false),
-            g = g)
+            g = g
+        )
+        res4g = adjoint_sensitivities(
+            soloop, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(
+                autodiff = false,
+                autojacvec = false
+            ),
+            g = g
+        )
+        res4h = adjoint_sensitivities(
+            soloop, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(
+                autodiff = true,
+                autojacvec = false
+            ),
+            g = g
+        )
 
-        @test norm(res_analytical' .- res4a) < 1e-7
-        @test norm(res_analytical' .- res4b) < 1e-7
-        @test norm(res_analytical' .- res4c) < 1e-7
-        @test norm(res_analytical' .- res4d) < 1e-7
-        @test norm(res_analytical' .- res4e) < 1e-7
-        @test norm(res_analytical' .- res4f) < 1e-7
-        @test norm(res_analytical' .- res4g) < 1e-7
-        @test norm(res_analytical' .- res4h) < 1e-7
+        @test norm(res_analytical' .- res4a) < 1.0e-7
+        @test norm(res_analytical' .- res4b) < 1.0e-7
+        @test norm(res_analytical' .- res4c) < 1.0e-7
+        @test norm(res_analytical' .- res4d) < 1.0e-7
+        @test norm(res_analytical' .- res4e) < 1.0e-7
+        @test norm(res_analytical' .- res4f) < 1.0e-7
+        @test norm(res_analytical' .- res4g) < 1.0e-7
+        @test norm(res_analytical' .- res4h) < 1.0e-7
     end
 
     @testset "for u0: (should be zero, steady state does not depend on initial condition)" begin
@@ -250,7 +328,7 @@ Random.seed!(12345)
             A = convert(Array, sol)
             g(A, p, nothing)
         end
-        @test abs(dot(res5, res5)) < 1e-7
+        @test abs(dot(res5, res5)) < 1.0e-7
     end
 end
 
@@ -274,61 +352,109 @@ end
         prob = SteadyStateProblem(f!, u0, p)
 
         sol = solve(prob, DynamicSS(Rodas5()))
-        res1 = adjoint_sensitivities(sol, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(), g = g1)
-        res2 = adjoint_sensitivities(sol, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(), g = g2)
+        res1 = adjoint_sensitivities(
+            sol, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(), g = g1
+        )
+        res2 = adjoint_sensitivities(
+            sol, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(), g = g2
+        )
 
         dp1 = Zygote.gradient(
-            p -> sum(solve(prob, DynamicSS(Rodas5()), u0 = u0, p = p,
-                sensealg = SteadyStateAdjoint())),
-            p)
+            p -> sum(
+                solve(
+                    prob, DynamicSS(Rodas5()), u0 = u0, p = p,
+                    sensealg = SteadyStateAdjoint()
+                )
+            ),
+            p
+        )
         dp2 = Zygote.gradient(
-            p -> sum((2.0 .-
-                      solve(prob, DynamicSS(Rodas5()), u0 = u0, p = p,
-                sensealg = SteadyStateAdjoint())) .^ 2) / 2.0,
-            p)
-
-        dp1d = Zygote.gradient(p -> sum(solve(prob, DynamicSS(Rodas5()), u0 = u0, p = p)),
-            p)
-        dp2d = Zygote.gradient(
-            p -> sum((2.0 .-
-                      solve(prob,
-                DynamicSS(Rodas5()),
-                u0 = u0,
-                p = p)) .^
-                     2) / 2.0,
-            p)
-
-        @test res1≈dp1[1] rtol=1e-12
-        @test res2≈dp2[1] rtol=1e-12
-        @test res1≈dp1d[1] rtol=1e-12
-        @test res2≈dp2d[1] rtol=1e-12
-
-        res1 = Zygote.gradient(
-            p -> sum(Array(solve(prob, DynamicSS(Rodas5()), u0 = u0,
-                p = p, sensealg = SteadyStateAdjoint()))[1]),
-            p)
-        dp1 = Zygote.gradient(
-            p -> sum(solve(prob, DynamicSS(Rodas5()), u0 = u0, p = p,
-                save_idxs = 1:1,
-                sensealg = SteadyStateAdjoint())),
-            p)
-        dp2 = Zygote.gradient(
-            p -> solve(prob, DynamicSS(Rodas5()), u0 = u0, p = p,
-                save_idxs = 1, sensealg = SteadyStateAdjoint())[1],
-            p)
+            p -> sum(
+                (
+                    2.0 .-
+                        solve(
+                        prob, DynamicSS(Rodas5()), u0 = u0, p = p,
+                        sensealg = SteadyStateAdjoint()
+                    )
+                ) .^ 2
+            ) / 2.0,
+            p
+        )
 
         dp1d = Zygote.gradient(
-            p -> sum(solve(prob, DynamicSS(Rodas5()), u0 = u0, p = p,
-                save_idxs = 1:1)), p)
+            p -> sum(solve(prob, DynamicSS(Rodas5()), u0 = u0, p = p)),
+            p
+        )
         dp2d = Zygote.gradient(
-            p -> solve(prob, DynamicSS(Rodas5()), u0 = u0, p = p,
-                save_idxs = 1)[1], p)
-        @test res1[1]≈dp1[1] rtol=1e-10
-        @test res1[1]≈dp2[1] rtol=1e-10
-        @test res1[1]≈dp1d[1] rtol=1e-10
-        @test res1[1]≈dp2d[1] rtol=1e-10
+            p -> sum(
+                (
+                    2.0 .-
+                        solve(
+                        prob,
+                        DynamicSS(Rodas5()),
+                        u0 = u0,
+                        p = p
+                    )
+                ) .^
+                    2
+            ) / 2.0,
+            p
+        )
+
+        @test res1 ≈ dp1[1] rtol = 1.0e-12
+        @test res2 ≈ dp2[1] rtol = 1.0e-12
+        @test res1 ≈ dp1d[1] rtol = 1.0e-12
+        @test res2 ≈ dp2d[1] rtol = 1.0e-12
+
+        res1 = Zygote.gradient(
+            p -> sum(
+                Array(
+                    solve(
+                        prob, DynamicSS(Rodas5()), u0 = u0,
+                        p = p, sensealg = SteadyStateAdjoint()
+                    )
+                )[1]
+            ),
+            p
+        )
+        dp1 = Zygote.gradient(
+            p -> sum(
+                solve(
+                    prob, DynamicSS(Rodas5()), u0 = u0, p = p,
+                    save_idxs = 1:1,
+                    sensealg = SteadyStateAdjoint()
+                )
+            ),
+            p
+        )
+        dp2 = Zygote.gradient(
+            p -> solve(
+                prob, DynamicSS(Rodas5()), u0 = u0, p = p,
+                save_idxs = 1, sensealg = SteadyStateAdjoint()
+            )[1],
+            p
+        )
+
+        dp1d = Zygote.gradient(
+            p -> sum(
+                solve(
+                    prob, DynamicSS(Rodas5()), u0 = u0, p = p,
+                    save_idxs = 1:1
+                )
+            ), p
+        )
+        dp2d = Zygote.gradient(
+            p -> solve(
+                prob, DynamicSS(Rodas5()), u0 = u0, p = p,
+                save_idxs = 1
+            )[1], p
+        )
+        @test res1[1] ≈ dp1[1] rtol = 1.0e-10
+        @test res1[1] ≈ dp2[1] rtol = 1.0e-10
+        @test res1[1] ≈ dp1d[1] rtol = 1.0e-10
+        @test res1[1] ≈ dp2d[1] rtol = 1.0e-10
     end
 
     @testset "oop" begin
@@ -340,58 +466,109 @@ end
         proboop = SteadyStateProblem(f, u0, p)
 
         soloop = solve(proboop, DynamicSS(Rodas5()))
-        res1oop = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(), g = g1)
-        res2oop = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
-            sensealg = SteadyStateAdjoint(), g = g2)
+        res1oop = adjoint_sensitivities(
+            soloop, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(), g = g1
+        )
+        res2oop = adjoint_sensitivities(
+            soloop, DynamicSS(Rodas5()),
+            sensealg = SteadyStateAdjoint(), g = g2
+        )
 
         dp1oop = Zygote.gradient(
-            p -> sum(solve(proboop, DynamicSS(Rodas5()), u0 = u0,
-                p = p, sensealg = SteadyStateAdjoint())),
-            p)
+            p -> sum(
+                solve(
+                    proboop, DynamicSS(Rodas5()), u0 = u0,
+                    p = p, sensealg = SteadyStateAdjoint()
+                )
+            ),
+            p
+        )
         dp2oop = Zygote.gradient(
-            p -> sum((2.0 .-
-                      solve(proboop, DynamicSS(Rodas5()), u0 = u0,
-                p = p, sensealg = SteadyStateAdjoint())) .^
-                     2) / 2.0,
-            p)
+            p -> sum(
+                (
+                    2.0 .-
+                        solve(
+                        proboop, DynamicSS(Rodas5()), u0 = u0,
+                        p = p, sensealg = SteadyStateAdjoint()
+                    )
+                ) .^
+                    2
+            ) / 2.0,
+            p
+        )
         dp1oopd = Zygote.gradient(
-            p -> sum(solve(proboop, DynamicSS(Rodas5()), u0 = u0,
-                p = p)), p)
+            p -> sum(
+                solve(
+                    proboop, DynamicSS(Rodas5()), u0 = u0,
+                    p = p
+                )
+            ), p
+        )
         dp2oopd = Zygote.gradient(
-            p -> sum((2.0 .-
-                      solve(proboop, DynamicSS(Rodas5()), u0 = u0,
-                p = p)) .^ 2) / 2.0,
-            p)
+            p -> sum(
+                (
+                    2.0 .-
+                        solve(
+                        proboop, DynamicSS(Rodas5()), u0 = u0,
+                        p = p
+                    )
+                ) .^ 2
+            ) / 2.0,
+            p
+        )
 
-        @test res1oop≈dp1oop[1] rtol=1e-12
-        @test res2oop≈dp2oop[1] rtol=1e-12
-        @test res1oop≈dp1oopd[1] rtol=1e-8
-        @test res2oop≈dp2oopd[1] rtol=1e-8
+        @test res1oop ≈ dp1oop[1] rtol = 1.0e-12
+        @test res2oop ≈ dp2oop[1] rtol = 1.0e-12
+        @test res1oop ≈ dp1oopd[1] rtol = 1.0e-8
+        @test res2oop ≈ dp2oopd[1] rtol = 1.0e-8
 
         res1oop = Zygote.gradient(
-            p -> sum(Array(solve(proboop, DynamicSS(Rodas5()),
-                u0 = u0, p = p,
-                sensealg = SteadyStateAdjoint()))[1]),
-            p)
+            p -> sum(
+                Array(
+                    solve(
+                        proboop, DynamicSS(Rodas5()),
+                        u0 = u0, p = p,
+                        sensealg = SteadyStateAdjoint()
+                    )
+                )[1]
+            ),
+            p
+        )
         dp1oop = Zygote.gradient(
-            p -> sum(solve(proboop, DynamicSS(Rodas5()), u0 = u0,
-                p = p, save_idxs = 1:1,
-                sensealg = SteadyStateAdjoint())),
-            p)
+            p -> sum(
+                solve(
+                    proboop, DynamicSS(Rodas5()), u0 = u0,
+                    p = p, save_idxs = 1:1,
+                    sensealg = SteadyStateAdjoint()
+                )
+            ),
+            p
+        )
         dp2oop = Zygote.gradient(
-            p -> solve(proboop, DynamicSS(Rodas5()), u0 = u0, p = p,
-                save_idxs = 1, sensealg = SteadyStateAdjoint())[1],
-            p)
+            p -> solve(
+                proboop, DynamicSS(Rodas5()), u0 = u0, p = p,
+                save_idxs = 1, sensealg = SteadyStateAdjoint()
+            )[1],
+            p
+        )
         dp1oopd = Zygote.gradient(
-            p -> sum(solve(proboop, DynamicSS(Rodas5()), u0 = u0,
-                p = p, save_idxs = 1:1)),
-            p)
+            p -> sum(
+                solve(
+                    proboop, DynamicSS(Rodas5()), u0 = u0,
+                    p = p, save_idxs = 1:1
+                )
+            ),
+            p
+        )
         dp2oopd = Zygote.gradient(
-            p -> solve(proboop, DynamicSS(Rodas5()), u0 = u0, p = p,
-                save_idxs = 1)[1], p)
-        @test res1oop[1]≈dp1oop[1] rtol=1e-10
-        @test res1oop[1]≈dp2oop[1] rtol=1e-10
+            p -> solve(
+                proboop, DynamicSS(Rodas5()), u0 = u0, p = p,
+                save_idxs = 1
+            )[1], p
+        )
+        @test res1oop[1] ≈ dp1oop[1] rtol = 1.0e-10
+        @test res1oop[1] ≈ dp2oop[1] rtol = 1.0e-10
     end
 end
 
@@ -407,19 +584,23 @@ end
 
     prob3 = SteadyStateProblem((u, p, t) -> -u .+ p[1] .- p[2], [0.0], p)
     solve3 = solve(prob3, DynamicSS(Rodas5()))
-    @test solve1.u≈solve3.u rtol=1e-6
+    @test solve1.u ≈ solve3.u rtol = 1.0e-6
 
     prob4 = SteadyStateProblem((du, u, p, t) -> du[1] = -u[1] + p[1] - p[2], [0.0], p)
     solve4 = solve(prob4, DynamicSS(Rodas5()))
-    @test solve3.u≈solve4.u rtol=1e-10
+    @test solve3.u ≈ solve4.u rtol = 1.0e-10
 
     prob5 = NonlinearProblem{false}((u, p) -> u .^ 2 .- p[1], fill(0.0, 50), p)
     prob6 = NonlinearProblem{false}((u, p) -> u .^ 2 .- p[1], fill(0.0, 51), p)
 
     function test_loss(p, prob, alg)
         _prob = remake(prob, p = p)
-        sol = sum(solve(_prob, alg,
-            sensealg = SteadyStateAdjoint(autojacvec = ReverseDiffVJP())))
+        sol = sum(
+            solve(
+                _prob, alg,
+                sensealg = SteadyStateAdjoint(autojacvec = ReverseDiffVJP())
+            )
+        )
         return sol
     end
 
@@ -432,16 +613,18 @@ end
     function enzyme_gradient(p, prob, alg)
         dp = Enzyme.make_zero(p)
         dprob = Enzyme.make_zero(prob)
-        Enzyme.autodiff(Reverse, test_loss, Active, Duplicated(p, dp),
-            Duplicated(prob, dprob), Const(alg))
+        Enzyme.autodiff(
+            Reverse, test_loss, Active, Duplicated(p, dp),
+            Duplicated(prob, dprob), Const(alg)
+        )
         return dp
     end
     dp1 = Zygote.gradient(p -> test_loss(p, prob, NewtonRaphson()), p)[1]
     dp1_enzyme = enzyme_gradient(p, prob, NewtonRaphson())
-    @test dp1≈dp1_enzyme rtol=1e-10
+    @test dp1 ≈ dp1_enzyme rtol = 1.0e-10
     dp2 = Zygote.gradient(p -> test_loss(p, prob2, NewtonRaphson()), p)[1]
     dp2_enzyme = enzyme_gradient(p, prob2, NewtonRaphson())
-    @test dp2≈dp2_enzyme rtol=1e-10
+    @test dp2 ≈ dp2_enzyme rtol = 1.0e-10
     dp3 = Zygote.gradient(p -> test_loss(p, prob3, DynamicSS(Rodas5())), p)[1]
     #dp3_enzyme = enzyme_gradient(p, prob3, DynamicSS(Rodas5()))
     #@test dp3≈dp3_enzyme rtol=1e-10
@@ -453,7 +636,7 @@ end
     #@test dp5≈dp5_enzyme rtol=1e-10
     dp6 = Zygote.gradient(p -> test_loss(p, prob2, Klement()), p)[1]
     dp6_enzyme = enzyme_gradient(p, prob2, Klement())
-    @test dp6≈dp6_enzyme rtol=1e-10
+    @test dp6 ≈ dp6_enzyme rtol = 1.0e-10
     dp7 = Zygote.gradient(p -> test_loss(p, prob2, SimpleTrustRegion()), p)[1]
     #dp7_enzyme = enzyme_gradient(p, prob2, SimpleTrustRegion())
     #@test dp7≈dp7_enzyme rtol=1e-10
@@ -462,12 +645,14 @@ end
     #@test dp8≈dp8_enzyme rtol=1e-10
     dp9 = Zygote.gradient(p -> test_loss(p, prob, TrustRegion()), p)[1]
     dp9_enzyme = enzyme_gradient(p, prob, TrustRegion())
-    @test dp9≈dp9_enzyme rtol=1e-10
+    @test dp9 ≈ dp9_enzyme rtol = 1.0e-10
 
     function test_loss2(p, prob, alg)
         _prob = remake(prob, p = p)
-        sol = solve(_prob, alg,
-            sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP()))
+        sol = solve(
+            _prob, alg,
+            sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP())
+        )
         return sol.u[1]
     end
 
@@ -475,17 +660,17 @@ end
     dp11 = Zygote.gradient(p -> test_loss2(p, prob6, Broyden()), p)[1]
     dp12 = ForwardDiff.gradient(p -> test_loss2(p, prob6, Broyden()), p)
 
-    @test dp1≈dp2 rtol=1e-10
-    @test dp1≈dp3 rtol=1e-10
-    @test dp1≈dp4 rtol=1e-10
-    @test dp1≈dp5 rtol=1e-10
-    @test dp1≈dp6 rtol=1e-10
-    @test dp1≈dp7 rtol=1e-10
-    @test dp1≈dp8 rtol=1e-10
-    @test dp1≈dp9 rtol=1e-10
-    @test dp10≈dp11 rtol=1e-10
-    @test dp11≈dp12 rtol=1e-10
-    @test dp10≈dp12 rtol=1e-10
+    @test dp1 ≈ dp2 rtol = 1.0e-10
+    @test dp1 ≈ dp3 rtol = 1.0e-10
+    @test dp1 ≈ dp4 rtol = 1.0e-10
+    @test dp1 ≈ dp5 rtol = 1.0e-10
+    @test dp1 ≈ dp6 rtol = 1.0e-10
+    @test dp1 ≈ dp7 rtol = 1.0e-10
+    @test dp1 ≈ dp8 rtol = 1.0e-10
+    @test dp1 ≈ dp9 rtol = 1.0e-10
+    @test dp10 ≈ dp11 rtol = 1.0e-10
+    @test dp11 ≈ dp12 rtol = 1.0e-10
+    @test dp10 ≈ dp12 rtol = 1.0e-10
 
     # Larger Batched Problem: For testing the Iterative Solvers Path
     u0 = zeros(128)
@@ -496,15 +681,21 @@ end
 
     function test_loss2(p, prob, alg)
         _prob = remake(prob, p = p)
-        sol = sum(solve(_prob, alg,
-            sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP())))
+        sol = sum(
+            solve(
+                _prob, alg,
+                sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP())
+            )
+        )
         return sol
     end
     function enzyme_gradient2(p, prob, alg)
         dp = Enzyme.make_zero(p)
         dprob = Enzyme.make_zero(prob)
-        Enzyme.autodiff(Reverse, test_loss2, Active, Duplicated(p, dp),
-            Duplicated(prob, dprob), Const(alg))
+        Enzyme.autodiff(
+            Reverse, test_loss2, Active, Duplicated(p, dp),
+            Duplicated(prob, dprob), Const(alg)
+        )
         return dp
     end
 
@@ -531,7 +722,7 @@ end
     p = [2.0, -2.0, 1.0, -4.0]
     prob = ODEProblem(f!, u0, (0, Inf), p)
 
-    tol = 1e-10
+    tol = 1.0e-10
     # steady state callback
     function condition(u, t, integrator)
         testval = first(get_tmp_cache(integrator))
@@ -543,16 +734,20 @@ end
     cb_t2 = DiscreteCallback(condition, affect!, save_positions = (true, true))
 
     for cb_t in (cb_t1, cb_t2)
-        sol = solve(prob, Tsit5(), reltol = tol, abstol = tol, callback = cb_t,
-            save_start = false, save_everystep = false)
+        sol = solve(
+            prob, Tsit5(), reltol = tol, abstol = tol, callback = cb_t,
+            save_start = false, save_everystep = false
+        )
 
         # derivative with respect to u0 and p0
         function loss(u0, p; sensealg = nothing, save_start = false, save_everystep = false)
             _prob = remake(prob, u0 = u0, p = p)
             # saving arguments can have a huge influence here
-            sol = solve(_prob, Tsit5(), reltol = tol, abstol = tol, sensealg = sensealg,
+            sol = solve(
+                _prob, Tsit5(), reltol = tol, abstol = tol, sensealg = sensealg,
                 callback = cb_t,
-                save_start = save_start, save_everystep = save_everystep)
+                save_start = save_start, save_everystep = save_everystep
+            )
             res = sol.u[end]
             g(res, p, nothing)
         end
@@ -562,98 +757,137 @@ end
 
         # save_start = false, save_everystep=false
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0, p) -> loss(u0, p,
-                sensealg = ForwardDiffSensitivity()),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+            Zdp = Zygote.gradient(
+            (u0, p) -> loss(
+                u0, p,
+                sensealg = ForwardDiffSensitivity()
+            ),
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
         Zdu0,
-        Zdp = Zygote.gradient((u0, p) -> loss(u0, p, sensealg = BacksolveAdjoint()),
+            Zdp = Zygote.gradient(
+            (u0, p) -> loss(u0, p, sensealg = BacksolveAdjoint()),
             u0,
-            p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+            p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0, p) -> loss(u0, p,
-                sensealg = InterpolatingAdjoint()),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+            Zdp = Zygote.gradient(
+            (u0, p) -> loss(
+                u0, p,
+                sensealg = InterpolatingAdjoint()
+            ),
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
 
         # save_start = true, save_everystep=false
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0, p) -> loss(u0, p,
+            Zdp = Zygote.gradient(
+            (u0, p) -> loss(
+                u0, p,
                 sensealg = ForwardDiffSensitivity(),
-                save_start = true),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+                save_start = true
+            ),
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0, p) -> loss(u0, p, sensealg = BacksolveAdjoint(),
-                save_start = true), u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+            Zdp = Zygote.gradient(
+            (u0, p) -> loss(
+                u0, p, sensealg = BacksolveAdjoint(),
+                save_start = true
+            ), u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0, p) -> loss(u0, p,
+            Zdp = Zygote.gradient(
+            (u0, p) -> loss(
+                u0, p,
                 sensealg = InterpolatingAdjoint(),
-                save_start = true),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+                save_start = true
+            ),
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
 
         # save_start = true, save_everystep=true
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0,
-                p) -> loss(u0, p,
+            Zdp = Zygote.gradient(
+            (
+                u0,
+                p,
+            ) -> loss(
+                u0, p,
                 sensealg = ForwardDiffSensitivity(),
                 save_start = true,
-                save_everystep = true),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+                save_everystep = true
+            ),
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
 
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0,
-                p) -> loss(u0, p, sensealg = BacksolveAdjoint(),
+            Zdp = Zygote.gradient(
+            (
+                u0,
+                p,
+            ) -> loss(
+                u0, p, sensealg = BacksolveAdjoint(),
                 save_start = true,
-                save_everystep = true),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+                save_everystep = true
+            ),
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0,
-                p) -> loss(u0, p,
+            Zdp = Zygote.gradient(
+            (
+                u0,
+                p,
+            ) -> loss(
+                u0, p,
                 sensealg = InterpolatingAdjoint(),
                 save_start = true,
-                save_everystep = true),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+                save_everystep = true
+            ),
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
         # QuadratureAdjoint makes sense only in this case, otherwise Zdp fails
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0,
-                p) -> loss(u0, p, sensealg = QuadratureAdjoint(),
+            Zdp = Zygote.gradient(
+            (
+                u0,
+                p,
+            ) -> loss(
+                u0, p, sensealg = QuadratureAdjoint(),
                 save_start = true,
-                save_everystep = true),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+                save_everystep = true
+            ),
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
 
         function loss2(u0, p; sensealg = nothing, saveat = 1.0)
             # remake tspan so saveat::Number makes sense
             _prob = remake(prob, tspan = (0.0, 100.0), u0 = u0, p = p)
             # saving arguments can have a huge influence here
-            sol = solve(_prob, Tsit5(), reltol = tol, abstol = tol, sensealg = sensealg,
-                callback = cb_t, saveat = saveat)
+            sol = solve(
+                _prob, Tsit5(), reltol = tol, abstol = tol, sensealg = sensealg,
+                callback = cb_t, saveat = saveat
+            )
             res = sol.u[end]
             g(res, p, nothing)
         end
@@ -663,30 +897,39 @@ end
 
         # saveat::Number
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0, p) -> loss2(u0, p,
-                sensealg = ForwardDiffSensitivity()),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+            Zdp = Zygote.gradient(
+            (u0, p) -> loss2(
+                u0, p,
+                sensealg = ForwardDiffSensitivity()
+            ),
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
         Zdu0,
-        Zdp = Zygote.gradient((u0, p) -> loss2(u0, p, sensealg = BacksolveAdjoint()),
+            Zdp = Zygote.gradient(
+            (u0, p) -> loss2(u0, p, sensealg = BacksolveAdjoint()),
             u0,
-            p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+            p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
         Zdu0,
-        Zdp = Zygote.gradient(
-            (u0, p) -> loss2(u0, p,
-                sensealg = InterpolatingAdjoint()),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+            Zdp = Zygote.gradient(
+            (u0, p) -> loss2(
+                u0, p,
+                sensealg = InterpolatingAdjoint()
+            ),
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
         Zdu0,
-        Zdp = Zygote.gradient(
+            Zdp = Zygote.gradient(
             (u0, p) -> loss2(u0, p, sensealg = QuadratureAdjoint()),
-            u0, p)
-        @test du0≈Zdu0 atol=1e-4
-        @test dp≈Zdp atol=1e-4
+            u0, p
+        )
+        @test du0 ≈ Zdu0 atol = 1.0e-4
+        @test dp ≈ Zdp atol = 1.0e-4
     end
 end

--- a/test/stiff_adjoints.jl
+++ b/test/stiff_adjoints.jl
@@ -5,14 +5,14 @@ using OrdinaryDiffEq, ForwardDiff, Test
 function lotka_volterra(u, p, t)
     x, y = u
     α, β, δ, γ = p
-    [α * x - β * x * y, -δ * y + γ * x * y]
+    return [α * x - β * x * y, -δ * y + γ * x * y]
 end
 
 function lotka_volterra(du, u, p, t)
     x, y = u
     α, β, δ, γ = p
     du[1] = dx = α * x - β * x * y
-    du[2] = dy = -δ * y + γ * x * y
+    return du[2] = dy = -δ * y + γ * x * y
 end
 
 u0 = [1.0, 1.0];
@@ -24,8 +24,10 @@ target_data = solve(prob0, RadauIIA5(), saveat = 0:0.5:10.0);
 
 loss_function = function (p)
     prob = remake(prob0; u0 = convert.(eltype(p), prob0.u0), p = p)
-    prediction = solve(prob, RadauIIA5(); saveat = 0.0:0.5:10.0, abstol = 1e-10,
-        reltol = 1e-10)
+    prediction = solve(
+        prob, RadauIIA5(); saveat = 0.0:0.5:10.0, abstol = 1.0e-10,
+        reltol = 1.0e-10
+    )
 
     tmpdata = prediction[[1, 2], :]
     tdata = target_data[[1, 2], :]
@@ -37,12 +39,14 @@ p = [1.5, 1.2, 1.4, 1.6];
 fdgrad = ForwardDiff.gradient(loss_function, p)
 rdgrad = Zygote.gradient(loss_function, p)[1]
 
-@test fdgrad≈rdgrad rtol=1e-5
+@test fdgrad ≈ rdgrad rtol = 1.0e-5
 
 loss_function = function (p)
     prob = remake(prob0; u0 = convert.(eltype(p), prob0.u0), p = p)
-    prediction = solve(prob, TRBDF2(); saveat = 0.0:0.5:10.0, abstol = 1e-10,
-        reltol = 1e-10)
+    prediction = solve(
+        prob, TRBDF2(); saveat = 0.0:0.5:10.0, abstol = 1.0e-10,
+        reltol = 1.0e-10
+    )
 
     tmpdata = prediction[[1, 2], :]
     tdata = target_data[[1, 2], :]
@@ -52,12 +56,14 @@ loss_function = function (p)
 end
 
 rdgrad = Zygote.gradient(loss_function, p)[1]
-@test fdgrad≈rdgrad rtol=1e-3
+@test fdgrad ≈ rdgrad rtol = 1.0e-3
 
 loss_function = function (p)
     prob = remake(prob0; u0 = convert.(eltype(p), prob0.u0), p = p)
-    prediction = solve(prob, Rosenbrock23(); saveat = 0.0:0.5:10.0, abstol = 1e-8,
-        reltol = 1e-8)
+    prediction = solve(
+        prob, Rosenbrock23(); saveat = 0.0:0.5:10.0, abstol = 1.0e-8,
+        reltol = 1.0e-8
+    )
 
     tmpdata = prediction[[1, 2], :]
     tdata = target_data[[1, 2], :]
@@ -67,11 +73,11 @@ loss_function = function (p)
 end
 
 rdgrad = Zygote.gradient(loss_function, p)[1]
-@test fdgrad≈rdgrad rtol=1e-3
+@test fdgrad ≈ rdgrad rtol = 1.0e-3
 
 loss_function = function (p)
     prob = remake(prob0; u0 = convert.(eltype(p), prob0.u0), p = p)
-    prediction = solve(prob, Rodas5(); saveat = 0.0:0.5:10.0, abstol = 1e-8, reltol = 1e-8)
+    prediction = solve(prob, Rodas5(); saveat = 0.0:0.5:10.0, abstol = 1.0e-8, reltol = 1.0e-8)
 
     tmpdata = prediction[[1, 2], :]
     tdata = target_data[[1, 2], :]
@@ -81,7 +87,7 @@ loss_function = function (p)
 end
 
 rdgrad = Zygote.gradient(loss_function, p)[1]
-@test fdgrad≈rdgrad rtol=1e-3
+@test fdgrad ≈ rdgrad rtol = 1.0e-3
 
 ### OOP
 
@@ -91,8 +97,10 @@ target_data = solve(prob0, RadauIIA5(), saveat = 0:0.5:10.0);
 
 loss_function = function (p)
     prob = remake(prob0_oop; u0 = convert.(eltype(p), prob0.u0), p = p)
-    prediction = solve(prob, RadauIIA5(); saveat = 0.0:0.5:10.0, abstol = 1e-10,
-        reltol = 1e-10)
+    prediction = solve(
+        prob, RadauIIA5(); saveat = 0.0:0.5:10.0, abstol = 1.0e-10,
+        reltol = 1.0e-10
+    )
 
     tmpdata = prediction[[1, 2], :]
     tdata = target_data[[1, 2], :]
@@ -105,12 +113,14 @@ p = [1.5, 1.2, 1.4, 1.6];
 fdgrad = ForwardDiff.gradient(loss_function, p)
 rdgrad = Zygote.gradient(loss_function, p)[1]
 
-@test fdgrad≈rdgrad rtol=1e-4
+@test fdgrad ≈ rdgrad rtol = 1.0e-4
 
 loss_function = function (p)
     prob = remake(prob0_oop; u0 = convert.(eltype(p), prob0.u0), p = p)
-    prediction = solve(prob, TRBDF2(); saveat = 0.0:0.5:10.0, abstol = 1e-10,
-        reltol = 1e-10)
+    prediction = solve(
+        prob, TRBDF2(); saveat = 0.0:0.5:10.0, abstol = 1.0e-10,
+        reltol = 1.0e-10
+    )
 
     tmpdata = prediction[[1, 2], :]
     tdata = target_data[[1, 2], :]
@@ -120,12 +130,14 @@ loss_function = function (p)
 end
 
 rdgrad = Zygote.gradient(loss_function, p)[1]
-@test fdgrad≈rdgrad rtol=1e-3
+@test fdgrad ≈ rdgrad rtol = 1.0e-3
 
 loss_function = function (p)
     prob = remake(prob0_oop; u0 = convert.(eltype(p), prob0.u0), p = p)
-    prediction = solve(prob, Rosenbrock23(); saveat = 0.0:0.5:10.0, abstol = 1e-8,
-        reltol = 1e-8)
+    prediction = solve(
+        prob, Rosenbrock23(); saveat = 0.0:0.5:10.0, abstol = 1.0e-8,
+        reltol = 1.0e-8
+    )
 
     tmpdata = prediction[[1, 2], :]
     tdata = target_data[[1, 2], :]
@@ -135,12 +147,14 @@ loss_function = function (p)
 end
 
 rdgrad = Zygote.gradient(loss_function, p)[1]
-@test fdgrad≈rdgrad rtol=1e-4
+@test fdgrad ≈ rdgrad rtol = 1.0e-4
 
 loss_function = function (p)
     prob = remake(prob0_oop; u0 = convert.(eltype(p), prob0.u0), p = p)
-    prediction = solve(prob, Rodas5(); saveat = 0.0:0.5:10.0, abstol = 1e-12,
-        reltol = 1e-12)
+    prediction = solve(
+        prob, Rodas5(); saveat = 0.0:0.5:10.0, abstol = 1.0e-12,
+        reltol = 1.0e-12
+    )
 
     tmpdata = prediction[[1, 2], :]
     tdata = target_data[[1, 2], :]
@@ -150,7 +164,7 @@ loss_function = function (p)
 end
 
 rdgrad = Zygote.gradient(loss_function, p)[1]
-@test fdgrad≈rdgrad rtol=1e-3
+@test fdgrad ≈ rdgrad rtol = 1.0e-3
 
 if VERSION >= v"1.7-"
     # all implicit solvers
@@ -172,19 +186,20 @@ if VERSION >= v"1.7-"
         ROS34PW3(),
         # Stabilized Explicit Methods (ok)
         ROCK2(),
-        ROCK4()]
+        ROCK4(),
+    ]
 
     p = rand(3)
 
     function dudt(u, p, t)
-        u .* p
+        return u .* p
     end
 
     for solver in solvers
         function loss(p)
             prob = ODEProblem(dudt, [3.0, 2.0, 1.0], (0.0, 1.0), p)
-            sol = solve(prob, solver, dt = 0.01, saveat = 0.1, abstol = 1e-5, reltol = 1e-5)
-            sum(abs2, Array(sol))
+            sol = solve(prob, solver, dt = 0.01, saveat = 0.1, abstol = 1.0e-5, reltol = 1.0e-5)
+            return sum(abs2, Array(sol))
         end
 
         loss(p)
@@ -192,30 +207,34 @@ if VERSION >= v"1.7-"
 
         function loss(p, sensealg)
             prob = ODEProblem(dudt, [3.0, 2.0, 1.0], (0.0, 1.0), p)
-            sol = solve(prob, solver, dt = 0.01, saveat = 0.1, sensealg = sensealg,
-                abstol = 1e-5, reltol = 1e-5)
-            sum(abs2, Array(sol))
+            sol = solve(
+                prob, solver, dt = 0.01, saveat = 0.1, sensealg = sensealg,
+                abstol = 1.0e-5, reltol = 1.0e-5
+            )
+            return sum(abs2, Array(sol))
         end
 
         dp1 = Zygote.gradient(p -> loss(p, InterpolatingAdjoint()), p)[1]
-        @test dp≈dp1 rtol=1e-2
+        @test dp ≈ dp1 rtol = 1.0e-2
         dp1 = Zygote.gradient(p -> loss(p, BacksolveAdjoint()), p)[1]
-        @test dp≈dp1 rtol=1e-2
+        @test dp ≈ dp1 rtol = 1.0e-2
         dp1 = Zygote.gradient(p -> loss(p, QuadratureAdjoint()), p)[1]
-        @test dp≈dp1 rtol=1e-2
+        @test dp ≈ dp1 rtol = 1.0e-2
         dp1 = Zygote.gradient(p -> loss(p, ForwardDiffSensitivity()), p)[1]
-        @test dp≈dp1 rtol=1e-2
+        @test dp ≈ dp1 rtol = 1.0e-2
         if SciMLBase.forwarddiffs_model(solver)
             @test Zygote.gradient(
-                p -> loss(p, QuadratureAdjoint(autojacvec = EnzymeVJP())), p)[1] isa Vector
+                p -> loss(p, QuadratureAdjoint(autojacvec = EnzymeVJP())), p
+            )[1] isa Vector
             @test_broken Zygote.gradient(p -> loss(p, ReverseDiffAdjoint()), p)[1] isa
-                         Vector
+                Vector
         else
             dp1 = Zygote.gradient(
-                p -> loss(p, QuadratureAdjoint(autojacvec = EnzymeVJP())), p)[1]
-            @test dp≈dp1 rtol=1e-2
+                p -> loss(p, QuadratureAdjoint(autojacvec = EnzymeVJP())), p
+            )[1]
+            @test dp ≈ dp1 rtol = 1.0e-2
             dp1 = Zygote.gradient(p -> loss(p, ReverseDiffAdjoint()), p)[1]
-            @test dp≈dp1 rtol=1e-2
+            @test dp ≈ dp1 rtol = 1.0e-2
         end
     end
 
@@ -227,19 +246,23 @@ if VERSION >= v"1.7-"
         du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
         du[2] = k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃
         du[3] = k₂ * y₂^2 + sum(p)
-        nothing
+        return nothing
     end
 
     function sum_of_solution_fwd(x)
-        _prob = ODEProblem(rober, x[1:3], (0.0, 1e4), x[4:end])
-        sum(solve(_prob, Rodas5(), saveat = 1, reltol = 1e-12, abstol = 1e-12))
+        _prob = ODEProblem(rober, x[1:3], (0.0, 1.0e4), x[4:end])
+        return sum(solve(_prob, Rodas5(), saveat = 1, reltol = 1.0e-12, abstol = 1.0e-12))
     end
 
     function sum_of_solution_CASA(x; vjp = EnzymeVJP())
         sensealg = QuadratureAdjoint(autodiff = false, autojacvec = vjp)
-        _prob = ODEProblem(rober, x[1:3], (0.0, 1e4), x[4:end])
-        sum(solve(_prob, Rodas5P(), reltol = 1e-12, abstol = 1e-12, saveat = 1,
-            sensealg = sensealg))
+        _prob = ODEProblem(rober, x[1:3], (0.0, 1.0e4), x[4:end])
+        return sum(
+            solve(
+                _prob, Rodas5P(), reltol = 1.0e-12, abstol = 1.0e-12, saveat = 1,
+                sensealg = sensealg
+            )
+        )
     end
 
     u0 = [1.0, 0.0, 0.0]
@@ -252,8 +275,10 @@ if VERSION >= v"1.7-"
     println("grad3")
     grad3 = Zygote.gradient(x -> sum_of_solution_CASA(x, vjp = ReverseDiffVJP()), [u0; p])[1]
     println("grad4")
-    grad4 = Zygote.gradient(x -> sum_of_solution_CASA(x, vjp = ReverseDiffVJP(true)),
-        [u0; p])[1]
+    grad4 = Zygote.gradient(
+        x -> sum_of_solution_CASA(x, vjp = ReverseDiffVJP(true)),
+        [u0; p]
+    )[1]
     # Is too numerically dependent
     #println("grad5")
     #@test_broken Zygote.gradient(x -> sum_of_solution_CASA(x, vjp = true), [u0; p])[1] isa Array
@@ -261,11 +286,15 @@ if VERSION >= v"1.7-"
     #println("grad6")
     #grad6 = Zygote.gradient(x -> sum_of_solution_CASA(x, vjp = false), [u0; p])[1]
     println("grad7")
-    @test_throws Any Zygote.gradient(x -> sum_of_solution_CASA(x, vjp = ZygoteVJP()),
-        [u0; p])[1]
+    @test_throws Any Zygote.gradient(
+        x -> sum_of_solution_CASA(x, vjp = ZygoteVJP()),
+        [u0; p]
+    )[1]
     println("grad8")
-    @test_throws Any Zygote.gradient(x -> sum_of_solution_CASA(x, vjp = TrackerVJP()),
-        [u0; p])[1]
+    @test_throws Any Zygote.gradient(
+        x -> sum_of_solution_CASA(x, vjp = TrackerVJP()),
+        [u0; p]
+    )[1]
 
     @test grad1 ≈ grad2
     @test grad1 ≈ grad3

--- a/test/time_type_mixing.jl
+++ b/test/time_type_mixing.jl
@@ -5,14 +5,14 @@ p_model = [1.0f0]
 u0 = Float32.([0.0])
 
 function dudt(du, u, p, t)
-    du[1] = p[1]
+    return du[1] = p[1]
 end
 
 prob = ODEProblem(dudt, u0, (0.0f0, 99.9f0))
 
 function predict_neuralode(p)
     _prob = remake(prob, p = p)
-    Array(solve(_prob, Tsit5(), saveat = 0.1))
+    return Array(solve(_prob, Tsit5(), saveat = 0.1))
 end
 
 loss(p) = sum(abs2, predict_neuralode(p)) / length(p)
@@ -32,13 +32,13 @@ tspan = (0.0f0, 1.5f0) # Time range
 tsteps = (rand(datasize) .* (tspan[2] - tspan[1]) .+ tspan[1]) |> sort
 
 function f(du, u, p, t)
-    du .= p * u
+    return du .= p * u
 end
 
 function loss(p)
     prob = ODEProblem(f, u0, tspan, p)
     sol = solve(prob, Tsit5(), saveat = tsteps, sensealg = InterpolatingAdjoint())
-    sum(sol)
+    return sum(sol)
 end
 
 Zygote.gradient(loss, p)[1]


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)