### PR TITLE
Fix Issue #995

### DIFF
--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -457,8 +457,18 @@ function GaussIntegrand(sol, sensealg, checkpoints, dgdp = nothing)
     u0 = state_values(prob)
     p = parameter_values(prob)
 
-    if p === nothing || p isa SciMLBase.NullParameters
+    # if p === nothing || p isa SciMLBase.NullParameters
+    #     tunables, repack = p, identity
+
+    # minimal fix 4 for #995
+    #---------------------------------------------------
+    if p === nothing
+        tunables = Float64[]          # 0-length, Functors-safe
+        repack = _ -> nothing         # preserve original semantics
+    elseif p isa SciMLBase.NullParameters
         tunables, repack = p, identity
+    #----------------------------------------------------
+    
     elseif isscimlstructure(p)
         tunables, repack, _ = canonicalize(Tunable(), p)
     elseif isfunctor(p)


### PR DESCRIPTION
Fixes a failure in GaussAdjoint when p === nothing.

Previously, the GaussAdjoint path assumed tunables supports length and Functors traversal. When p === nothing, this resulted in errors (e.g. length(::Nothing) or recursive traversal failures), causing Zygote.gradient(..., nothing) to error.

The fix represents the no-parameter case using an empty tunables container (Float64[]) while preserving repack = _ -> nothing to maintain RHS semantics. This allows Zygote.gradient(..., nothing) to correctly return (nothing,), consistent with InterpolatingAdjoint.

## Checklist

- [ ] Appropriate tests were added: No new tests were added; verified with a minimal reproducer.
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated: Not applicable; internal fix
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Testing:
1. Ran Pkg.test() locally.
2. Confirmed the reproduction snippet from Issue #995 now succeeds: Zygote(loss2, nothing) returns nothing as expected.

Docs:
No documentation updates were required (internal fix; no public API changes).

I have not yet added a dedicated regression test; I can add one if you can point me to the preferred test location/pattern for SciMLSensitivity.