### PR TITLE
Remove V100 CUDA compatibility workarounds

### DIFF
--- a/docs/LocalPreferences.toml
+++ b/docs/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,6 @@
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/test/gpu/LocalPreferences.toml
+++ b/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 DiffEqFlux = "aae7a2af-3d4f-5e19-a356-7da93b79d9d0"
 LuxCUDA = "d0bbae9a-e099-4d5b-a835-1c6931763bda"


### PR DESCRIPTION
## Summary
- Remove `docs/LocalPreferences.toml` and `test/gpu/LocalPreferences.toml` that pinned CUDA runtime to 12.6
- Remove `CUDA_Driver_jll` and `CUDA_Runtime_jll` dependency additions from docs and test Project.toml files

demeter4's driver has been downgraded to CUDA 12.9 (from 13.x), so these workarounds are no longer needed. The CUDA 12.x driver will automatically select a compatible toolkit for the V100s.

Reverts the workaround parts of #1390 (keeps other improvements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)