### PR TITLE
Fix BoundsError in InterpolatingAdjoint when checkpoint cpsol has 1 point

### DIFF
--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -132,6 +132,19 @@ function choose_dt(dt, ts, interval)
     return dt
 end
 
+# Compute a safe initial dt from a checkpoint solution's time vector. The
+# checkpoint solution may contain only a single saved point (e.g. when an
+# adaptive forward solve takes one step that already reaches the interval
+# end), in which case `cpsol_t[end - 1]` would be a `BoundsError`. Fall back
+# to the interval width in that case.
+function checkpoint_dt(cpsol_t, interval)
+    if length(cpsol_t) >= 2
+        return abs(cpsol_t[end] - cpsol_t[end - 1])
+    else
+        return abs(interval[2] - interval[1])
+    end
+end
+
 # u = λ'
 # add tstop on all the checkpoints
 function (S::ODEInterpolatingAdjointSensitivityFunction)(du, u, p, t)
@@ -230,7 +243,11 @@ function split_states(
                         prob, tspan = intervals[cursor′], u0 = y,
                         noise = forwardnoise
                     )
-                    dt = choose_dt(abs(cpsol_t[1] - cpsol_t[2]), cpsol_t, interval)
+                    dt = if length(cpsol_t) >= 2
+                        choose_dt(abs(cpsol_t[1] - cpsol_t[2]), cpsol_t, interval)
+                    else
+                        abs(interval[2] - interval[1])
+                    end
                     cpsol′ = solve(
                         prob′, sol.alg, save_noise = false; dt,
                         tstops = _ts[idx1:idx2], checkpoint_sol.tols...
@@ -240,7 +257,7 @@ function split_states(
                         prob′ = remake(prob, tspan = intervals[cursor′], u0 = y)
                         cpsol′ = solve(
                             prob′, sol.alg;
-                            dt = abs(cpsol_t[end] - cpsol_t[end - 1]),
+                            dt = checkpoint_dt(cpsol_t, interval),
                             checkpoint_sol.tols...
                         )
                     else
@@ -250,7 +267,7 @@ function split_states(
                             prob′ = remake(prob, tspan = intervals[cursor′], u0 = y, p = _p)
                             cpsol′ = solve(
                                 prob′, sol.alg;
-                                dt = abs(cpsol_t[end] - cpsol_t[end - 1]),
+                                dt = checkpoint_dt(cpsol_t, interval),
                                 tstops = checkpoint_sol.tstops,
                                 checkpoint_sol.tols...
                             )
@@ -258,7 +275,7 @@ function split_states(
                             prob′ = remake(prob, tspan = intervals[cursor′], u0 = y)
                             cpsol′ = solve(
                                 prob′, sol.alg;
-                                dt = abs(cpsol_t[end] - cpsol_t[end - 1]),
+                                dt = checkpoint_dt(cpsol_t, interval),
                                 tstops = checkpoint_sol.tstops,
                                 checkpoint_sol.tols...
                             )

--- a/test/checkpoint_single_step.jl
+++ b/test/checkpoint_single_step.jl
@@ -1,0 +1,47 @@
+using SciMLSensitivity, OrdinaryDiffEqTsit5, Test
+
+# Regression test for a BoundsError in
+# `ODEInterpolatingAdjointSensitivityFunction.split_states` when the
+# checkpoint solution that is built between two adjacent saveat / discrete
+# observation times only contains a single saved time point.
+#
+# Previously, the dt for the recomputed forward sub-solve was computed as
+# `abs(cpsol_t[end] - cpsol_t[end - 1])`, which throws
+# `BoundsError: attempt to access 1-element Vector at index [0]` when
+# `length(cpsol_t) == 1`. The fix falls back to the interval width.
+
+function dudt(u, p, t)
+    return p .* u
+end
+
+u0 = Float32[1.0]
+p = Float32[-0.5]
+tspan = (0.0f0, 1.5f0)
+prob = ODEProblem{false}(dudt, u0, tspan, p)
+
+# saveat times that are tightly spaced enough that an adaptive solver may
+# only take a single step inside a checkpoint interval
+time_batch = collect(range(tspan[1], tspan[2]; length = 30))
+
+forward_sol = solve(prob, Tsit5(); p, saveat = time_batch)
+
+batch = ones(Float32, length(time_batch))
+dgdu_discrete = (out, u, p, t, i) -> (out .= -2 * (batch[i] .- u[1]))
+
+@test_nowarn adjoint_sensitivities(
+    forward_sol, Tsit5();
+    t = time_batch, p,
+    dgdu_discrete,
+    sensealg = InterpolatingAdjoint()
+)
+
+result = adjoint_sensitivities(
+    forward_sol, Tsit5();
+    t = time_batch, p,
+    dgdu_discrete,
+    sensealg = InterpolatingAdjoint()
+)
+@test result isa Tuple
+@test length(result) == 2
+@test all(isfinite, result[1])
+@test all(isfinite, result[2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ end
             @time @safetestset "Time Type Mixing Adjoints" include("time_type_mixing.jl")
             @time @safetestset "SciMLStructures Interface" include("scimlstructures_interface.jl")
             @time @safetestset "Functor Parameters" include("functor_params.jl")
+            @time @safetestset "Checkpoint Single Step" include("checkpoint_single_step.jl")
         end
     end
 


### PR DESCRIPTION
## Summary
- `split_states` for `ODEInterpolatingAdjointSensitivityFunction` recomputes a forward sub-solve between two adjacent checkpoint times and uses `abs(cpsol_t[end] - cpsol_t[end - 1])` to seed the integrator's `dt`. When the previous checkpoint sub-solve only saved a single time point (e.g. because the adaptive forward solve took one step that already reached the interval end), `cpsol_t[end - 1]` becomes `cpsol_t[0]` and throws `BoundsError: attempt to access 1-element Vector at index [0]`.
- Adds a `checkpoint_dt(cpsol_t, interval)` helper that falls back to the interval width when fewer than two saved time points are available, and uses it from all three ODE branches in `split_states`.
- Guards the SDE branch's `cpsol_t[1] - cpsol_t[2]` access with the same length check.
- Adds `test/checkpoint_single_step.jl` (also wired into `runtests.jl` Core1) which reproduces the failure on master and passes with the fix.

## Repro
This is the exact failure surfacing in [SciML/Optimization.jl#1169 CI](https://github.com/SciML/Optimization.jl/actions/runs/23171032225/job/67322714897?pr=1169) (and on Optimization.jl `master` since at least 2026-04-08, run `24144818227`), where `test/minibatch.jl` calls `adjoint_sensitivities(...; sensealg = InterpolatingAdjoint())` against a forward solve produced with tightly-spaced `saveat`. Stack trace:

```
BoundsError: attempt to access 1-element Vector{Float32} at index [0]
  [3] split_states(du, u, t, S::ODEInterpolatingAdjointSensitivityFunction{...})
      @ SciMLSensitivity src/interpolating_adjoint.jl:241
```

Line 241 in v7.99.0 is `cpsol′ = solve(... dt = abs(cpsol_t[end] - cpsol_t[end - 1]) ...)` — same expression and same bug on current master (still at lines 243/253/261 of `src/interpolating_adjoint.jl`). Reproduced locally on Julia 1.11 with the patched and unpatched package and the new regression test fails on master and passes here.

## Test plan
- [x] `test/checkpoint_single_step.jl` reproduces the BoundsError on master, passes after the fix
- [x] `Optimization.jl/test/minibatch.jl` runs to completion against the patched SciMLSensitivity (was previously erroring out at the `loss_grad` call)
- [ ] Full SciMLSensitivity CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)