### PR TITLE
Fix StackOverflow in parameter handling for structs with non-differentiable fields

### DIFF
--- a/src/parameters_handling.jl
+++ b/src/parameters_handling.jl
@@ -1,6 +1,12 @@
 # NOTE: `fmap` can handle all these cases without us defining them, but it often makes the
 #       code type unstable. So we define them here to make the code type stable.
 # Handle Non-Array Parameters in a Generic Fashion
+
+# Base cases for non-differentiable Functors leaf types (Symbol, String, Char, etc.)
+# that fmap will pass to the mapped function. Without these, the generic fallbacks
+# `f(x) = fmap(f, x)` infinitely recurse on leaves since fmap calls f(leaf) again.
+# Number gets proper zero/arithmetic; non-numeric leaves are returned unchanged.
+const _NonDiffLeaf = Union{Symbol, AbstractString, AbstractChar}
 """
     recursive_copyto!(y, x)
 
@@ -18,6 +24,8 @@ recursive_copyto!(::Nothing, ::Nothing) = nothing
 function recursive_copyto!(y::T, x::NamedTuple) where {T}
     return fmap(recursive_copyto!, y, x)
 end
+recursive_copyto!(y::Number, x::Number) = x
+recursive_copyto!(y::T, x::T) where {T <: _NonDiffLeaf} = y
 
 """
     neg!(x)
@@ -29,6 +37,8 @@ recursive_neg!(x::Tuple) = map(recursive_neg!, x)
 recursive_neg!(x::NamedTuple{F}) where {F} = NamedTuple{F}(map(recursive_neg!, values(x)))
 recursive_neg!(x) = fmap(recursive_neg!, x)
 recursive_neg!(::Nothing) = nothing
+recursive_neg!(x::Number) = -x
+recursive_neg!(x::_NonDiffLeaf) = x
 
 """
     recursive_sub!(y, x)
@@ -43,6 +53,8 @@ end
 recursive_sub!(y::T, x::T) where {T} = fmap(recursive_sub!, y, x)
 recursive_sub!(y, ::Nothing) = y
 recursive_sub!(::Nothing, ::Nothing) = nothing
+recursive_sub!(y::Number, x::Number) = y - x
+recursive_sub!(y::T, x::T) where {T <: _NonDiffLeaf} = y
 
 """
     recursive_add!(y, x)
@@ -57,6 +69,8 @@ end
 recursive_add!(y::T, x::T) where {T} = fmap(recursive_add!, y, x)
 recursive_add!(y, ::Nothing) = y
 recursive_add!(::Nothing, ::Nothing) = nothing
+recursive_add!(y::Number, x::Number) = y + x
+recursive_add!(y::T, x::T) where {T <: _NonDiffLeaf} = y
 
 """
     allocate_vjp(λ, x)
@@ -72,11 +86,15 @@ function allocate_vjp(λ::AbstractArray, x::NamedTuple{F}) where {F}
     return NamedTuple{F}(allocate_vjp.((λ,), values(x)))
 end
 allocate_vjp(λ::AbstractArray, x) = fmap(Base.Fix1(allocate_vjp, λ), x)
+allocate_vjp(λ::AbstractArray{T}, x::Number) where {T} = zero(T)
+allocate_vjp(::AbstractArray, x::_NonDiffLeaf) = x
 
 allocate_vjp(x::AbstractArray) = zero(x) # similar(x)
 allocate_vjp(x::Tuple) = allocate_vjp.(x)
 allocate_vjp(x::NamedTuple{F}) where {F} = NamedTuple{F}(allocate_vjp.(values(x)))
 allocate_vjp(x) = fmap(allocate_vjp, x)
+allocate_vjp(x::Number) = zero(x)
+allocate_vjp(x::_NonDiffLeaf) = x
 
 """
     allocate_zeros(x)
@@ -87,6 +105,8 @@ allocate_zeros(x::AbstractArray) = zero.(x)
 allocate_zeros(x::Tuple) = allocate_zeros.(x)
 allocate_zeros(x::NamedTuple{F}) where {F} = NamedTuple{F}(allocate_zeros.(values(x)))
 allocate_zeros(x) = fmap(allocate_zeros, x)
+allocate_zeros(x::Number) = zero(x)
+allocate_zeros(x::_NonDiffLeaf) = x
 
 """
     recursive_adjoint(y)
@@ -97,3 +117,5 @@ recursive_adjoint(y::AbstractArray) = adjoint(y)
 recursive_adjoint(y::Tuple) = recursive_adjoint.(y)
 recursive_adjoint(y::NamedTuple{F}) where {F} = NamedTuple{F}(recursive_adjoint.(values(y)))
 recursive_adjoint(y) = fmap(recursive_adjoint, y)
+recursive_adjoint(y::Number) = adjoint(y)
+recursive_adjoint(y::_NonDiffLeaf) = y


### PR DESCRIPTION
## Summary
- Adds base cases for non-differentiable Functors leaf types (`Symbol`, `AbstractString`, `AbstractChar`, `Number`) in `parameters_handling.jl`
- Without these, `allocate_vjp`, `allocate_zeros`, `recursive_neg!`, `recursive_add!`, `recursive_sub!`, `recursive_copyto!`, and `recursive_adjoint` infinitely recurse when `fmap` traverses a struct and encounters a leaf type like `Symbol`, because the generic fallback `f(x) = fmap(f, x)` calls `f(leaf)` which calls `fmap(f, leaf)` which calls `f(leaf)` again

## Root cause
Diagnosed by @wsmoses in https://github.com/EnzymeAD/Enzyme.jl/issues/3013#issuecomment-4108129645:
> The StackOverflowError is not a bug in Enzyme's compiler, but rather an infinite recursion originating in SciMLSensitivity.jl during the execution of the adjoint pass setup.

When `fmap` from Functors.jl traverses a struct like `MyParams{T}(values::Vector{T}, tag::Symbol)`, it visits each field. `Symbol` is a Functors leaf (`isleaf(:foo) == true`), so `fmap` passes it directly to the mapped function. But `allocate_vjp(:foo)` has no base case and falls through to `allocate_vjp(x) = fmap(allocate_vjp, x)` → infinite recursion.

## Fix
- `Number` fields get proper arithmetic: `zero(x)`, `-x`, `y + x`, `y - x`, `adjoint(y)`
- Non-differentiable leaf types (`Symbol`, `AbstractString`, `AbstractChar`) are returned unchanged — they're metadata, not parameters

Not piracy since `allocate_vjp` et al. are SciMLSensitivity's own functions.

## Test plan
- [x] Verified `allocate_vjp`, `allocate_zeros`, `recursive_neg!`, `recursive_add!`, `recursive_sub!` all work correctly on `@functor`-annotated struct with `Symbol` field
- [x] Verified the Enzyme MWE from issue 3013 no longer StackOverflows (now hits a separate downstream `MethodError` in Enzyme's adjoint pass, which is the secondary issue wsmoses described)
- [ ] CI passes existing `functor_params.jl` tests

Fixes: https://github.com/EnzymeAD/Enzyme.jl/issues/3013
Ref: https://github.com/SciML/SciMLSensitivity.jl/issues/1358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>