### PR TITLE
Filter save_everystep from adjoint kwargs in concrete_solve

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -542,10 +542,12 @@ function SciMLBase._concrete_solve_adjoint(
     }(values(kwargs))
 
     # Capture the callback_adj for the reverse pass and remove both callbacks
+    # Also remove save_everystep since each adjoint method sets its own
+    # (e.g. GaussAdjoint uses save_everystep=false, QuadratureAdjoint uses true)
     kwargs_adj = NamedTuple{
         Base.diff_names(
             Base._nt_names(values(kwargs)),
-            (:callback_adj, :callback)
+            (:callback_adj, :callback, :save_everystep)
         ),
     }(values(kwargs))
     isq = sensealg isa QuadratureAdjoint

--- a/test/concrete_solve_derivatives.jl
+++ b/test/concrete_solve_derivatives.jl
@@ -774,3 +774,42 @@ SDE Tests
         @test isapprox(result[3:end], adj_ref', rtol = 1.0e-4)
     end
 end
+
+#=
+Test: save_everystep kwarg doesn't leak to adjoint solve for GaussAdjoint/GaussKronrodAdjoint
+
+When a user passes save_everystep=false to the outer solve, it should not propagate
+to the inner adjoint solve (which sets its own save_everystep). Previously this could
+cause duplicate keyword argument errors.
+=#
+@testset "save_everystep filtered from adjoint kwargs" begin
+    ref_loss = u0p -> sum(
+        solve(
+            prob, Tsit5(), u0 = u0p[1:2], p = u0p[3:end],
+            abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.1,
+            sensealg = GaussAdjoint()
+        )
+    )
+    u0p = vcat(u0, p)
+    ref_grad = ForwardDiff.gradient(ref_loss, u0p)
+
+    # Test that explicit save_everystep=false doesn't cause errors with GaussAdjoint
+    @testset "GaussAdjoint save_everystep=$sev - $backend_name" for sev in [true, false],
+            (backend_name, grad_fn) in REVERSE_BACKENDS
+
+        if backend_name == "Tracker" && VERSION >= v"1.12"
+            @test_broken false
+            continue
+        end
+        loss = u0p -> sum(
+            solve(
+                prob, Tsit5(), u0 = u0p[1:2], p = u0p[3:end],
+                abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.1,
+                save_everystep = sev,
+                sensealg = GaussAdjoint()
+            )
+        )
+        result = grad_fn(loss, u0p)
+        @test result ≈ ref_grad rtol = 1.0e-4
+    end
+end


### PR DESCRIPTION
## Summary

- Adds `:save_everystep` to the `kwargs_adj` filter list in `_concrete_solve_adjoint`, alongside `:callback_adj` and `:callback`
- Each adjoint method already sets its own `save_everystep` during the reverse pass (e.g. `GaussAdjoint` uses `save_everystep=false` at `gauss_adjoint.jl:749`, `QuadratureAdjoint` uses `save_everystep=true`). If a user passes `save_everystep` to the outer `solve` call, it should not leak through to the inner adjoint solve.
- Adds a test verifying `GaussAdjoint` produces correct gradients with both `save_everystep=true` and `save_everystep=false` passed to the outer solve

## Test plan

- [x] New test `"save_everystep filtered from adjoint kwargs"` added to `test/concrete_solve_derivatives.jl`
- [x] Tests GaussAdjoint with `save_everystep=true` and `save_everystep=false` against ForwardDiff reference gradient
- [x] Tests pass locally with ReverseDiff backend
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)