### PR TITLE
Fix PolyOpt maxiters in parameter estimation tutorial

### DIFF
--- a/docs/src/tutorials/parameter_estimation_ode.md
+++ b/docs/src/tutorials/parameter_estimation_ode.md
@@ -60,7 +60,7 @@ optprob = OPT.OptimizationProblem(optf, p)
 
 result_ode = OPT.solve(optprob, OPA.PolyOpt(),
     callback = callback,
-    maxiters = 100)
+    maxiters = 1000)
 ```
 
 ## Explanation
@@ -155,7 +155,7 @@ optprob = OPT.OptimizationProblem(optf, p)
 
 result_ode = OPT.solve(optprob, OPA.PolyOpt(),
     callback = callback,
-    maxiters = 100)
+    maxiters = 1000)
 ```
 
 In just seconds we found parameters which give a relative loss of `1e-16`! We can


### PR DESCRIPTION
## Summary
- Increases `maxiters` from 100 to 1000 in the parameter estimation ODE tutorial
- Fixes the `retcode: Failure` issue reported in #1278

## Root Cause Analysis
The `PolyOpt` algorithm runs ADAM followed by BFGS. With `maxiters=100`, the BFGS phase doesn't have enough iterations to converge, resulting in a failure return code.

Testing showed:
- `maxiters=100`: Failure
- `maxiters=500`: Failure  
- `maxiters=1000`: **Success**

## Test plan
- [ ] Verify docs build successfully
- [ ] Check that the example shows `retcode: Success`

Fixes #1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)