### PR TITLE
Refactor callback VJP closures into callable structs

### DIFF
--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -544,14 +544,7 @@ function _update_integrand_and_dgrad(
     indx, pos_neg = get_indx(cb, t)
     tprev = get_tprev(cb, indx, pos_neg)
 
-    wp = let tprev = tprev, pos_neg = pos_neg
-        function (dp, p, u, t)
-            _affect! = get_affect!(cb, pos_neg)
-            fakeinteg = FakeIntegrator([x for x in u], [x for x in p], t, tprev)
-            _affect!(fakeinteg)
-            return dp .= fakeinteg.p
-        end
-    end
+    wp = CallbackAffectPWrapper(cb, ReverseDiffVJP(), pos_neg, nothing, tprev)
 
     _p = similar(integrand.p, size(integrand.p))
     _p .= false
@@ -585,14 +578,7 @@ function _update_integrand_and_dgrad(
         integrand = update_p_integrand(integrand, _p)
     end
 
-    w = let tprev = tprev, pos_neg = pos_neg
-        function (du, u, p, t)
-            _affect! = get_affect!(cb, pos_neg)
-            fakeinteg = FakeIntegrator([x for x in u], [x for x in p], t, tprev)
-            _affect!(fakeinteg)
-            return du .= vec(fakeinteg.u)
-        end
-    end
+    w = CallbackAffectWrapper(cb, ReverseDiffVJP(), pos_neg, nothing, tprev)
 
     # Create a fake sensitivity function to do the vjps needs to be done
     # to account for parameter dependence of affect function


### PR DESCRIPTION
## Summary

- Replace anonymous closures in `setup_w_wp` and `quadrature_adjoint.jl` with named callable structs (`CallbackAffectWrapper`, `CallbackAffectPWrapper`) to avoid AD recompilation caused by new anonymous types being created on every callback event during the adjoint pass
- Unify the two `setup_w_wp` methods (one for `DiscreteCallback`/`ContinuousCallback`, one for `VectorContinuousCallback`) into a single method that handles all callback types via runtime dispatch
- `pos_neg` is `Bool` (not a type parameter) to avoid creating distinct struct types for `true`/`false`

### Design notes

- `CallbackSensitivityFunctionPSwap` and the PSwap branch in `derivative_wrappers.jl` are preserved. Eliminating PSwap was considered but is incorrect: `_vecjacobian!` puts the y-slot derivative into `dλ`, and for `wp` the derivative w.r.t. `integrator.p` must occupy the y-slot.
- In `quadrature_adjoint.jl`, the structs use `ReverseDiffVJP()` explicitly (not `sensealg.autojacvec`) because the same callable is used both for direct evaluation and through the AD tape. The direct evaluation (`wp(_p, integrand.p, integrand.y, t)`) requires copying arrays since the affect modifies `fakeinteg.u`/`fakeinteg.p` in-place — with `EnzymeVJP`, `get_FakeIntegrator` skips the copy, which would corrupt the caller's arrays.

## Test plan

- [x] Callbacks1 test group — all pass
- [x] Callbacks2 test group (continuous callbacks, continuous vs discrete, vector continuous) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)