### PR TITLE
Enable Mooncake through init test for use_scc=false DAE path

### DIFF
--- a/test/desauty_dae_mwe.jl
+++ b/test/desauty_dae_mwe.jl
@@ -120,12 +120,21 @@ eqs = [
         end
 
         @testset "Mooncake through init" begin
-            @test_broken begin
+            if use_scc
+                @test_broken begin
+                    rule = Mooncake.build_rrule(init_loss, itunables)
+                    _, (_, igs) = Mooncake.value_and_gradient!!(
+                        rule, init_loss, itunables,
+                    )
+                    !iszero(sum(igs))
+                end
+            else
                 rule = Mooncake.build_rrule(init_loss, itunables)
                 _, (_, igs) = Mooncake.value_and_gradient!!(
                     rule, init_loss, itunables,
                 )
-                !iszero(sum(igs))
+                @test !iszero(sum(igs))
+                @test isapprox(igs, fd_init_grad, rtol = 0.05)
             end
         end
 


### PR DESCRIPTION
## Summary
Enable the Mooncake-through-DAE-initialization test for the `use_scc=false` (NonlinearProblem) path in `desauty_dae_mwe.jl`. The `use_scc=true` (SCCNonlinearProblem) path remains `@test_broken`.

## Dependencies
- Mooncake v0.5.25 — chalk-lab/Mooncake.jl#1115 fixes `build_rrule` hang during abstract interpretation
- ModelingToolkitBase v1.28.0 — SciML/ModelingToolkit.jl#4432 fixes `increment_and_get_rdata!` for `MTKParameters` with varying FData layouts (e.g. empty `SVector{0}` initials → `NoFData`)

## Verified locally
```
FiniteDiff: [0.0, 0.0, 0.366, 0.310, 0.0, 0.0, 0.0, 0.733, 0.0, 0.0]
Mooncake:   [0.0, 0.0, 0.366, 0.310, 0.0, 0.0, 0.0, 0.733, 0.0, 0.0]
Match: true
```

## Context
Partial progress on #1358. The SCCNonlinearProblem path remains blocked for all AD backends (needs `_concrete_solve_adjoint(::SCCNonlinearProblem)` implementation).

## Test plan
- [x] Verified Mooncake gradient matches FiniteDiff on Julia 1.10
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)