### PR TITLE
Mark Zygote+EnzymeAdjoint as broken on Julia 1.10 (LTS)

### DIFF
--- a/test/concrete_solve_derivatives.jl
+++ b/test/concrete_solve_derivatives.jl
@@ -75,6 +75,12 @@ const BACKEND_SENSEALG_STATUS = Dict{Tuple{String, String}, Symbol}(
     ("Zygote", "ForwardSensitivity") => :skip,  # Returns nothing for u0
 )
 
+# Zygote + EnzymeAdjoint hits IllegalTypeAnalysisException on Julia 1.10 (LTS)
+# due to Union types in ODE solver internals triggering Enzyme strict aliasing
+if VERSION < v"1.11"
+    BACKEND_SENSEALG_STATUS[("Zygote", "EnzymeAdjoint")] = :broken
+end
+
 function get_status(backend_name::String, sensealg_name::String)
     return get(BACKEND_SENSEALG_STATUS, (backend_name, sensealg_name), :works)
 end


### PR DESCRIPTION
## Summary
- Enzyme v0.13.129 hits `IllegalTypeAnalysisException` when Zygote is used as the outer AD backend with `EnzymeAdjoint` sensealg on Julia 1.10 (LTS)
- The error is caused by Union types in ODE solver internals triggering Enzyme's strict aliasing analysis
- This works fine on Julia 1.11+ (Core1 1.11 passes, Core1 LTS fails)
- Regression between Enzyme v0.13.125 (worked) and v0.13.129 (broken)
- Marks the combination as `@test_broken` only on `VERSION < v"1.11"` to unblock CI

## Test plan
- [ ] Verify Core1 LTS no longer errors (should show `@test_broken` instead)
- [ ] Verify Core1 on Julia 1 and 1.11 still pass (Zygote+EnzymeAdjoint not marked broken there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)