### PR TITLE
Fix ReactantVJP with stiff solvers via Enzyme fallback for ForwardDiff.Dual

### DIFF
--- a/test/nested_ad_regression.jl
+++ b/test/nested_ad_regression.jl
@@ -48,13 +48,10 @@ res1 = adjoint_sensitivities(
 @test res1[1] ≈ res2[1]
 @test res1[2] ≈ res2[2]
 
-# ReactantVJP: KenCarp4 uses ForwardDiff for internal Jacobian, which pushes Dual numbers
-# through reactant_run_ad! — ConcreteRArray/Float64 conversions don't support Dual types.
-@test_broken begin
-    res3 = adjoint_sensitivities(
-        sol, KenCarp4(); dgdu_continuous = dg, g,
-        abstol = 1.0e-6, reltol = 1.0e-6,
-        sensealg = QuadratureAdjoint(autojacvec = ReactantVJP(allow_scalar = true))
-    )
-    res1[1] ≈ res3[1] && res1[2] ≈ res3[2]
-end
+res3 = adjoint_sensitivities(
+    sol, KenCarp4(); dgdu_continuous = dg, g,
+    abstol = 1.0e-6, reltol = 1.0e-6,
+    sensealg = QuadratureAdjoint(autojacvec = ReactantVJP(allow_scalar = true))
+)
+@test res1[1] ≈ res3[1]
+@test res1[2] ≈ res3[2]

--- a/test/stiff_adjoints.jl
+++ b/test/stiff_adjoints.jl
@@ -227,9 +227,7 @@ if VERSION >= v"1.7-"
             @test Zygote.gradient(
                 p -> loss(p, QuadratureAdjoint(autojacvec = EnzymeVJP())), p
             )[1] isa Vector
-            # ReactantVJP: stiff solvers push ForwardDiff.Dual through reactant_run_ad!,
-            # which can't convert Dual → Float64 for ConcreteRArray.
-            @test_broken Zygote.gradient(
+            @test Zygote.gradient(
                 p -> loss(p, QuadratureAdjoint(autojacvec = ReactantVJP())), p
             )[1] isa Vector
             @test_broken Zygote.gradient(p -> loss(p, ReverseDiffAdjoint()), p)[1] isa
@@ -312,13 +310,9 @@ if VERSION >= v"1.7-"
     #@test grad1 ≈ grad6
     @test grad1 ≈ grad7 rtol = 1.0e-2
 
-    # ReactantVJP: Rodas5P uses ForwardDiff for the adjoint ODE Jacobian, which pushes
-    # Dual numbers through reactant_run_ad! — ConcreteRArray doesn't support Dual types.
-    @test_broken begin
-        grad9 = Zygote.gradient(
-            x -> sum_of_solution_CASA(x, vjp = ReactantVJP(allow_scalar = true)),
-            [u0; p]
-        )[1]
-        grad1 ≈ grad9
-    end
+    grad9 = Zygote.gradient(
+        x -> sum_of_solution_CASA(x, vjp = ReactantVJP(allow_scalar = true)),
+        [u0; p]
+    )[1]
+    @test grad1 ≈ grad9
 end


### PR DESCRIPTION
## Summary

- Add Enzyme fallback in `_vecjacobian!` for `ReactantVJP` when `ForwardDiff.Dual` types are detected (stiff solvers like KenCarp4 push Dual numbers through the adjoint RHS internally)
- Convert `@test_broken` to `@test` in `nested_ad_regression.jl` and `stiff_adjoints.jl` for ReactantVJP cases that now pass

## Context

Stiff ODE solvers (KenCarp4, Rodas5P, etc.) use ForwardDiff internally for Jacobian computation. When combined with `ReactantVJP`, Dual numbers flow into `reactant_run_ad!` which only supports `Float64` via `ConcreteRArray`. The fix detects Dual element types and falls back to `Enzyme.autodiff` (which handles Dual types natively), using `LazyBufferCache` for dynamically-sized buffers — matching the existing `EnzymeVJP` pattern.

The original "frozen Const" issue (#1361 Bug 2) turned out to be a usage issue — scalars need `track_numbers=true` in `Reactant.to_rarray`, which is already applied in the extension code. See EnzymeAD/Reactant.jl#2505.

## Test plan

- [x] `nested_ad_regression.jl` — ReactantVJP with KenCarp4 passes locally
- [x] `stiff_adjoints.jl` — ReactantVJP rober test passes locally
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)