### PR TITLE
Fix use of remake_zero! with callback affect differentiation

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -795,14 +795,7 @@ function _vecjacobian!(
     enzyme_mode = isautojacvec isa EnzymeVJP ? isautojacvec.mode : Enzyme.Reverse
 
     if inplace_sensitivity(S)
-        if S isa CallbackSensitivityFunction
-            # Correctness over speed
-            # TODO: Get a fix for `remake_zero!` to allow reusing zero'd memory
-            # https://github.com/EnzymeAD/Enzyme.jl/issues/2400
-            _tmp6 = Enzyme.make_zero(SciMLBase.Void(f))
-        else
-            Enzyme.remake_zero!(_tmp6)
-        end
+        Enzyme.remake_zero!(_tmp6)
 
         if W === nothing
             Enzyme.autodiff(


### PR DESCRIPTION
## Summary

Rebased version of #1223.

Removes the workaround that used `Enzyme.make_zero` (allocating new shadow memory each call) instead of `Enzyme.remake_zero!` (reusing zeroed memory) for `CallbackSensitivityFunction`. 

The workaround was needed due to [EnzymeAD/Enzyme.jl#2400](https://github.com/EnzymeAD/Enzyme.jl/issues/2400), which has since been resolved by [EnzymeAD/Enzyme.jl#2436](https://github.com/EnzymeAD/Enzyme.jl/pull/2436) (`remake_zero` support). The issue is now closed.

This should improve performance for callback sensitivity computations with EnzymeVJP by avoiding repeated allocation.

## Test plan
- CI should pass with the existing test suite (Core6 callback tests in particular)

🤖 Generated with [Claude Code](https://claude.com/claude-code)