### PR TITLE
Add diff_tunables to SteadyStateAdjoint for full-parameter VJP

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -33,12 +33,17 @@ return (AdjointDiffCache, y)
 function adjointdiffcache(
         g::G, sensealg, discrete, sol, dgdu::DG1, dgdp::DG2, f, alg;
         quad = false,
-        noiseterm = false, needs_jac = false
+        noiseterm = false, needs_jac = false, use_full_p = false
     ) where {G, DG1, DG2}
     prob = sol.prob
     u0 = state_values(prob)
     p = parameter_values(prob)
-    if p === nothing || p isa SciMLBase.NullParameters
+    if use_full_p && p !== nothing && !(p isa SciMLBase.NullParameters)
+        # Use full parameter object (including caches) for VJP computation.
+        # Required for SCCNonlinearProblem where explicitfuns! write active
+        # data into non-tunable parameter components.
+        tunables, repack = p, identity
+    elseif p === nothing || p isa SciMLBase.NullParameters
         tunables, repack = p, identity
     elseif isscimlstructure(p)
         tunables, repack, _ = canonicalize(Tunable(), p)

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -900,7 +900,7 @@ function SciMLBase._concrete_solve_adjoint(
 
         du0 = reshape(du0, size(u0))
 
-        dp = if p === nothing || p === SciMLBase.NullParameters()
+        dp_full = if p === nothing || p === SciMLBase.NullParameters()
             nothing
         elseif dp isa AbstractArray
             reshape(dp', size(tunables))
@@ -908,35 +908,47 @@ function SciMLBase._concrete_solve_adjoint(
             dp
         end
 
-        dp = Zygote.accum(dp, igs)
-
-        _,
-            repack_adjoint = if p === nothing || p === SciMLBase.NullParameters()
-            nothing, x -> (x,)
-        elseif isscimlstructure(p)
-            Zygote.pullback(p) do p
-                t, _, _ = canonicalize(Tunable(), p)
-                t
-            end
-        elseif isfunctor(p) && supports_functor_params(sensealg)
-            Zygote.pullback(p) do p
-                t, _ = Functors.functor(p)
-                t
-            end
+        # When diff_tunables=Val(false), dp_full is the full parameter
+        # gradient (SciMLStructure). Return it directly so the AD
+        # reverse rule can accumulate into all shadow components
+        # (including caches for SCCNonlinearProblem).
+        _use_full_p = hasproperty(sensealg, :diff_tunables) &&
+            sensealg.diff_tunables isa Val{false}
+        dp_tangent = if _use_full_p && isscimlstructure(dp_full)
+            Zygote.accum(dp_full, igs)
         else
-            nothing, x -> (x,)
+            dp = Zygote.accum(dp_full, igs)
+
+            _,
+                repack_adjoint = if p === nothing || p === SciMLBase.NullParameters()
+                nothing, x -> (x,)
+            elseif isscimlstructure(p)
+                Zygote.pullback(p) do p
+                    t, _, _ = canonicalize(Tunable(), p)
+                    t
+                end
+            elseif isfunctor(p) && supports_functor_params(sensealg)
+                Zygote.pullback(p) do p
+                    t, _ = Functors.functor(p)
+                    t
+                end
+            else
+                nothing, x -> (x,)
+            end
+
+            repack_adjoint(dp)[1]
         end
 
         return if originator isa SciMLBase.TrackerOriginator ||
                 originator isa SciMLBase.ReverseDiffOriginator
             (
-                NoTangent(), NoTangent(), du0, repack_adjoint(dp)[1], NoTangent(),
+                NoTangent(), NoTangent(), du0, dp_tangent, NoTangent(),
                 ntuple(_ -> NoTangent(), length(args))...,
             )
         else
             (
                 NoTangent(), NoTangent(), NoTangent(),
-                du0, repack_adjoint(dp)[1], NoTangent(),
+                du0, dp_tangent, NoTangent(),
                 ntuple(_ -> NoTangent(), length(args))...,
             )
         end
@@ -2368,58 +2380,65 @@ function SciMLBase._concrete_solve_adjoint(
             end
         end
 
-        dp = adjoint_sensitivities(sol, alg; sensealg, dgdu = df)
+        dp_full = adjoint_sensitivities(sol, alg; sensealg, dgdu = df)
 
-        dp,
-            Δtunables = if Δ isa AbstractArray || Δ isa Number
-            # if Δ isa AbstractArray, the gradients correspond to `u`
-            # this is something that needs changing in the future, but
-            # this is the applicable till the movement to structuaral
-            # tangents is completed
-            dp, Δtunables = if isscimlstructure(dp)
-                dp, _, _ = canonicalize(Tunable(), dp)
-                dp, nothing
-            elseif isfunctor(dp)
-                dp, _ = Functors.functor(dp)
-                dp, nothing
-            else
-                dp, nothing
-            end
+        # When diff_tunables=Val(false), dp_full is the full parameter
+        # gradient. Return it directly so AD can accumulate into all
+        # shadow components (including caches for SCCNonlinearProblem).
+        _use_full_p = hasproperty(sensealg, :diff_tunables) &&
+            sensealg.diff_tunables isa Val{false}
+        dp_tangent = if _use_full_p && isscimlstructure(dp_full)
+            dp_full
         else
-            dp, Δtunables = if isscimlstructure(p)
-                if (Δ.prob.p == ZeroTangent() || Δ.prob.p == NoTangent())
-                    dp, _, _ = canonicalize(Tunable(), dp)
+            dp,
+                Δtunables = if Δ isa AbstractArray || Δ isa Number
+                dp, Δtunables = if isscimlstructure(dp_full)
+                    dp, _, _ = canonicalize(Tunable(), dp_full)
+                    dp, nothing
+                elseif isfunctor(dp_full)
+                    dp, _ = Functors.functor(dp_full)
                     dp, nothing
                 else
-                    Δp = setproperties(dp, to_nt(Δ.prob.p))
-                    Δtunables, _, _ = canonicalize(Tunable(), Δp)
-                    dp, _, _ = canonicalize(Tunable(), dp)
-                    dp, Δtunables
+                    dp_full, nothing
                 end
-            elseif isfunctor(p)
-                dp, _ = Functors.functor(dp)
-                Δtunables, _ = Functors.functor(Δ.prob.p)
-                dp, Δtunables
             else
-                dp, Δ.prob.p
+                dp, Δtunables = if isscimlstructure(p)
+                    if (Δ.prob.p == ZeroTangent() || Δ.prob.p == NoTangent())
+                        dp, _, _ = canonicalize(Tunable(), dp_full)
+                        dp, nothing
+                    else
+                        Δp = setproperties(dp_full, to_nt(Δ.prob.p))
+                        Δtunables, _, _ = canonicalize(Tunable(), Δp)
+                        dp, _, _ = canonicalize(Tunable(), dp_full)
+                        dp, Δtunables
+                    end
+                elseif isfunctor(p)
+                    dp, _ = Functors.functor(dp_full)
+                    Δtunables, _ = Functors.functor(Δ.prob.p)
+                    dp, Δtunables
+                else
+                    dp_full, Δ.prob.p
+                end
             end
-        end
 
-        dp = Zygote.accum(
-            dp, (isnothing(Δtunables) || isempty(Δtunables)) ? nothing :
-                Δtunables
-        )
+            dp = Zygote.accum(
+                dp, (isnothing(Δtunables) || isempty(Δtunables)) ? nothing :
+                    Δtunables
+            )
+
+            repack_adjoint(dp)[1]
+        end
 
         return if originator isa SciMLBase.TrackerOriginator ||
                 originator isa SciMLBase.ReverseDiffOriginator
             (
-                NoTangent(), NoTangent(), NoTangent(), repack_adjoint(dp)[1], NoTangent(),
+                NoTangent(), NoTangent(), NoTangent(), dp_tangent, NoTangent(),
                 ntuple(_ -> NoTangent(), length(args))...,
             )
         else
             (
                 NoTangent(), NoTangent(), NoTangent(),
-                NoTangent(), repack_adjoint(dp)[1], NoTangent(),
+                NoTangent(), dp_tangent, NoTangent(),
                 ntuple(_ -> NoTangent(), length(args))...,
             )
         end

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -1293,30 +1293,31 @@ documentation page or the docstrings of the vjp types.
 Johnson, S. G., Notes on Adjoint Methods for 18.336, Online at
 http://math.mit.edu/stevenj/18.336/adjoint.pdf (2007)
 """
-struct SteadyStateAdjoint{CS, AD, FDT, VJP, LS, LK} <:
+struct SteadyStateAdjoint{CS, AD, FDT, VJP, LS, LK, DT <: Val} <:
     AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}
     autojacvec::VJP
     linsolve::LS
     linsolve_kwargs::LK
+    diff_tunables::DT
 end
 
 Base.@pure function SteadyStateAdjoint(;
         chunk_size = 0, autodiff = true,
         diff_type = Val{:central}, autojacvec = nothing, linsolve = nothing,
-        linsolve_kwargs = (;)
+        linsolve_kwargs = (;), diff_tunables = Val(true)
     )
     return SteadyStateAdjoint{
         chunk_size, autodiff, diff_type, typeof(autojacvec),
-        typeof(linsolve), typeof(linsolve_kwargs),
-    }(autojacvec, linsolve, linsolve_kwargs)
+        typeof(linsolve), typeof(linsolve_kwargs), typeof(diff_tunables),
+    }(autojacvec, linsolve, linsolve_kwargs, diff_tunables)
 end
 function setvjp(
         sensealg::SteadyStateAdjoint{CS, AD, FDT, VJP, LS, LK},
         vjp
     ) where {CS, AD, FDT, VJP, LS, LK}
-    return SteadyStateAdjoint{CS, AD, FDT, typeof(vjp), LS, LK}(
+    return SteadyStateAdjoint{CS, AD, FDT, typeof(vjp), LS, LK, typeof(sensealg.diff_tunables)}(
         vjp, sensealg.linsolve,
-        sensealg.linsolve_kwargs
+        sensealg.linsolve_kwargs, sensealg.diff_tunables
     )
 end
 

--- a/src/steadystate_adjoint.jl
+++ b/src/steadystate_adjoint.jl
@@ -20,10 +20,14 @@ function SteadyStateAdjointSensitivityFunction(
     )
     (; p, u0) = sol.prob
 
+    # When diff_tunables = Val(false), use the full parameter object so
+    # the VJP includes gradients w.r.t. all parameter components (e.g. caches).
+    _use_full_p = sensealg.diff_tunables isa Val{false} &&
+        isscimlstructure(p) && !(p isa AbstractArray)
     diffcache,
         y = adjointdiffcache(
         g, sensealg, false, sol, dgdu, dgdp, f, alg;
-        quad = false, needs_jac
+        quad = false, needs_jac, use_full_p = _use_full_p
     )
 
     λ = zero(y)


### PR DESCRIPTION
## Summary

Add `diff_tunables::Val` field to `SteadyStateAdjoint`. When `Val(false)`, the adjoint differentiates w.r.t. ALL parameter components (tunables + caches + initials + ...) instead of only the `Tunable()` portion.

This is the minimal plumbing needed for SCCNonlinearProblem gradient flow, extracted from #1397 without the `automatic_sensealg_choice` changes that caused stiff_adjoints regressions.

## Problem

The `_concrete_solve_adjoint` for NonlinearProblem calls `canonicalize(Tunable(), p)` to extract only tunable parameters. The adjoint computes `dp` only for tunables, returning `nothing` for caches/initials/etc. 

For SCCNonlinearProblem, `CacheWriter` stores intermediate solve results in `p.caches` between sub-problems. The gradient must flow through caches, but with tunables-only `dp`, it's always zero.

## Changes

- `sensitivity_algorithms.jl`: Add `diff_tunables` field + constructor kwarg to `SteadyStateAdjoint` (default `Val(true)` = no behavior change)
- `adjoint_common.jl`: Add `use_full_p` kwarg to `adjointdiffcache` that bypasses `canonicalize(Tunable(), p)`
- `steadystate_adjoint.jl`: Wire `diff_tunables` → `use_full_p`
- `concrete_solve.jl`: When `diff_tunables=Val(false)`, return full parameter gradient instead of extracting/repacking tunables

## What this does NOT change

- `automatic_sensealg_choice` is untouched — no risk of regressions in ODE adjoints
- No changes to `GaussAdjoint`, `QuadratureAdjoint`, `InterpolatingAdjoint`
- Opt-in only via `SteadyStateAdjoint(diff_tunables=Val(false))`

## Context
- Extracted from #1397 (the cache handling, without the automatic_sensealg_choice changes)
- Part of #1358 (DAE initialization AD support)
- The automatic sensealg detection for caches will be a separate follow-up PR

## Test plan
- [x] Default `Val(true)` preserves existing behavior (no API change)
- [ ] CI passes (existing tests unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)