### PR TITLE
Fix ReactantVJP with stiff solvers via Enzyme fallback for ForwardDiff.Dual

### DIFF
--- a/test/nested_ad_regression.jl
+++ b/test/nested_ad_regression.jl
@@ -48,13 +48,10 @@ res1 = adjoint_sensitivities(
 @test res1[1] ≈ res2[1]
 @test res1[2] ≈ res2[2]
 
-# ReactantVJP: KenCarp4 uses ForwardDiff for internal Jacobian, which pushes Dual numbers
-# through reactant_run_ad! — ConcreteRArray/Float64 conversions don't support Dual types.
-@test_broken begin
-    res3 = adjoint_sensitivities(
-        sol, KenCarp4(); dgdu_continuous = dg, g,
-        abstol = 1.0e-6, reltol = 1.0e-6,
-        sensealg = QuadratureAdjoint(autojacvec = ReactantVJP(allow_scalar = true))
-    )
-    res1[1] ≈ res3[1] && res1[2] ≈ res3[2]
-end
+res3 = adjoint_sensitivities(
+    sol, KenCarp4(); dgdu_continuous = dg, g,
+    abstol = 1.0e-6, reltol = 1.0e-6,
+    sensealg = QuadratureAdjoint(autojacvec = ReactantVJP(allow_scalar = true))
+)
+@test res1[1] ≈ res3[1]
+@test res1[2] ≈ res3[2]

--- a/test/stiff_adjoints.jl
+++ b/test/stiff_adjoints.jl
@@ -227,9 +227,7 @@ if VERSION >= v"1.7-"
             @test Zygote.gradient(
                 p -> loss(p, QuadratureAdjoint(autojacvec = EnzymeVJP())), p
             )[1] isa Vector
-            # ReactantVJP: stiff solvers push ForwardDiff.Dual through reactant_run_ad!,
-            # which can't convert Dual → Float64 for ConcreteRArray.
-            @test_broken Zygote.gradient(
+            @test Zygote.gradient(
                 p -> loss(p, QuadratureAdjoint(autojacvec = ReactantVJP())), p
             )[1] isa Vector
             @test_broken Zygote.gradient(p -> loss(p, ReverseDiffAdjoint()), p)[1] isa
@@ -312,13 +310,9 @@ if VERSION >= v"1.7-"
     #@test grad1 ≈ grad6
     @test grad1 ≈ grad7 rtol = 1.0e-2
 
-    # ReactantVJP: Rodas5P uses ForwardDiff for the adjoint ODE Jacobian, which pushes
-    # Dual numbers through reactant_run_ad! — ConcreteRArray doesn't support Dual types.
-    @test_broken begin
-        grad9 = Zygote.gradient(
-            x -> sum_of_solution_CASA(x, vjp = ReactantVJP(allow_scalar = true)),
-            [u0; p]
-        )[1]
-        grad1 ≈ grad9
-    end
+    grad9 = Zygote.gradient(
+        x -> sum_of_solution_CASA(x, vjp = ReactantVJP(allow_scalar = true)),
+        [u0; p]
+    )[1]
+    @test grad1 ≈ grad9
 end


### PR DESCRIPTION
## Summary

- When stiff ODE solvers (Rodas5P, KenCarp4, etc.) use ForwardDiff internally for Jacobians (`forwarddiffs_model(solver) == true`), `ForwardDiff.Dual` numbers flow into `reactant_run_ad!` which fails because `ConcreteRArray` only supports `Float64`
- Adds runtime detection of `ForwardDiff.Dual` element types in the ReactantVJP `_vecjacobian!` path
- Falls back to `Enzyme.autodiff` (which handles Duals natively) using `LazyBufferCache`-adapted buffers, following the same pattern as EnzymeVJP
- Promotes 3 `@test_broken` to passing `@test` in `stiff_adjoints.jl` and `nested_ad_regression.jl`

Fixes the first part of #1362 (Category 1: ForwardDiff.Dual incompatibility with Reactant for stiff solvers).

## Design

The Reactant compiled kernel is fixed to `Float64` and cannot handle Dual numbers. Rather than trying to make the Reactant path handle Duals (which would require decomposing the VJP computation and running multiple kernel calls), we detect Duals at runtime and fall back to Enzyme:

- **Float64 inputs** → Reactant compiled kernel (fast path, unchanged)
- **ForwardDiff.Dual inputs** → Enzyme fallback with `LazyBufferCache` buffers

The `paramjac_config` for ReactantVJP is now `(reactant_config, enzyme_fallback)` where:
- `reactant_config` = the 9-element tuple from the Reactant extension (unchanged)
- `enzyme_fallback` = `(tmp1, tmp2, tmp3, tmp4, tmp5, f_shadow, p_shadow)` with `LazyBufferCache` for y-shaped buffers when `forwarddiffs_model(alg)` is true

Callback VJPs are unaffected — stiff solver ForwardDiff does not propagate through callback affects.

## Test plan

- [x] Rober + Rodas5P + ReactantVJP: gradients match EnzymeVJP
- [x] Lotka-Volterra + Rodas5P + ReactantVJP: gradients match EnzymeVJP
- [x] KenCarp4 nested AD + ReactantVJP: results match EnzymeVJP
- [x] Tsit5 + ReactantVJP (non-stiff): Reactant fast path still works
- [x] Full `stiff_adjoints.jl` test file passes
- [x] Full `nested_ad_regression.jl` test file passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)