### PR TITLE
Fix return values for in-place functions

### DIFF
--- a/test/HybridNODE.jl
+++ b/test/HybridNODE.jl
@@ -62,7 +62,8 @@ function test_hybridNODE2(sensealg)
         @views dx[1:2] .= x[1:2] + x[3:4]
         dx[1] += x[2]
         dx[2] += x[1]
-        return dx[3:4] .= 0.0f0
+        dx[3:4] .= 0.0f0
+        return nothing
     end
     cb_ = PeriodicCallback(
         trueaffect!, 0.1f0, save_positions = (true, true),
@@ -82,7 +83,8 @@ function test_hybridNODE2(sensealg)
     end
     function ODEfunc(dx, x, p, t)
         dx[1:2] .= first(dudt2(x, p, st))
-        return dx[3:4] .= 0.0f0
+        dx[3:4] .= 0.0f0
+        return nothing
     end
     z0 = u0
     prob = ODEProblem(ODEfunc, z0, tspan)

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -4,7 +4,8 @@ using Test
 
 function fb(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2] * t
-    return du[2] = dy = -p[3] * u[2] + t * p[4] * u[1] * u[2]
+    du[2] = dy = -p[3] * u[2] + t * p[4] * u[1] * u[2]
+    return nothing
 end
 function foop(u, p, t)
     dx = p[1] * u[1] - p[2] * u[1] * u[2] * t
@@ -16,7 +17,8 @@ function jac(J, u, p, t)
     J[1, 1] = a + y * b * -1 * t
     J[2, 1] = t * y * d
     J[1, 2] = b * x * -1 * t
-    return J[2, 2] = c * -1 + t * x * d
+    J[2, 2] = c * -1 + t * x * d
+    return nothing
 end
 
 f = ODEFunction(fb; jac)
@@ -877,7 +879,8 @@ g(u, p, t) = (sum(u) .^ 2) ./ 2
 # Gradient of (u1 + u2)^2 / 2
 function dg(out, u, p, t)
     out[1] = u[1] + u[2]
-    return out[2] = u[1] + u[2]
+    out[2] = u[1] + u[2]
+    return nothing
 end
 
 adj_prob = ODEAdjointProblem(
@@ -1211,7 +1214,8 @@ params = [-0.4142135623730951, 0.0, -0.0, -0.4142135623730951, 0.0, 0.0]
 
 function dynamics!(du, u, p, t)
     du[1] = -u[1] + tanh(p[1] * u[1] + p[2] * u[2])
-    return du[2] = -u[2] + tanh(p[3] * u[1] + p[4] * u[2])
+    du[2] = -u[2] + tanh(p[3] * u[1] + p[4] * u[2])
+    return nothing
 end
 
 function backsolve_grad(sol, lqr_params, checkpointing)
@@ -1502,7 +1506,8 @@ end
 # u' = x = p * u
 function simple_linear_dae(du, u, p, t)
     du[1] = u[2]
-    return du[2] = u[2] - p[1] * u[1]
+    du[2] = u[2] - p[1] * u[1]
+    return nothing
 end
 p = [0.5]
 prob_singular_mm = ODEProblem(
@@ -1544,7 +1549,8 @@ end
 # u' = x = p * u^2
 function simple_nonlinear_dae(du, u, p, t)
     du[1] = u[2]
-    return du[2] = u[2] - p[1] * u[1]^2
+    du[2] = u[2] - p[1] * u[1]^2
+    return nothing
 end
 p = [0.5]
 prob_singular_mm = ODEProblem(
@@ -1596,7 +1602,8 @@ function pend(du, u, p, t)
     du[2] = T * x
     du[3] = dy
     du[4] = T * y - g
-    return du[5] = 2 * (dx^2 + dy^2 + y * (y * T - g) + T * x^2)
+    du[5] = 2 * (dx^2 + dy^2 + y * (y * T - g) + T * x^2)
+    return nothing
 end
 
 x0 = [1.0, 0, 0, 0, 0]

--- a/test/adjoint_param.jl
+++ b/test/adjoint_param.jl
@@ -5,7 +5,8 @@ reltol = 1.0e-12
 
 function pendulum_eom(dx, x, p, t)
     dx[1] = p[1] * x[2]
-    return dx[2] = -sin(x[1]) + (-p[1] * sin(x[1]) + p[2] * x[2])  # Second term is a simple controller that stabilizes π
+    dx[2] = -sin(x[1]) + (-p[1] * sin(x[1]) + p[2] * x[2])  # Second term is a simple controller that stabilizes π
+    return nothing
 end
 
 x0 = [0.1, 0.0]
@@ -49,7 +50,8 @@ res2 = ForwardDiff.gradient(G, p)
 p = [2.0, 3.0]
 u0 = [2.0]
 function f(du, u, p, t)
-    return du[1] = -u[1] * p[1] - p[2]
+    du[1] = -u[1] * p[1] - p[2]
+    return nothing
 end
 
 prob = ODEProblem(f, u0, (0.0, 1.0), p)

--- a/test/adjoint_shapes.jl
+++ b/test/adjoint_shapes.jl
@@ -28,7 +28,8 @@ else
         x = @view z[2:end]
         u = -K * x
         dz[1] = x' * x + u' * u
-        return dz[2:end] = x + u
+        dz[2:end] = x + u
+        return nothing
     end
 
     policy_params = ones(2, 2)
@@ -64,7 +65,8 @@ else
         x = @view z[2:end]
         u = -K * x
         dz[1] = x' * Q * x + u' * R * u
-        return dz[2:end] = A * x + B * u # or just `x + u`
+        dz[2:end] = A * x + B * u # or just `x + u`
+        return nothing
     end
 
     policy_params = ones(2, 2)

--- a/test/autodiff_events.jl
+++ b/test/autodiff_events.jl
@@ -4,7 +4,8 @@ using Zygote
 
 function f(du, u, p, t)
     du[1] = u[2]
-    return du[2] = -p[1]
+    du[2] = -p[1]
+    return nothing
 end
 
 function condition(u, t, integrator) # Event when event_f(u,t) == 0
@@ -14,7 +15,8 @@ end
 function affect!(integrator)
     @show integrator.t
     println("bounced.")
-    return integrator.u[2] = -integrator.p[2] * integrator.u[2]
+    integrator.u[2] = -integrator.p[2] * integrator.u[2]
+    return nothing
 end
 
 cb = ContinuousCallback(condition, affect!)

--- a/test/automatic_sensealg_choice.jl
+++ b/test/automatic_sensealg_choice.jl
@@ -19,7 +19,8 @@ function dxdt_(dx, x, p, t)
     ps = ComponentArray(p, ax)
     x1, x2 = x
     dx[1] = x[2]
-    return dx[2] = first(ann([t], ps, st))[1]^3
+    dx[2] = first(ann([t], ps, st))[1]^3
+    return nothing
 end
 x0 = [-4.0f0, 0.0f0]
 ts = Float32.(collect(0.0:0.01:tspan[2]))

--- a/test/branching_derivatives.jl
+++ b/test/branching_derivatives.jl
@@ -12,7 +12,8 @@ end
 function fiip(du, u, p, t)
     a = get_param([1.0, 2.0, 3.0], p[1:4], t)
     du[1] = dx = a * u[1] - u[1] * u[2]
-    return du[2] = dy = -a * u[2] + u[1] * u[2]
+    du[2] = dy = -a * u[2] + u[1] * u[2]
+    return nothing
 end
 
 p = [1.0, 1.0, 1.0, 1.0];

--- a/test/callback_reversediff.jl
+++ b/test/callback_reversediff.jl
@@ -41,7 +41,8 @@ ps = ComponentArray(ps)
 
 function dudt(du, u, p, t)
     du[1:2] .= -u[1:2]
-    return du[3:end] .= first(dudt2(u[1:2], p, st)) #re(p)(u[3:end])
+    du[3:end] .= first(dudt2(u[1:2], p, st)) #re(p)(u[3:end])
+    return nothing
 end
 z0 = Float32[u0; u0]
 prob = ODEProblem(dudt, z0, tspan)

--- a/test/callbacks/SDE_callbacks.jl
+++ b/test/callbacks/SDE_callbacks.jl
@@ -10,12 +10,14 @@ function test_SDE_callbacks()
         x, y = u
         α, β, δ, γ = p
         du[1] = dx = α * x - β * x * y
-        return du[2] = dy = -δ * y + γ * x * y
+        du[2] = dy = -δ * y + γ * x * y
+        return nothing
     end
 
     function dW!(du, u, p, t)
         du[1] = 0.1u[1]
-        return du[2] = 0.1u[2]
+        du[2] = 0.1u[2]
+        return nothing
     end
 
     u0 = [1.0, 1.0]

--- a/test/callbacks/continuous_callbacks.jl
+++ b/test/callbacks/continuous_callbacks.jl
@@ -8,7 +8,8 @@ savingtimes = 0.5
 function test_continuous_callback(cb, g, dg!; only_backsolve = false)
     function fiip(du, u, p, t)
         du[1] = u[2]
-        return du[2] = -p[1]
+        du[2] = -p[1]
+        return nothing
     end
     function foop(u, p, t)
         dx = u[2]

--- a/test/callbacks/continuous_vs_discrete.jl
+++ b/test/callbacks/continuous_vs_discrete.jl
@@ -10,7 +10,8 @@ function test_continuous_wrt_discrete_callback()
     function f(du, u, p, t)
         #Bouncing Ball
         du[1] = u[2]
-        return du[2] = -p[1]
+        du[2] = -p[1]
+        return nothing
     end
 
     # no saving in Callbacks; prescribed vafter and vbefore; loss on the endpoint

--- a/test/callbacks/discrete_callbacks.jl
+++ b/test/callbacks/discrete_callbacks.jl
@@ -8,7 +8,8 @@ savingtimes = 0.5
 function test_discrete_callback(cb, tstops, g, dg!, cboop = nothing, tprev = false)
     function fiip(du, u, p, t)
         du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-        return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+        du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+        return nothing
     end
     function foop(u, p, t)
         dx = p[1] * u[1] - p[2] * u[1] * u[2]

--- a/test/callbacks/forward_sensitivity_callback.jl
+++ b/test/callbacks/forward_sensitivity_callback.jl
@@ -10,7 +10,8 @@ savingtimes = 0.1
 function test_discrete_callback(cb, tstops, g)
     function fiip(du, u, p, t)
         #du[1] = dx = p[1]*u[1]
-        return du[:] .= p[1] * u
+        du[:] .= p[1] * u
+        return nothing
     end
 
     p = Float64[0.8123198]

--- a/test/callbacks/vector_continuous_callbacks.jl
+++ b/test/callbacks/vector_continuous_callbacks.jl
@@ -11,7 +11,8 @@ function test_vector_continuous_callback(cb, g)
         du[1] = u[2]
         du[2] = -p[1]
         du[3] = u[4]
-        return du[4] = 0.0
+        du[4] = 0.0
+        return nothing
     end
 
     u0 = [50.0, 0.0, 0.0, 2.0]

--- a/test/complex_adjoints.jl
+++ b/test/complex_adjoints.jl
@@ -68,7 +68,8 @@ dp3 = Zygote.gradient(
 
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return nothing
 end
 p = [1.5, 1.0, 3.0, 1.0];
 u0 = [1.0; 1.0];

--- a/test/concrete_solve_derivatives.jl
+++ b/test/concrete_solve_derivatives.jl
@@ -104,7 +104,8 @@ Problem Definitions
 
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return nothing
 end
 
 function foop(u, p, t)
@@ -721,7 +722,8 @@ SDE Tests
 @testset "SDE Gradients" begin
     function σiip(du, u, p, t)
         du[1] = p[5] * u[1]
-        return du[2] = p[6] * u[2]
+        du[2] = p[6] * u[2]
+        return nothing
     end
 
     function σoop(u, p, t)

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -2,14 +2,16 @@ using SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, Calculus
 using Test
 function fb(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    return du[2] = dy = -t * p[3] * u[2] + t * u[1] * u[2]
+    du[2] = dy = -t * p[3] * u[2] + t * u[1] * u[2]
+    return nothing
 end
 function jac(J, u, p, t)
     (x, y, a, b, c) = (u[1], u[2], p[1], p[2], p[3])
     J[1, 1] = a + y * b * -1
     J[2, 1] = t * y
     J[1, 2] = b * x * -1
-    return J[2, 2] = t * c * -1 + t * x
+    J[2, 2] = t * c * -1 + t * x
+    return nothing
 end
 function paramjac(pJ, u, p, t)
     (x, y, a, b, c) = (u[1], u[2], p[1], p[2], p[3])
@@ -18,7 +20,8 @@ function paramjac(pJ, u, p, t)
     pJ[1, 2] = -x * y
     pJ[2, 2] = 0.0
     pJ[1, 3] = 0.0
-    return pJ[2, 3] = -t * y
+    pJ[2, 3] = -t * y
+    return nothing
 end
 
 f = ODEFunction(fb; jac, paramjac)
@@ -248,7 +251,8 @@ sen_no_MM = extract_local_sensitivities(sol_no_MM, 10.0, true)
 
 function f32(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    return du[2] = dy = -p[3] * u[2] + u[1] * u[2]
+    du[2] = dy = -p[3] * u[2] + u[1] * u[2]
+    return nothing
 end
 p = [1.5f0, 1.0f0, 3.0f0]
 prob = ODEForwardSensitivityProblem(f32, [1.0f0; 1.0f0], (0.0f0, 10.0f0), p)
@@ -283,7 +287,8 @@ function jac_with_count(J, u, p, t)
     J[1, 1] = a + y * b * -1
     J[2, 1] = t * y
     J[1, 2] = b * x * -1
-    return J[2, 2] = t * c * -1 + t * x
+    J[2, 2] = t * c * -1 + t * x
+    return nothing
 end
 
 f = ODEFunction(fb; jac = jac_with_count, paramjac)

--- a/test/forward_chunking.jl
+++ b/test/forward_chunking.jl
@@ -109,7 +109,8 @@ du0 = ForwardDiff.gradient(u0 -> loss(u0, p), u0)
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
     du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
-    return du[3:end] .= p[4]
+    du[3:end] .= p[4]
+    return nothing
 end
 function foop(u, p, t)
     dx = p[1] * u[1] - p[2] * u[1] * u[2]

--- a/test/forward_prob_kwargs.jl
+++ b/test/forward_prob_kwargs.jl
@@ -9,7 +9,8 @@ u0 = [1.0, 1.0]
 p = [1.5, 1.0, 3.0, 1.0]
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return nothing
 end
 
 prob = ODEProblem(

--- a/test/forward_remake.jl
+++ b/test/forward_remake.jl
@@ -2,7 +2,8 @@ using SciMLSensitivity, ForwardDiff, Distributions, OrdinaryDiffEq, LinearAlgebr
 
 function fiip(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return nothing
 end
 function g(sol)
     J = extract_local_sensitivities(sol, true)[2]
@@ -40,7 +41,8 @@ end
 
 function ff3(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    return du[2] = dy = -p[3] * u[2] + u[1] * u[2]
+    du[2] = dy = -p[3] * u[2] + u[1] * u[2]
+    return nothing
 end
 
 p = [1.5, 1.0, 3.0]

--- a/test/hybrid_de.jl
+++ b/test/hybrid_de.jl
@@ -23,7 +23,8 @@ ps = ComponentArray(ps)
 
 function dudt(du, u, p, t)
     du[1:2] .= -u[1:2]
-    return du[3:end] .= first(dudt2(u[1:2], p, st))
+    du[3:end] .= first(dudt2(u[1:2], p, st))
+    return nothing
 end
 z0 = Float32[u0; u0]
 prob = ODEProblem(dudt, z0, tspan)

--- a/test/layers.jl
+++ b/test/layers.jl
@@ -20,7 +20,8 @@ else
         x, y = u
         α, β, δ, γ = p
         du[1] = dx = (α - β * y)x
-        return du[2] = dy = (δ * x - γ)y
+        du[2] = dy = (δ * x - γ)y
+        return nothing
     end
     p = [2.2, 1.0, 2.0, 0.4]
     u0 = [1.0, 1.0]

--- a/test/layers_dde.jl
+++ b/test/layers_dde.jl
@@ -19,7 +19,8 @@ else
         x, y = u
         α, β, δ, γ = p
         du[1] = dx = (α - β * y) * h(p, t - 0.1)[1]
-        return du[2] = dy = (δ * x - γ) * y
+        du[2] = dy = (δ * x - γ) * y
+        return nothing
     end
     h(p, t) = ones(eltype(p), 2)
     prob = DDEProblem(delay_lotka_volterra, [1.0, 1.0], h, (0.0, 10.0), constant_lags = [0.1])

--- a/test/layers_sde.jl
+++ b/test/layers_sde.jl
@@ -18,7 +18,8 @@ else
         x, y = u
         α, β, δ, γ = p
         du[1] = dx = α * x - β * x * y
-        return du[2] = dy = -δ * y + γ * x * y
+        du[2] = dy = -δ * y + γ * x * y
+        return nothing
     end
     function lotka_volterra(u, p, t)
         x, y = u
@@ -29,7 +30,8 @@ else
     end
     function lotka_volterra_noise(du, u, p, t)
         du[1] = 0.01u[1]
-        return du[2] = 0.01u[2]
+        du[2] = 0.01u[2]
+        return nothing
     end
     function lotka_volterra_noise(u, p, t)
         return [0.01u[1], 0.01u[2]]

--- a/test/literal_adjoint.jl
+++ b/test/literal_adjoint.jl
@@ -3,7 +3,8 @@ function lv!(du, u, p, t)
     x, y = u
     a, b, c, d = p
     du[1] = a * x - b * x * y
-    return du[2] = -c * y + d * x * y
+    du[2] = -c * y + d * x * y
+    return nothing
 end
 function test(u0, p)
     tspan = [0.0, 1.0]

--- a/test/mixed_costs.jl
+++ b/test/mixed_costs.jl
@@ -365,23 +365,27 @@ dFiniteDiff = FiniteDiff.finite_difference_gradient(mixed_cost_forward, input)
 
 function dgdu_discrete(out, u, p, t, i)
     out[1] = 2u[1]
-    return out[2] = 0.0
+    out[2] = 0.0
+    return nothing
 end
 function dgdp_discrete(out, u, p, t, i)
     out[1] = 0.0
     out[2] = 1.0
     out[3] = 0.0
-    return out[4] = 0.0
+    out[4] = 0.0
+    return nothing
 end
 function dgdu_continuous(out, u, p, t)
     out[1] = 2u[1]
-    return out[2] = 0.0
+    out[2] = 0.0
+    return nothing
 end
 function dgdp_continuous(out, u, p, t)
     out[1] = 1.0
     out[2] = 0.0
     out[3] = 0.0
-    return out[4] = 0.0
+    out[4] = 0.0
+    return nothing
 end
 
 # BacksolveAdjoint, all vjps

--- a/test/mooncake_vjp_prob_kwargs.jl
+++ b/test/mooncake_vjp_prob_kwargs.jl
@@ -10,7 +10,8 @@ using DifferentiationInterface
 using Test
 
 function f!(du, u, p, t)
-    return du[1] = p[1] * u[1]
+    du[1] = p[1] * u[1]
+    return nothing
 end
 
 const u0 = [1.0]

--- a/test/nested_ad_regression.jl
+++ b/test/nested_ad_regression.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEq, SciMLSensitivity, Test
 function f!(du, u::AbstractArray{T}, p, x) where {T}
-    return du[1] = -p[1] * exp((x - 8)) * u[1]
+    du[1] = -p[1] * exp((x - 8)) * u[1]
+    return nothing
 end
 
 # primal calculation

--- a/test/save_idxs.jl
+++ b/test/save_idxs.jl
@@ -4,7 +4,8 @@ function lotka_volterra!(du, u, p, t)
     x, y = u
     α, β, δ, γ = p
     du[1] = dx = α * x - β * x * y
-    return du[2] = dy = -δ * y + γ * x * y
+    du[2] = dy = -δ * y + γ * x * y
+    return nothing
 end
 
 # Initial condition

--- a/test/second_order.jl
+++ b/test/second_order.jl
@@ -3,7 +3,8 @@ using Test
 
 function fb(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
-    return du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return nothing
 end
 
 function jac(J, u, p, t)
@@ -11,7 +12,8 @@ function jac(J, u, p, t)
     J[1, 1] = a + y * b * -1
     J[2, 1] = y
     J[1, 2] = b * x * -1
-    return J[2, 2] = c * -1 + x
+    J[2, 2] = c * -1 + x
+    return nothing
 end
 
 f = ODEFunction(fb; jac)

--- a/test/size_handling_adjoint.jl
+++ b/test/size_handling_adjoint.jl
@@ -4,7 +4,8 @@ using Optimization, OptimizationOptimisers
 p = [1.5 1.0; 3.0 1.0]
 function lotka_volterra(du, u, p, t)
     du[1] = p[1, 1] * u[1] - p[1, 2] * u[1] * u[2]
-    return du[2] = -p[2, 1] * u[2] + p[2, 2] * u[1] * u[2]
+    du[2] = -p[2, 1] * u[2] + p[2, 2] * u[1] * u[2]
+    return nothing
 end
 
 u0 = [1.0, 1.0]

--- a/test/stiff_adjoints.jl
+++ b/test/stiff_adjoints.jl
@@ -12,7 +12,8 @@ function lotka_volterra(du, u, p, t)
     x, y = u
     α, β, δ, γ = p
     du[1] = dx = α * x - β * x * y
-    return du[2] = dy = -δ * y + γ * x * y
+    du[2] = dy = -δ * y + γ * x * y
+    return nothing
 end
 
 u0 = [1.0, 1.0];

--- a/test/time_type_mixing.jl
+++ b/test/time_type_mixing.jl
@@ -5,7 +5,8 @@ p_model = [1.0f0]
 u0 = Float32.([0.0])
 
 function dudt(du, u, p, t)
-    return du[1] = p[1]
+    du[1] = p[1]
+    return nothing
 end
 
 prob = ODEProblem(dudt, u0, (0.0f0, 99.9f0))


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Formatter mistakenly understood the last assignment of an in-place function to also be the return value. Now explicitly return `nothing` in keeping with the formatter requirements.
