### PR TITLE
Enable Enzyme test for Tuple SCCNonlinearProblem on Julia 1.10

### DIFF
--- a/test/desauty_dae_mwe.jl
+++ b/test/desauty_dae_mwe.jl
@@ -119,13 +119,25 @@ eqs = [
         end
 
         @testset "Enzyme through init" begin
-            # Broken due to multiple upstream Enzyme/NonlinearSolve issues:
-            # - Julia 1.12: NonlinearSolveBaseEnzymeExt rules disabled (VERSION < v"1.12" guard)
-            #   causing LLVM crash in GC invariant verifier
-            # - Julia 1.10: EnzymeMutabilityException from MTK's remake (mutable closure),
-            #   MixedReturnException with default PolyAlgorithm, and NamedTuple broadcasting
-            #   error in NonlinearSolveBaseEnzymeExt reverse rule with MTKParameters
-            # See: NonlinearSolve.jl#869, Enzyme.jl#2699
+            # Status (verified 2026-04-10 with Enzyme 0.13, NonlinearSolve
+            # 4.17, SciMLBase 2.153, ModelingToolkit current release):
+            #
+            #   * Julia 1.10 (LTS): hits an `EnzymeMutabilityException` because
+            #     the closure capturing `iprob`/`irepack` cannot be proven
+            #     read-only. Wrapping `init_loss` in `Const(...)` advances past
+            #     the activity check but then crashes the LLVM GC invariant
+            #     verifier with `Illegal inttoptr` during `MTK.remake`/
+            #     `SciMLStructures.replace`. Even calling
+            #     `Enzyme.set_runtime_activity(Reverse)` produces the same
+            #     LLVM crash. The issue reproduces equally for `use_scc=false`
+            #     and `use_scc=true` and is independent of SCCNonlinearSolve.
+            #   * Julia 1.11+: same crashes plus a separate
+            #     `IllegalTypeAnalysisException` on `Base._typed_vcat!` inside
+            #     SCCNonlinearSolve's solution assembly.
+            #
+            # Tracking issues: NonlinearSolve.jl#869, Enzyme.jl#2699,
+            # Enzyme.jl#3021 (vcat type analysis), and the upstream MTK
+            # remake/Enzyme interaction.
             @test_broken begin
                 igs = Enzyme.gradient(Enzyme.Reverse, init_loss, itunables)
                 !iszero(sum(igs))

--- a/test/scc_nonlinearsolve.jl
+++ b/test/scc_nonlinearsolve.jl
@@ -70,14 +70,22 @@ p_test = [4.0, 3.0]
         @test isapprox(fwd, fd, rtol = 0.05)
     end
 
-    # Enzyme test skipped: Enzyme produces correct gradients with Tuple-based
-    # SCCNonlinearProblem (verified manually: [1.0, 2.0] matches FiniteDiff),
-    # but intermittently segfaults due to GC corruption on Julia 1.10,
-    # crashing the test process. Vector-based SCC fails because heterogeneous
-    # function types get erased to Any.
-    # See Enzyme.jl#3021.
+    # Enzyme through Tuple-based SCCNonlinearProblem now works reliably on
+    # Julia 1.10 (verified across 40+ consecutive runs with the current
+    # SCCNonlinearSolve, NonlinearSolveBase, and Enzyme releases). On Julia
+    # 1.11+, Enzyme still hits an `IllegalTypeAnalysisException` on
+    # `Base._typed_vcat!` inside SCCNonlinearSolve's solution assembly,
+    # which segfaults the worker process — gate the test on the LTS until
+    # the upstream Enzyme/NonlinearSolve issues are fixed.
+    # Vector-based SCC remains unsupported because heterogeneous function
+    # types get erased to Any. See Enzyme.jl#3021.
     @testset "Enzyme" begin
-        @test_skip true
+        if VERSION < v"1.11"
+            enz = Enzyme.gradient(Enzyme.Reverse, loss, copy(p_test))
+            @test isapprox(collect(enz[1]), fd, rtol = 0.05)
+        else
+            @test_skip true
+        end
     end
 
     @testset "Mooncake" begin


### PR DESCRIPTION
## Summary

- **`test/scc_nonlinearsolve.jl`** — drop `@test_skip` for Enzyme and actually run `Enzyme.gradient(Reverse, loss, p_test)` on the Tuple-based SCC problem. The previously reported intermittent GC corruption no longer reproduces with current Enzyme / NonlinearSolveBase / SCCNonlinearSolve releases (verified across 40+ consecutive standalone runs and 3 full-test-file runs on Julia 1.10). The new assertion is gated on `VERSION < v\"1.11\"` because Julia 1.11 / 1.12 still segfault inside Enzyme's type analysis of `Base._typed_vcat!` (Enzyme.jl#3021). For those versions the existing `@test_skip` is preserved.
- **`test/desauty_dae_mwe.jl`** — refresh the comment block on the `Enzyme through init` `@test_broken` to reflect what currently happens. I tried multiple approaches (closure, `Const(init_loss)`, explicit `Const(iprob)`/`Const(irepack)` arguments, `SciMLStructures.replace` instead of `remake`, `Enzyme.set_runtime_activity(Reverse)`) for both `use_scc=false` and `use_scc=true`. They all either hit `EnzymeMutabilityException` or crash the LLVM GC invariant verifier with `Illegal inttoptr` during the `MTK.remake` / `SciMLStructures.replace` path. The breakage is not specific to SCCNonlinearSolve — `use_scc=false` and `use_scc=true` fail identically — so the test stays `@test_broken` with an updated note.

This sits on top of #1412 (Mooncake-through-SCC fix), which is needed for the Mooncake side of the same testset to pass.

## Tested locally

| Julia | scc_nonlinearsolve.jl | desauty_dae_mwe.jl |
| --- | --- | --- |
| 1.10 (lts) | `Pass: 8 / Total: 8` | `Pass: 17 / Broken: 7 / Total: 24` |
| 1.11 | `Pass: 7 / Broken: 1 / Total: 8` (Enzyme skipped) | (not re-run; same skip path) |
| 1.12.5 | `Pass: 7 / Broken: 1 / Total: 8` (Enzyme skipped) | (not re-run; same skip path) |

Stress run (Julia 1.10, 15 standalone gradient invocations): all 15 returned `[1.0, 2.0]` to within `1e-12` of FiniteDiff.

## Test plan

- [x] `julia +1.10 test/scc_nonlinearsolve.jl` — passes 8/8
- [x] `julia +1.11 test/scc_nonlinearsolve.jl` — passes 7/8 with the Enzyme test correctly skipped
- [x] `julia +1.12.5 test/scc_nonlinearsolve.jl` — passes 7/8 with the Enzyme test correctly skipped
- [x] `julia +1.10 test/desauty_dae_mwe.jl` — passes 17/24 with the existing `@test_broken` entries still broken
- [ ] CI matrix on the SciMLSensitivity repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)