### PR TITLE
Dispatch init-path adjoint on AD originator (Mooncake-native, no hardcoded Zygote)

### DIFF
--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -3,7 +3,7 @@ module SciMLSensitivityMooncakeExt
 using SciMLSensitivity: SciMLSensitivity
 using Mooncake: Mooncake
 import SciMLSensitivity: get_paramjac_config, mooncake_run_ad, MooncakeVJP, MooncakeLoaded,
-    DiffEqBase, MooncakeAdjoint
+    DiffEqBase, MooncakeAdjoint, _init_originator_gradient
 using SciMLSensitivity: SciMLBase, SciMLStructures, canonicalize, Tunable, isscimlstructure,
     SciMLStructuresCompatibilityError, convert_tspan,
     has_continuous_callback,
@@ -11,6 +11,17 @@ using SciMLSensitivity: SciMLBase, SciMLStructures, canonicalize, Tunable, issci
 using SciMLSensitivity: FunctionWrappersWrappers, ODEFunction
 using ChainRulesCore: NoTangent, ZeroTangent, Tangent, unthunk
 using Accessors: @reset
+
+# Mooncake-native gradient for the DAE/ODE init path. Avoids pulling Zygote
+# into the rrule when the user is differentiating with Mooncake. The default
+# (Zygote-based) implementation lives in src/concrete_solve.jl.
+function _init_originator_gradient(
+        ::SciMLBase.MooncakeOriginator, f, tunables,
+    )
+    rule = Mooncake.build_rrule(f, tunables)
+    _, (_, igs) = Mooncake.value_and_gradient!!(rule, f, tunables)
+    return igs
+end
 
 function get_paramjac_config(::MooncakeLoaded, ::MooncakeVJP, pf, p, f, y, _t)
     dy_mem = zero(y)

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -358,6 +358,26 @@ function automatic_sensealg_choice(
     return default_sensealg
 end
 
+"""
+    _init_originator_gradient(originator, f, tunables)
+
+Compute `∂(f(tunables))/∂tunables` for a *scalar-valued* `f`, dispatched on
+the AD originator that triggered the surrounding `_concrete_solve_adjoint`
+rrule.
+
+Used by the DAE/ODE initialization adjoint path to differentiate
+`get_initial_values` w.r.t. the tunable parameters. The default
+implementation uses Zygote (which composes with all
+ChainRules-aware originators including `EnzymeOriginator`,
+`ReverseDiffOriginator`, `TrackerOriginator`, and `ChainRulesOriginator`).
+A `MooncakeOriginator` method lives in `ext/SciMLSensitivityMooncakeExt.jl`
+so Mooncake-driven differentiation does not pull in Zygote at this point.
+"""
+function _init_originator_gradient(::SciMLBase.ADOriginator, f, tunables)
+    iy, back = Zygote.pullback(f, tunables)
+    return back(one(iy))[1]
+end
+
 function SciMLBase._concrete_solve_adjoint(
         prob::Union{
             SciMLBase.AbstractODEProblem,
@@ -592,8 +612,6 @@ function SciMLBase._concrete_solve_adjoint(
             SciMLBase.has_initialization_data(_prob.f) &&
                 initializealg isa default_inits
         )
-        local new_u0
-        local new_p
         initializeprob = prob.f.initialization_data.initializeprob
         iu0 = state_values(initializeprob)
         isAD = if iu0 === nothing
@@ -609,25 +627,47 @@ function SciMLBase._concrete_solve_adjoint(
         initializealg = initializealg isa Union{Nothing, DefaultInit} ?
             initializealg_default : initializealg
 
-        iy,
-            back = Zygote.pullback(tunables) do tunables
-            new_prob = remake(_prob, p = repack(tunables))
-            new_u0, new_p,
-                _ = SciMLBase.get_initial_values(
-                new_prob, new_prob, new_prob.f, initializealg, Val(isinplace(new_prob));
-                sensealg = SteadyStateAdjoint(autojacvec = sensealg.autojacvec),
-                nlsolve_alg,
-                kwargs_init...
-            )
-            new_tunables, _,
-                _ = SciMLStructures.canonicalize(SciMLStructures.Tunable(), new_p)
-            if SciMLBase.initialization_status(_prob) == SciMLBase.OVERDETERMINED
-                sum(new_tunables)
-            else
-                sum(new_u0) + sum(new_tunables)
+        # Forward: actually compute the initial values once outside any AD
+        # call. This avoids depending on side-effect capture of `new_u0` /
+        # `new_p` from inside an AD-traced closure, which is unsafe for
+        # backends like Mooncake/Enzyme that build a separate trace.
+        new_u0, new_p,
+            _ = SciMLBase.get_initial_values(
+            _prob, _prob, _prob.f, initializealg, Val(isinplace(_prob));
+            sensealg = SteadyStateAdjoint(autojacvec = sensealg.autojacvec),
+            nlsolve_alg,
+            kwargs_init...
+        )
+
+        # Reverse: gradient of `sum(new_u0)` w.r.t. tunables, treating the
+        # initialization map `tunables -> new_u0` as a function. The
+        # OVERDETERMINED case has no contribution. The non-OVERDETERMINED
+        # case dispatches to the AD backend that triggered this rrule via
+        # `_init_originator_gradient`, so Mooncake-driven AD does not pull
+        # in Zygote at this point.
+        igs = if SciMLBase.initialization_status(_prob) == SciMLBase.OVERDETERMINED
+            zero(tunables)
+        else
+            init_loss = let _prob = _prob, repack = repack,
+                    initializealg = initializealg, nlsolve_alg = nlsolve_alg,
+                    sensealg = sensealg, kwargs_init = kwargs_init
+                function (t)
+                    new_prob_t = remake(_prob, p = repack(t))
+                    nu0, _,
+                        _ = SciMLBase.get_initial_values(
+                        new_prob_t, new_prob_t, new_prob_t.f, initializealg,
+                        Val(isinplace(new_prob_t));
+                        sensealg = SteadyStateAdjoint(
+                            autojacvec = sensealg.autojacvec,
+                        ),
+                        nlsolve_alg,
+                        kwargs_init...,
+                    )
+                    return sum(nu0)
+                end
             end
+            _init_originator_gradient(originator, init_loss, tunables)
         end
-        igs = back(one(iy))[1] .- one(eltype(tunables))
 
         igs, new_u0, new_p, SciMLBase.CheckInit()
     else


### PR DESCRIPTION
## Summary

The DAE/ODE initialization adjoint inside `_concrete_solve_adjoint` (the dispatch shared by `BacksolveAdjoint` / `QuadratureAdjoint` / `InterpolatingAdjoint` / `GaussAdjoint` / `GaussKronrodAdjoint`) hardcoded `Zygote.pullback` to compute the gradient of `get_initial_values` w.r.t. tunables, regardless of which AD backend triggered the surrounding rrule. The same function already dispatches on `originator` for Enzyme / Tracker / ReverseDiff handling further down — only the init path was locked to Zygote.

This PR introduces a small originator-dispatched helper, `_init_originator_gradient(originator, f, tunables)`. The default method uses Zygote (which composes with all ChainRules-aware originators), and a `MooncakeOriginator` method in `SciMLSensitivityMooncakeExt` uses `Mooncake.build_rrule` + `value_and_gradient!!` so Mooncake-driven AD does not pull in Zygote at this point.

Built on top of #1412.

## Changes

`src/concrete_solve.jl`:

1. Add `_init_originator_gradient(::SciMLBase.ADOriginator, f, tunables)` — default method, uses `Zygote.pullback`. Documented as the entry point for the init-path AD dispatch.

2. Restructure the init path inside the `BacksolveAdjoint`/`QuadratureAdjoint`/`InterpolatingAdjoint`/`GaussAdjoint`/`GaussKronrodAdjoint` dispatch:
   - Compute `get_initial_values` once **outside** any AD call to obtain `new_u0` / `new_p`. The previous implementation declared `local new_u0` / `local new_p` and assigned them inside a `Zygote.pullback` closure, relying on Zygote running the closure forward in the calling scope. That side-effect-capture pattern is unsafe for AD backends like Mooncake / Enzyme that build a separate trace.
   - Compute the gradient via `_init_originator_gradient(originator, init_loss, tunables)`, where `init_loss` returns `sum(nu0)` for a freshly-remade problem.
   - Drop the `back(one(iy))[1] .- one(eltype(tunables))` arithmetic trick — it existed only because the closure had to return a scalar that included `sum(new_tunables)` as a 1-derivative baseline. The new formulation differentiates `sum(nu0)` directly, and short-circuits the `OVERDETERMINED` branch to `zero(tunables)`.

`ext/SciMLSensitivityMooncakeExt.jl`:

3. Add the `::SciMLBase.MooncakeOriginator` method. Uses `Mooncake.build_rrule` + `Mooncake.value_and_gradient!!` natively.

## Why this matters

- Removes a hardcoded Zygote dependency from a code path that should be AD-agnostic — Mooncake-driven differentiation no longer routes through Zygote at the init step.
- Eliminates the fragile `local new_u0` / `local new_p` scope-capture pattern, which only worked because Zygote runs the closure forward in the enclosing scope.
- Aligns the init path with the rest of `_concrete_solve_adjoint`, which already dispatches on `originator` (lines 944, 967, 974 etc.).
- Paves the way for full Mooncake-through-ODE-solve once the remaining upstream Rodas5P/Mooncake/MTK issues clear.

## Validated locally (Julia 1.11)

| Test | Result |
| --- | --- |
| `test/desauty_dae_mwe.jl` (SCC + DAE init, the canonical case) | 17 pass, 7 broken — **matches baseline** |
| `test/scc_nonlinearsolve.jl` (SCCNonlinearProblem differentiation, Mooncake) | 7 pass, 1 broken |
| `test/parameter_initialization.jl` | 2 pass — **directly exercises the refactored init path via `Tracker` (`TrackerOriginator` → default Zygote helper method)** |
| `test/mtk.jl` | 1 pass, 2 `@test_broken` (unchanged) |

`parameter_initialization.jl` is the most important validation: its `Tracker.gradient` over `solve(prob; sensealg = GaussAdjoint(autojacvec = EnzymeVJP()))` on an MTK ODE with implicit DAE initialization (`__legacy_defaults__ = [ρ => missing]`) goes through the exact lines of the refactor.

A direct unit-test of the helper for each originator also passes:
```
zygote: [2.0, 4.0, 6.0]
enzyme (via Zygote default): [2.0, 4.0, 6.0]
reversediff (via Zygote default): [2.0, 4.0, 6.0]
tracker (via Zygote default): [2.0, 4.0, 6.0]
mooncake (native): [2.0, 4.0, 6.0]
```

## Note on Mooncake-through-full-ODE-solve

While testing this PR I tried adding a Mooncake-through-full-ODE-solve test against the desauty system. It fails for both `use_scc=false` (Rodas5P internal `FirstAutodiffJacError` — `MethodError: no method matching Float64(::ForwardDiff.Dual{...})`) and `use_scc=true` (`SciMLBase.AdjointNotFoundError` from a fallback inside the SCC NonlinearProblem rrule chain). These are upstream MTK / Mooncake / NonlinearSolve compatibility issues, not consequences of the init path. They are out of scope for this PR; the existing `Mooncake through init` test in `desauty_dae_mwe.jl` (which exercises `solve(::SCCNonlinearProblem)` directly via Mooncake) continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)