### PR TITLE
Exclude QA tests from All group for downstream testing compatibility

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,7 +109,7 @@ end
         end
     end
 
-    if GROUP == "All" || GROUP == "QA"
+    if GROUP == "QA"
         @time @safetestset "Quality Assurance" include("aqua.jl")
     end
 


### PR DESCRIPTION
## Summary
- Modified `test/runtests.jl` to only run QA tests when `GROUP="QA"` (not when `GROUP="All"`)

Aqua tests do not work properly in downstream testing scenarios, so QA tests should only run when explicitly requested.

## Test plan
- [ ] Verify CI passes for Core1-8, SDE1-3 groups
- [ ] Verify QA tests run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)