### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -684,7 +684,7 @@ function SciMLBase._concrete_solve_adjoint(
                     ) &&
                         length(Δu) == 1 && i == 1
                     # user did sol[end] on only_end
-                    x = Δu isa AbstractVectorOfArray ? Δu[1] : Δu[1]
+                    x = Δu isa AbstractVectorOfArray ? Δu.u[1] : Δu[1]
                     if _save_idxs isa Number
                         vx = vec(x)
                         _out[_save_idxs] .= vx[_save_idxs]
@@ -710,7 +710,7 @@ function SciMLBase._concrete_solve_adjoint(
                 end
             else
                 !Base.isconcretetype(eltype(Δ)) &&
-                    (Δu[i] isa NoTangent || eltype(Δu) <: NoTangent) && return
+                    ((Δu isa AbstractVectorOfArray ? Δu.u[i] : Δu[i]) isa NoTangent || eltype(Δu) <: NoTangent) && return
                 if Δ isa AbstractArray{<:AbstractArray} || Δ isa AbstractVectorOfArray ||
                         Δ isa Tangent
                     x = Δ isa AbstractVectorOfArray ? Δu.u[i] :
@@ -793,7 +793,7 @@ function SciMLBase._concrete_solve_adjoint(
                 end
             else
                 !Base.isconcretetype(eltype(Δ)) &&
-                    (Δ[i] isa NoTangent || eltype(Δ) <: NoTangent) && return
+                    ((Δ isa AbstractVectorOfArray ? Δ.u[i] : Δ[i]) isa NoTangent || eltype(Δ) <: NoTangent) && return
                 if Δ isa AbstractArray{<:AbstractArray} || Δ isa AbstractVectorOfArray
                     x = Δ isa AbstractVectorOfArray ? Δ.u[i] : Δ[i]
                     if _save_idxs isa Number
@@ -1903,7 +1903,7 @@ function SciMLBase._concrete_solve_adjoint(
                 (u isa ZeroTangent || u isa NoTangent) ? zero(u0) : u
             end
             reduce(hcat, ut_)
-        elseif ybar[1] isa Array
+        elseif ybar.u[1] isa Array
             return Array(ybar)
         else
             tmp = vec(ybar.u[1])

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -723,7 +723,7 @@ Compatible with a limited subset of `AbstractArray` types for `u0`, including `C
 
     TrackerAdjoint is incompatible with Stiff ODE solvers using forward-mode automatic
     differentiation for the Jacobians. Thus, for example, `TRBDF2()` will error. Instead,
-    use `autodiff=false`, i.e. `TRBDF2(autodiff=false)`. This will only remove the
+    use `autodiff=AutoFiniteDiff()`, i.e. `TRBDF2(autodiff=AutoFiniteDiff())`. This will only remove the
     forward-mode automatic differentiation of the Jacobian construction, not the reverse-mode
     AD usage, and thus performance will still be nearly the same, though Jacobian accuracy
     may suffer which could cause more steps to be required.

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -1,5 +1,5 @@
 using SciMLSensitivity, OrdinaryDiffEq, RecursiveArrayTools, DiffEqBase,
-    ForwardDiff, Calculus, QuadGK, LinearAlgebra, Zygote, Mooncake
+    ForwardDiff, Calculus, QuadGK, LinearAlgebra, Zygote, Mooncake, ADTypes
 using Test
 
 function fb(du, u, p, t)
@@ -1270,12 +1270,12 @@ using LinearAlgebra, SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, QuadGK
 function G(p, prob, ts, cost)
     tmp_prob_mm = remake(prob; u0 = convert.(eltype(p), prob.u0), p)
     sol = solve(
-        tmp_prob_mm, Rodas4(autodiff = false), abstol = 1.0e-14, reltol = 1.0e-14,
+        tmp_prob_mm, Rodas4(autodiff = AutoFiniteDiff()), abstol = 1.0e-14, reltol = 1.0e-14,
         saveat = ts
     )
     return cost(sol)
 end
-alg = Rodas4(autodiff = false)
+alg = Rodas4(autodiff = AutoFiniteDiff())
 @info "discrete cost"
 A = [1 2 3; 4 5 6; 7 8 9]
 function foo(du, u, p, t)
@@ -1381,7 +1381,7 @@ function G_cont(p)
         tspan = eltype(p).(prob_mm.tspan)
     )
     sol = solve(
-        tmp_prob_mm, Rodas4(autodiff = false),
+        tmp_prob_mm, Rodas4(autodiff = AutoFiniteDiff()),
         abstol = 1.0e-14, reltol = 1.0e-14
     )
     res, err = quadgk(
@@ -1424,7 +1424,7 @@ for iip in [true, false]
 
     prob_singular_mm = ODEProblem(f, [1.0, 0.0, 1.0], (0.0, 100), p)
     sol_singular_mm = solve(
-        prob_singular_mm, FBDF(autodiff = false),
+        prob_singular_mm, FBDF(autodiff = AutoFiniteDiff()),
         reltol = 1.0e-12, abstol = 1.0e-12, initializealg = BrownFullBasicInit()
     )
     ts = [50, sol_singular_mm.t[end]]
@@ -1518,7 +1518,7 @@ prob_singular_mm = ODEProblem(
     [2.2, 1.1], (0.0, 1.5), p
 )
 sol_singular_mm = solve(
-    prob_singular_mm, Rodas4(autodiff = false),
+    prob_singular_mm, Rodas4(autodiff = AutoFiniteDiff()),
     reltol = 1.0e-14, abstol = 1.0e-14
 )
 ts = [0.01, 0.25, 0.5, 1.0, 1.5]
@@ -1561,7 +1561,7 @@ prob_singular_mm = ODEProblem(
     [1.0, 1.0], (0.0, 1), p
 )
 sol_singular_mm = solve(
-    prob_singular_mm, Rodas4(autodiff = false),
+    prob_singular_mm, Rodas4(autodiff = AutoFiniteDiff()),
     reltol = 1.0e-12, abstol = 1.0e-12
 )
 ts = [0.5, 1.0]

--- a/test/autodiff_events.jl
+++ b/test/autodiff_events.jl
@@ -28,7 +28,7 @@ function test_f(p)
     return solve(
         _prob, Tsit5(), abstol = 1.0e-14, reltol = 1.0e-14, callback = cb,
         save_everystep = false
-    )[end]
+    ).u[end]
 end
 findiff = Calculus.finite_difference_jacobian(test_f, p)
 findiff
@@ -48,10 +48,10 @@ function test_f2(
         _prob, alg; sensealg, controller, abstol = 1.0e-14, reltol = 1.0e-14,
         callback = cb, save_everystep = false
     )
-    return u[end][end]
+    return u.u[end][end]
 end
 
-@test test_f2(p) == test_f(p)[end]
+@test test_f2(p) == test_f(p)[end] # test_f returns a Vector, so [end] is fine here
 
 g1 = Zygote.gradient(θ -> test_f2(θ, ForwardDiffSensitivity()), p)
 g2 = Zygote.gradient(θ -> test_f2(θ, ReverseDiffAdjoint()), p)

--- a/test/concrete_solve_derivatives.jl
+++ b/test/concrete_solve_derivatives.jl
@@ -1,4 +1,4 @@
-using SciMLSensitivity, OrdinaryDiffEq, StochasticDiffEq
+using SciMLSensitivity, OrdinaryDiffEq, StochasticDiffEq, ADTypes
 using Test, ForwardDiff, Random
 import Tracker, ReverseDiff, ChainRulesCore, Mooncake, Enzyme
 
@@ -682,7 +682,7 @@ https://github.com/SciML/SciMLSensitivity.jl/issues/943
     ff_ball = ODEFunction{false}(fx_ball)
     prob_ball = ODEProblem{false}(ff_ball, u0_ball, (t_start, t_stop), p_ball)
 
-    solver_ball = Rosenbrock23(autodiff = false)
+    solver_ball = Rosenbrock23(autodiff = AutoFiniteDiff())
 
     function loss_ball(p)
         solution = solve(

--- a/test/forwarddiffsensitivity_sparsity_components.jl
+++ b/test/forwarddiffsensitivity_sparsity_components.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, SciMLSensitivity
+using OrdinaryDiffEq, SciMLSensitivity, ADTypes
 using ComponentArrays, LinearAlgebra, Optimization, OptimizationOptimisers, Test
 
 const nknots = 10
@@ -23,7 +23,7 @@ prob = ODEProblem(ODEFunction(f #=, jac_prototype = jac_proto =#), u0, (0.0, 1.0
 function loss(p)
     _prob = remake(prob; p)
     sol = solve(
-        _prob, Rodas4P(autodiff = false), saveat = 0.1,
+        _prob, Rodas4P(autodiff = AutoFiniteDiff()), saveat = 0.1,
         sensealg = ForwardDiffSensitivity()
     )
     return sum((sol .- sol_true) .^ 2)

--- a/test/nested_ad_regression.jl
+++ b/test/nested_ad_regression.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, SciMLSensitivity, Test
+using OrdinaryDiffEq, SciMLSensitivity, Test, ADTypes
 function f!(du, u::AbstractArray{T}, p, x) where {T}
     du[1] = -p[1] * exp((x - 8)) * u[1]
     return nothing
@@ -23,7 +23,7 @@ adj_prob = ODEAdjointProblem(
 )
 adj_sol = solve(adj_prob, KenCarp4())
 @test length(adj_sol.t) < 300
-adj_sol2 = solve(adj_prob, KenCarp4(autodiff = false))
+adj_sol2 = solve(adj_prob, KenCarp4(autodiff = AutoFiniteDiff()))
 @test abs(length(adj_sol.t) - length(adj_sol2.t)) < 20
 
 adj_prob2 = ODEAdjointProblem(
@@ -32,7 +32,7 @@ adj_prob2 = ODEAdjointProblem(
     KenCarp4(),
     nothing, nothing, nothing, dg, nothing, g
 )
-adj_sol3 = solve(adj_prob, KenCarp4(autodiff = false))
+adj_sol3 = solve(adj_prob, KenCarp4(autodiff = AutoFiniteDiff()))
 @test abs(length(adj_sol.t) - length(adj_sol3.t)) < 20
 
 res2 = adjoint_sensitivities(

--- a/test/physical_ode_regression.jl
+++ b/test/physical_ode_regression.jl
@@ -2,7 +2,7 @@
 
 using OrdinaryDiffEq
 using ForwardDiff, ReverseDiff, Zygote, FiniteDiff
-using Test, SciMLSensitivity
+using Test, SciMLSensitivity, ADTypes
 
 # A falling mass (without contact, just gravity)
 GRAVITY = 9.81
@@ -42,7 +42,7 @@ end
 analyt_sol = [-27.675, 0.0]
 atol = 1.0e-2
 
-solvers = [Tsit5(), Rosenbrock23(autodiff = false), Rosenbrock23(autodiff = true)]
+solvers = [Tsit5(), Rosenbrock23(autodiff = AutoFiniteDiff()), Rosenbrock23(autodiff = AutoForwardDiff())]
 for solver in solvers
     loss = (p) -> sum(mysolve(p; solver))
     @test isapprox(FiniteDiff.finite_difference_gradient(loss, p), analyt_sol; atol)


### PR DESCRIPTION
## Summary

- Replace deprecated `autodiff=false/true` Bool usage in ODE solver constructors with `autodiff=AutoFiniteDiff()`/`AutoForwardDiff()` from ADTypes across all affected test files
- Fix deprecated `AbstractVectorOfArray` linear indexing (`A[i]` → `A.u[i]`) in `src/concrete_solve.jl` adjoint backpass implementations (4 locations)
- Fix deprecated positional `alg` argument in `ODEForwardSensitivityProblem` calls in `test/forward.jl` (use `sensealg=` keyword instead)
- Fix deprecated solution linear indexing in `test/autodiff_events.jl` (`sol[end]` → `sol.u[end]`)
- Update docstring in `src/sensitivity_algorithms.jl` to reference `AutoFiniteDiff()` instead of `autodiff=false`
- Add `using ADTypes` to test files that need it (required because `@safetestset` creates isolated module scopes)

## Files changed

**Source fixes:**
- `src/concrete_solve.jl` — Fix 4 instances of deprecated `AbstractVectorOfArray` linear indexing in adjoint backpass code
- `src/sensitivity_algorithms.jl` — Update docstring example

**Test fixes:**
- `test/forward.jl` — Fix positional `alg` usage + `autodiff=Bool` + add `using ADTypes`
- `test/adjoint.jl` — Fix 7 `autodiff=Bool` usages + add `using ADTypes`
- `test/autodiff_events.jl` — Fix deprecated solution indexing
- `test/concrete_solve_derivatives.jl` — Fix `autodiff=Bool` + add `using ADTypes`
- `test/nested_ad_regression.jl` — Fix `autodiff=Bool` + add `using ADTypes`
- `test/physical_ode_regression.jl` — Fix `autodiff=Bool` + add `using ADTypes`
- `test/forwarddiffsensitivity_sparsity_components.jl` — Fix `autodiff=Bool` + add `using ADTypes`

## Upstream note

Some `autodiff=Bool` deprecation warnings originate from within OrdinaryDiffEqCore's internal `_process_AD_choice` function when algorithms auto-select their AD backend. These are upstream issues in OrdinaryDiffEqCore and cannot be fixed in this repository.

## Test plan

- [x] Ran Core1 tests with `JULIA_DEPWARN=error` — zero deprecation warnings
- [x] Ran Core2 tests with `JULIA_DEPWARN=error` — zero deprecation warnings
- [x] All tests pass
- [x] Ran Runic formatter — all files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)