### PR TITLE
Narrow NonlinearProblem dispatches to exclude SCCNonlinearProblem

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -6,7 +6,9 @@
 # Use a narrow union instead of AbstractNonlinearProblem so that composite problem
 # types like SCCNonlinearProblem (which should differentiate through their individual
 # NonlinearProblem sub-solves) don't accidentally match these dispatches.
-const ConcreteNonlinearProblem = Union{NonlinearProblem, SciMLBase.SteadyStateProblem}
+const ConcreteNonlinearProblem = Union{
+    NonlinearProblem, SciMLBase.ImmutableNonlinearProblem, SciMLBase.SteadyStateProblem,
+}
 
 const have_not_warned_vjp = Ref(true)
 const STACKTRACE_WITH_VJPWARN = Ref(false)


### PR DESCRIPTION
## Summary
- Replace `AbstractNonlinearProblem` with `Union{NonlinearProblem, SteadyStateProblem}` in all `_concrete_solve_adjoint` dispatches and `automatic_sensealg_choice`
- This prevents `SCCNonlinearProblem` from accidentally matching these methods, since it should instead differentiate through its individual `NonlinearProblem` sub-solves
- Supersedes #1308 with a simpler approach

## Context
`SCCNonlinearProblem <: AbstractNonlinearProblem`, so it was matching all the adjoint dispatches meant for `NonlinearProblem`/`SteadyStateProblem`. Since an `SCCNonlinearProblem` is just a collection of `NonlinearProblem`s, AD should flow through the individual sub-solves rather than being intercepted at the composite level.

## Test plan
- [ ] Existing tests should pass unchanged since `NonlinearProblem` and `SteadyStateProblem` are still covered
- [ ] `SCCNonlinearProblem` solves should now differentiate through sub-problem solves naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)