### PR TITLE
Replace De Sauty component model with flat DAE for SCC init tests

### DIFF
--- a/test/desauty_dae_mwe.jl
+++ b/test/desauty_dae_mwe.jl
@@ -5,6 +5,7 @@ import SciMLStructures as SS
 import SciMLSensitivity
 using SymbolicIndexingInterface
 using FiniteDiff
+using ForwardDiff
 using Tracker
 using Enzyme
 using Mooncake
@@ -91,6 +92,25 @@ eqs = [
 
         fd_init_grad = FiniteDiff.finite_difference_gradient(init_loss, itunables)
         @test any(!iszero, fd_init_grad)
+
+        @testset "ForwardDiff through init" begin
+            if use_scc
+                @test_broken begin
+                    fwd_init = ForwardDiff.gradient(init_loss, itunables)
+                    isapprox(fwd_init, fd_init_grad, rtol = 0.05)
+                end
+            else
+                fwd_init = ForwardDiff.gradient(init_loss, itunables)
+                @test isapprox(fwd_init, fd_init_grad, rtol = 0.05)
+            end
+        end
+
+        @testset "ForwardDiff through ODE solve" begin
+            @test_broken begin
+                fwd_grad = ForwardDiff.gradient(loss, tunables)
+                isapprox(fwd_grad, fd_grad, rtol = 0.05)
+            end
+        end
 
         @testset "Enzyme through init" begin
             @test_broken begin


### PR DESCRIPTION
## Summary

- Replace the `ModelingToolkitStandardLibrary`-based De Sauty bridge circuit in `test/desauty_dae_mwe.jl` with a flat DAE system using nonlinear cubic algebraic constraints
- The new system forms a natural SCC chain that produces `SCCNonlinearProblem` with `use_scc=true`
- Tests both `use_scc=false` (NonlinearProblem init) and `use_scc=true` (SCCNonlinearProblem init with 2 sub-problems)
- Removes `ModelingToolkitStandardLibrary` dependency from this test

The new DAE system:
```
D(x) = a*x + y + z
0 = y^3 + y - b*x    (cubic in y, can't be eliminated by structural_simplify)
0 = z^3 + z - c*y    (cubic in z, can't be eliminated by structural_simplify)
```

### Test results

```
Test Summary:               | Pass  Broken  Total     Time
DAE with SCC Initialization |   12       6     18  9m25.4s
  use_scc = false           |    6       3      9
  use_scc = true            |    6       3      9
```

**Passing tests** (both modes): init problem type verification, forward solve, initial condition checks (y(0)≈1, z(0)≈0.86), FiniteDiff gradient nonzero for both ODE and init problems.

**Broken tests** (both modes): Enzyme through init, Mooncake through init, Tracker + GaussAdjoint through ODE solve. All fail in the initialization path due to missing AD type support in MTK-generated code.

Related: #1358

## Test plan
- [x] Verify test passes locally with `julia --project=@none` runner (12 pass, 6 broken, 0 errors)
- [ ] CI Core8 group passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)