### PR TITLE
Fix GPU scalar indexing in mul! with Adjoint wrappers

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -328,7 +328,9 @@ function _vecjacobian_vjp!(dλ, y, λ, p, t, S, dgrad, dy, W)
             else
                 f.paramjac(pJ, y, p, t, W)
             end
-            mul!(dgrad', λ', pJ)
+            # Use pJ' * λ instead of dgrad' = λ' * pJ to avoid GPU scalar indexing
+            # with Adjoint wrappers on vectors
+            mul!(vec(dgrad), pJ', λ)
         else
             # AD backends compute dλ and dgrad jointly; pass dλ=nothing to skip
             # redundant state VJP (already computed above).
@@ -398,7 +400,9 @@ function _vecjacobian_vjp(y, λ, p, t, S, dgrad, dy, W)
             else
                 f.paramjac(pJ, y, p, t, W)
             end
-            mul!(dgrad', λ', pJ)
+            # Use pJ' * λ instead of dgrad' = λ' * pJ to avoid GPU scalar indexing
+            # with Adjoint wrappers on vectors
+            mul!(vec(dgrad), pJ', λ)
         else
             _, _, dgrad = _vecjacobian(y, λ, p, t, S, S.sensealg.autojacvec, dgrad, dy, W)
             dy = nothing  # dy handled by the fallback
@@ -474,7 +478,9 @@ function _vecjacobian!(
                 jacobian!(J, uf, y, f_cache, sensealg, jac_config)
             end
         end
-        mul!(dλ', λ', J)
+        # Use J' * λ instead of dλ' = λ' * J to avoid GPU scalar indexing
+        # with Adjoint wrappers on vectors
+        mul!(vec(dλ), J', λ)
     end
     if dgrad !== nothing && !isempty(dgrad)
         (; pJ, pf, paramjac_config) = S.diffcache
@@ -525,7 +531,9 @@ function _vecjacobian!(
                 end
             end
         end
-        mul!(dgrad', λ', pJ)
+        # Use pJ' * λ instead of dgrad' = λ' * pJ to avoid GPU scalar indexing
+        # with Adjoint wrappers on vectors
+        mul!(vec(dgrad), pJ', λ)
     end
     if dy !== nothing
         if W === nothing

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -573,7 +573,8 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
             _pJ = similar(y, length(y), length(out))
         end
         _odef.paramjac(_pJ, y, p, t)
-        mul!(out', λ', _pJ)
+        # Use _pJ' * λ instead of out' = λ' * _pJ to avoid GPU scalar indexing
+        mul!(vec(out), _pJ', λ)
         return out
     end
 
@@ -585,7 +586,8 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
             pf.u = y
             jacobian!(pJ, pf, tunables, f_cache, sensealg, paramjac_config)
         end
-        mul!(out', λ', pJ)
+        # Use pJ' * λ instead of out' = λ' * pJ to avoid GPU scalar indexing
+        mul!(vec(out), pJ', λ)
     elseif sensealg.autojacvec isa ReverseDiffVJP
         tape = paramjac_config
         tu, tp, tt = ReverseDiff.input_hook(tape)

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -339,7 +339,8 @@ function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
             _pJ = similar(y, length(y), length(out))
         end
         _odef.paramjac(_pJ, y, p, t)
-        mul!(out', λ', _pJ)
+        # Use _pJ' * λ instead of out' = λ' * _pJ to avoid GPU scalar indexing
+        mul!(vec(out), _pJ', λ)
         return out
     end
 
@@ -353,7 +354,8 @@ function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
             pf.u = y
             jacobian!(pJ, pf, tunables, f_cache, sensealg, paramjac_config)
         end
-        mul!(out', λ', pJ)
+        # Use pJ' * λ instead of out' = λ' * pJ to avoid GPU scalar indexing
+        mul!(vec(out), pJ', λ)
     elseif sensealg.autojacvec isa ReverseDiffVJP
         tape = paramjac_config
         tu, tp, tt = ReverseDiff.input_hook(tape)


### PR DESCRIPTION
## Summary

Replace `mul!(dgrad', λ', pJ)` with `mul!(vec(dgrad), pJ', λ)` to fix CUDA scalar indexing errors.

The `mul!(dgrad', λ', pJ)` pattern creates `Adjoint` wrappers on CUDA vectors which, combined with matrix multiplication against a `CuMatrix`, triggers `LinearAlgebra._generic_matmatmul_generic!` fallback that uses scalar indexing (disallowed by CUDA).

The new form computes the mathematically equivalent operation: `dgrad = pJ' * λ` (column vector = transposed matrix × column vector), which dispatches correctly to CUBLAS.

### Files Changed
- `src/derivative_wrappers.jl`: 4 occurrences fixed
- `src/quadrature_adjoint.jl`: 2 occurrences fixed
- `src/gauss_adjoint.jl`: 2 occurrences fixed

## Test plan
- [ ] GPU Tests CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)