### PR TITLE
Re-enable all ReactantVJP @test_broken tests (#1362 categories 2, 3, 4)

### DIFF
--- a/test/null_parameters.jl
+++ b/test/null_parameters.jl
@@ -324,12 +324,12 @@ du0 = Zygote.gradient(
     u0
 )[1]
 @test Fdu0 ≈ du0 rtol = 1.0e-10
-# ReactantVJP: IIP dynamics uses .= broadcasting which hits a Reactant compilation bug
-# (Reactant produces zeros for Enzyme.autodiff when the function uses .= broadcasting)
-@test_broken Zygote.gradient(
+# ReactantVJP: IIP dynamics with .= broadcasting (fixed in Reactant.jl#2512)
+du0 = Zygote.gradient(
     u0 -> loss_iip(u0, sensealg = BacksolveAdjoint(autojacvec = ReactantVJP())),
     u0
-)[1] ≈ Fdu0
+)[1]
+@test Fdu0 ≈ du0
 
 # InterpolatingAdjoint
 du0 = Zygote.gradient(
@@ -371,10 +371,11 @@ du0 = Zygote.gradient(
     u0
 )[1]
 @test Fdu0 ≈ du0 rtol = 1.0e-10
-@test_broken Zygote.gradient(
+du0 = Zygote.gradient(
     u0 -> loss_iip(u0, sensealg = InterpolatingAdjoint(autojacvec = ReactantVJP())),
     u0
-)[1] ≈ Fdu0
+)[1]
+@test Fdu0 ≈ du0
 
 # QuadratureAdjoint
 du0 = Zygote.gradient(
@@ -413,10 +414,11 @@ du0 = Zygote.gradient(
     u0
 )[1]
 @test Fdu0 ≈ du0 rtol = 1.0e-10
-@test_broken Zygote.gradient(
+du0 = Zygote.gradient(
     u0 -> loss_iip(u0, sensealg = QuadratureAdjoint(autojacvec = ReactantVJP())),
     u0
-)[1] ≈ Fdu0
+)[1]
+@test Fdu0 ≈ du0
 
 # ForwardDiffSensitivity
 du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = ForwardDiffSensitivity()), u0)[1]


### PR DESCRIPTION
## Summary

Resolves all three remaining `@test_broken` categories from #1362.

**Commit 1: Re-enable ReactantVJP IIP tests in null_parameters.jl (category 2)**
- Upstream Reactant.jl#2502 fixed in [Reactant.jl#2512](https://github.com/EnzymeAD/Reactant.jl/pull/2512) (v0.2.228)
- 3 `@test_broken` → `@test` for BacksolveAdjoint, InterpolatingAdjoint, QuadratureAdjoint with ReactantVJP on IIP dynamics

**Commit 2: Use Duplicated function annotation in ReactantVJP (category 4)**
- ReactantVJP was passing the ODE function as `Enzyme.Const`, preventing Enzyme from differentiating through captured mutable state
- Now matches EnzymeVJP: wraps IIP functions in `SciMLBase.Void`, passes as `Enzyme.Duplicated` with shadow from `Enzyme.make_zero`
- 1 `@test_broken` → `@test` in adjoint_shapes.jl for IIP matrix-shaped parameters

**Commit 3: Replace Flux-style ReactantVJP tests with Lux in enzyme_closure.jl (category 3)**
- Reactant's ahead-of-time compilation freezes closure-captured mutable state, so the Flux-style `set_params(nn, p)` pattern can't work with ReactantVJP (filed as [Reactant.jl#2555](https://github.com/EnzymeAD/Reactant.jl/issues/2555))
- Replaced the 4 `@test_broken` with Lux-based equivalents using functional parameters — all pass
- Kept original Flux-style EnzymeVJP tests (EnzymeVJP natively handles closure differentiation)

## Test plan

- [x] `test/null_parameters.jl` passes locally (Julia 1.11.9, Reactant 0.2.228)
- [x] `test/adjoint_shapes.jl` passes locally
- [x] `test/enzyme_closure.jl` passes locally
- [x] Runic formatting verified on all changed files
- [ ] CI: Core 1, Core 6 test groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)