### PR TITLE
Enable full-parameter VJP for Mooncake (SCCNonlinearProblem support)

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -936,14 +936,15 @@ function SciMLBase._concrete_solve_adjoint(
         end
 
         # When diff_tunables=Val(false), dp_full is the full parameter
-        # gradient (SciMLStructure). For Enzyme, return it directly so
-        # the reverse rule can accumulate into all shadow components.
+        # gradient (SciMLStructure). Return it as a NamedTuple tangent so
+        # the AD reverse rule can accumulate into all shadow components.
+        # This applies to all originators — diff_tunables=Val(false) is
+        # itself opt-in.
         _use_full_p = hasproperty(sensealg, :diff_tunables) &&
             sensealg.diff_tunables isa Val{false}
-        dp_tangent = if _use_full_p &&
-                originator isa SciMLBase.EnzymeOriginator &&
-                isscimlstructure(dp_full)
-            Zygote.accum(dp_full, igs)
+        dp_tangent = if _use_full_p && isscimlstructure(dp_full)
+            accumulated = Zygote.accum(dp_full, igs)
+            originator isa SciMLBase.EnzymeOriginator ? accumulated : to_nt(accumulated)
         else
             dp = Zygote.accum(dp_full, igs)
 
@@ -2415,13 +2416,14 @@ function SciMLBase._concrete_solve_adjoint(
         dp_full = adjoint_sensitivities(sol, alg; sensealg, dgdu = df)
 
         # When diff_tunables=Val(false), dp_full is the full parameter
-        # gradient (SciMLStructure). For Enzyme, return it directly so
-        # the reverse rule can accumulate into all shadow components
-        # (including caches for SCCNonlinearProblem).
-        dp_tangent = if originator isa SciMLBase.EnzymeOriginator &&
+        # gradient (SciMLStructure). Return it as a NamedTuple tangent so
+        # the AD reverse rule can accumulate into all shadow components
+        # (including caches for SCCNonlinearProblem). This applies to all
+        # originators — diff_tunables=Val(false) is itself opt-in.
+        dp_tangent = if hasproperty(sensealg, :diff_tunables) &&
                 sensealg.diff_tunables isa Val{false} &&
                 isscimlstructure(dp_full)
-            dp_full
+            originator isa SciMLBase.EnzymeOriginator ? dp_full : to_nt(dp_full)
         else
             dp = if isscimlstructure(dp_full)
                 canonicalize(Tunable(), dp_full)[1]

--- a/test/desauty_dae_mwe.jl
+++ b/test/desauty_dae_mwe.jl
@@ -133,22 +133,12 @@ eqs = [
         end
 
         @testset "Mooncake through init" begin
-            if use_scc
-                @test_broken begin
-                    rule = Mooncake.build_rrule(init_loss, itunables)
-                    _, (_, igs) = Mooncake.value_and_gradient!!(
-                        rule, init_loss, itunables,
-                    )
-                    !iszero(sum(igs))
-                end
-            else
-                rule = Mooncake.build_rrule(init_loss, itunables)
-                _, (_, igs) = Mooncake.value_and_gradient!!(
-                    rule, init_loss, itunables,
-                )
-                @test !iszero(sum(igs))
-                @test isapprox(igs, fd_init_grad, rtol = 0.05)
-            end
+            rule = Mooncake.build_rrule(init_loss, itunables)
+            _, (_, igs) = Mooncake.value_and_gradient!!(
+                rule, init_loss, itunables,
+            )
+            @test !iszero(sum(igs))
+            @test isapprox(igs, fd_init_grad, rtol = 0.05)
         end
 
         @testset "Tracker + GaussAdjoint through ODE solve" begin


### PR DESCRIPTION
## Summary

After #1397 merged, Mooncake `use_scc=false` worked but `use_scc=true` still produced zero gradients. The full-parameter VJP path was gated on `EnzymeOriginator` only, so for ChainRules-based AD backends (Mooncake), the rrule still extracted only tunables and discarded cache gradients — breaking the SCC chain.

## Changes

Two `_concrete_solve_adjoint` rrules in `concrete_solve.jl`:

1. **Remove the `EnzymeOriginator` gate** when `diff_tunables=Val(false)`. The flag is itself opt-in, so all originators should get the full-parameter gradient.

2. **Convert `dp_full` to a NamedTuple for non-Enzyme originators**. Mooncake's `@from_chainrules` bridge expects NamedTuple tangents for SciMLStructure params, while Enzyme accumulates into the struct shadow directly.

## Verified

```
SCC init (use_scc=true):
  FiniteDiff: [0.0, 0.0, 0.366, 0.310, 0.0, 0.0, 0.0, 0.733, 0.0, 0.0]
  Mooncake:   [0.0, 0.0, 0.366, 0.310, 0.0, 0.0, 0.0, 0.733, 0.0, 0.0]
  Match: true ✓

non-SCC init (use_scc=false):
  Match: true ✓ (no regression)
```

## Test changes

`test/desauty_dae_mwe.jl`: Mooncake-through-init test no longer needs the `if use_scc ... @test_broken` branch — both paths now pass.

## Context
Closes the Mooncake side of #1358 for the DAE initialization path. Built on top of #1397 (`diff_tunables` plumbing) and FunctionWrappersWrappers.jl#40 (Mooncake extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)