### PR TITLE
Fix SteadyStateAdjoint to use SciMLStructures tunables for VJP allocation

### DIFF
--- a/src/steadystate_adjoint.jl
+++ b/src/steadystate_adjoint.jl
@@ -28,7 +28,7 @@ function SteadyStateAdjointSensitivityFunction(
 
     λ = zero(y)
     linsolve = needs_jac ? nothing : sensealg.linsolve
-    vjp = allocate_vjp(λ, p)
+    vjp = allocate_vjp(λ, diffcache.tunables)
 
     return SteadyStateAdjointSensitivityFunction(
         diffcache, sensealg, y, sol, f, colorvec,


### PR DESCRIPTION
## Summary

- Fix `SteadyStateAdjointSensitivityFunction` to allocate VJP storage using `diffcache.tunables` (the flat tunable vector from `SciMLStructures.canonicalize`) instead of the raw parameter object `p`
- For structured parameter types like `MTKParameters` that don't implement `@functor`, `allocate_vjp(λ, p)` via `fmap` returns `p` unchanged, later causing `adjoint(MTKParameters)` MethodError when `mul!(dgrad', λ', pJ)` is called in `_vecjacobian!`
- This aligns SteadyStateAdjoint with the rest of the adjoint codepaths which properly use `diffcache.tunables`

## Root Cause

In `SteadyStateAdjointSensitivityFunction` constructor (`src/steadystate_adjoint.jl:31`):
```julia
# Before (broken for structured parameter types):
vjp = allocate_vjp(λ, p)

# After (consistent with other adjoint paths):
vjp = allocate_vjp(λ, diffcache.tunables)
```

The `adjointdiffcache` already properly handles `SciMLStructures.isscimlstructure(p)` by extracting tunables via `canonicalize(Tunable(), p)`, but SteadyStateAdjoint was bypassing this and using raw `p` for VJP allocation.

## Test plan

- [x] Verified Zygote gradient through DAE init NonlinearProblem with MTKParameters matches FiniteDiff to ~10 digits
- [x] Core6 test suite passes (133 passed, 3 broken pre-existing, 0 failed): `GROUP=Core6 Pkg.test()`

Fixes #1358

🤖 Generated with [Claude Code](https://claude.com/claude-code)