### PR TITLE
Fix downstream DEQ CI: use CPU group instead of ALL

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest]
         package:
           - {user: SciML, repo: DiffEqFlux.jl, group: All}
-          - {user: SciML, repo: DeepEquilibriumNetworks.jl, group: ALL}
+          - {user: SciML, repo: DeepEquilibriumNetworks.jl, group: CPU}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Change DeepEquilibriumNetworks.jl downstream test group from `ALL` to `CPU` in `Downstream.yml`

## Problem

The downstream CI job for DeepEquilibriumNetworks.jl was failing because `GROUP=ALL` triggers a `using LuxCUDA` import in DEQ's [test/shared_testsetup.jl](https://github.com/SciML/DeepEquilibriumNetworks.jl/blob/main/test/shared_testsetup.jl#L10-L12). `LuxCUDA` is not in DEQ's test dependencies (nor should it be on a CPU runner), so the import fails with:

```
LoadError: ArgumentError: Package LuxCUDA not found in current path.
```

See: https://github.com/SciML/SciMLSensitivity.jl/actions/runs/22472383113/job/65091940105

CUDA tests for DEQ belong on Buildkite GPU runners, not GitHub Actions CPU runners.

## Fix

Set `group: CPU` so only CPU tests run on GHA, matching what the runner can actually support.

## Test plan

- [ ] Downstream CI for DeepEquilibriumNetworks.jl should pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)