### PR TITLE
Normalize CallbackAffectPWrapper VJP argument ordering

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -492,8 +492,10 @@ function _vecjacobian!(
         _y = eltype(y) === eltype(λ) ? y : convert.(promote_type(eltype(y), eltype(λ)), y)
         if W === nothing
             _tunables, _repack, _ = canonicalize(Tunable(), _p)
+            _is_pswap = TS <: CallbackSensitivityFunctionPSwap
             tape = ReverseDiff.GradientTape((_y, _tunables, [t])) do u, p, t
-                du1 = similar(u, size(u))
+                du1 = _is_pswap ? similar(p, length(p)) : similar(u, size(u))
+                du1 .= false
                 f(du1, u, _repack(p), first(t))
                 return vec(du1)
             end

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -548,14 +548,11 @@ function _update_integrand_and_dgrad(
 
     _p = similar(integrand.p, size(integrand.p))
     _p .= false
-    wp(_p, integrand.p, integrand.y, t)
+    wp(_p, integrand.y, integrand.p, t)
 
     if _p != integrand.p
-        paramjac_config = get_paramjac_config(
-            sensealg.autojacvec, integrand.y, wp, _p, integrand.y, t;
-            numindvar = length(integrand.y), alg = nothing,
-            isinplace = true, isRODE = false,
-            _W = nothing
+        paramjac_config = _get_wp_paramjac_config(
+            sensealg.autojacvec, integrand.p, wp, integrand.y, integrand.p, t
         )
         pf = get_pf(sensealg.autojacvec; _f = wp, isinplace = true, isRODE = false)
         if sensealg.autojacvec isa EnzymeVJP
@@ -572,8 +569,8 @@ function _update_integrand_and_dgrad(
         fakeSp = CallbackSensitivityFunctionPSwap(wp, sensealg, diffcache_wp, sol.prob)
         #vjp with Jacobin given by dw/dp before event and vector given by grad
         vecjacobian!(
-            res, integrand.p, res, integrand.y, t, fakeSp;
-            dgrad = nothing, dy = nothing
+            nothing, integrand.y, res, integrand.p, t, fakeSp;
+            dgrad = res, dy = nothing
         )
         integrand = update_p_integrand(integrand, _p)
     end


### PR DESCRIPTION
## Summary

- Normalizes `CallbackAffectPWrapper` signature from `(dp, p, u, t)` to `(dp, u, p, t)` to match the standard `(du, u, p, t)` convention
- Uses the `dgrad` output path (p-derivative) in `vecjacobian!` instead of hijacking the `dλ` path (u-derivative) via swapped arguments
- Adds `_get_wp_paramjac_config` helper for correct param-sized output buffers in Enzyme and ReverseDiff VJP paths

This unblocks PRs #1335, #1292, #1260, #1223 that need SciMLStructures support, where `canonicalize(Tunable(), _p)` was running on state `y` instead of actual parameters (because `integrator.p` was passed in the `y` position), and Enzyme code assumed position 2 is a state-like object.

### Files changed

- `src/callback_tracking.jl` — Signature change, normalized `vecjacobian!` calls, added `_get_wp_paramjac_config` helper, replaced `get_paramjac_config` with param-aware version
- `src/derivative_wrappers.jl` — ReverseDiff on-the-fly tape: `CallbackSensitivityFunctionPSwap` dispatch for param-sized output buffer
- `src/quadrature_adjoint.jl` — QuadratureAdjoint callback path: normalized `wp` call order, `vecjacobian!` args, and paramjac config

## Test plan

- [x] Callbacks1 test group passes all 360 tests locally (Julia 1.12.4)
- [x] Verified unmodified code also passes 360 tests (baseline comparison)
- [x] Critical test cases exercised: "parameter changing callback", "Dosing example", all sensealg variants (BacksolveAdjoint, InterpolatingAdjoint, QuadratureAdjoint, GaussAdjoint, ReverseDiffAdjoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)