### PR TITLE
Skip ReactantVJP test that hangs due to upstream Reactant bug

### DIFF
--- a/test/size_handling_adjoint.jl
+++ b/test/size_handling_adjoint.jl
@@ -69,5 +69,8 @@ dp6 = Zygote.pullback(x -> loss(x; vjp = false), p0)[2](1)[1]
 @test dp1 ≈ dp5
 @test dp1 ≈ dp6
 
-dp7 = Zygote.pullback(x -> loss(x; vjp = ReactantVJP(allow_scalar = true)), p0)[2](1)[1]
-@test dp1 ≈ dp7
+# Skipped: ReactantVJP hangs due to upstream Reactant MLIR compiler bug
+# (infinite loop in ReduceMulToDotGeneral pattern rewrite).
+# See https://github.com/EnzymeAD/Reactant.jl/issues/2652
+#dp7 = Zygote.pullback(x -> loss(x; vjp = ReactantVJP(allow_scalar = true)), p0)[2](1)[1]
+#@test dp1 ≈ dp7


### PR DESCRIPTION
## Summary

- Skip the `ReactantVJP` test in `test/size_handling_adjoint.jl` that causes Core5 CI to hang for 6+ hours and time out

## Context

Reactant v0.2.229+ (Reactant_jll v0.0.345+) introduced an MLIR compiler bug where the `ReduceMulToDotGeneral` greedy pattern rewrite enters an infinite loop when compiling the VJP kernel for a matrix-valued ODE (30×50 state) through `InterpolatingAdjoint(autojacvec = ReactantVJP(...))`.

- Upstream Reactant issue: https://github.com/EnzymeAD/Reactant.jl/issues/2652
- Tracking issue: #1386
- This unblocks #1336 and any other PR affected by the Core5 timeout

## Test plan

- [ ] Core5 CI jobs should complete instead of timing out
- [ ] Re-enable the skipped test once upstream Reactant fix lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)