### PR TITLE
Stop singular mass matrix BacksolveAdjoint test from erroring CI

### DIFF
--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -1515,24 +1515,36 @@ for iip in [true, false]
     )
     @test res_interp2 ≈ res rtol = 1.0e-5
 
-    # backsolve doesn't work
-    _,
-        res_bs = adjoint_sensitivities(
-        sol_singular_mm, alg, t = ts,
-        dgdu_discrete = dg_singular, abstol = 1.0e-8,
-        reltol = 1.0e-8,
-        sensealg = BacksolveAdjoint(checkpointing = false)
-    )
-    @test_broken res_bs ≈ res rtol = 1.0e-5
-    _,
-        res_bs2 = adjoint_sensitivities(
-        sol_singular_mm, alg, t = ts,
-        dgdu_discrete = dg_singular, abstol = 1.0e-8,
-        reltol = 1.0e-8,
-        sensealg = BacksolveAdjoint(checkpointing = true),
-        checkpoints = sol_singular_mm.t
-    )
-    @test_broken res_bs2 ≈ res rtol = 1.0e-5
+    # backsolve doesn't work: BacksolveAdjoint is documented to fail on
+    # semi-explicit DAEs, and depending on Julia/LAPACK version the augmented
+    # Rodas4 W-matrix can become exactly singular and throw rather than
+    # returning a wrong result. Wrap in try/catch so @test_broken records it
+    # as broken either way instead of erroring the testset.
+    @test_broken try
+        _,
+            res_bs = adjoint_sensitivities(
+            sol_singular_mm, alg, t = ts,
+            dgdu_discrete = dg_singular, abstol = 1.0e-8,
+            reltol = 1.0e-8,
+            sensealg = BacksolveAdjoint(checkpointing = false)
+        )
+        isapprox(res_bs, res; rtol = 1.0e-5)
+    catch
+        false
+    end
+    @test_broken try
+        _,
+            res_bs2 = adjoint_sensitivities(
+            sol_singular_mm, alg, t = ts,
+            dgdu_discrete = dg_singular, abstol = 1.0e-8,
+            reltol = 1.0e-8,
+            sensealg = BacksolveAdjoint(checkpointing = true),
+            checkpoints = sol_singular_mm.t
+        )
+        isapprox(res_bs2, res; rtol = 1.0e-5)
+    catch
+        false
+    end
 end
 
 # u' = x = p * u


### PR DESCRIPTION
## Summary

The `Singular mass matrix` rober block in `test/adjoint.jl` exercises `BacksolveAdjoint` on a semi-explicit DAE — a combination that's documented to fail (the SciMLSensitivity warning prints `BacksolveAdjoint is likely to fail on semi-explicit DAEs`). The test marks the comparisons `@test_broken` because the result is wrong-but-finite.

On Julia 1.10/1.11 the augmented `Rodas4` W-matrix becomes *exactly* singular at some adopted step and LAPACK throws `SingularException(9)` (or `LAPACKException(9)`) instead of returning a wrong result. Because the `adjoint_sensitivities(...; sensealg = BacksolveAdjoint())` call sat **outside** the `@test_broken` macro, the throw escaped as `Got exception outside of a @test` and errored the whole Core3 testset on `1.11` and `lts`. Julia 1.12 happens to dodge the exact-singularity step pattern, so the same test passes there — which is why it looked like a version-flaky test.

This wraps both `BacksolveAdjoint` calls in `try/catch` inside `@test_broken` so the macro records `broken` in both regimes (thrown exception and wrong-but-finite numeric result). The underlying fact that BacksolveAdjoint doesn't work on semi-explicit DAEs is unchanged and still documented by the runtime warning.

## What this is *not*

- Not a fix for `BacksolveAdjoint` on semi-explicit DAEs (still broken, by design — that's the whole point of the warning).
- Not introduced by SciML/SciMLSensitivity.jl#1410. The same `SingularException(9)` error appears on every recent master Core3 (1.11, lts) run; it predates the SciMLBase v3 work.

## Test plan

- [x] Verified locally on Julia 1.11.9 that the singular-mass-matrix block runs to completion: `Test Summary: 4 broken, 0 errors, 5m22s`.
- [x] `Runic --check test/adjoint.jl` passes.
- [ ] CI Core3 on `1.11` and `lts` no longer errors at `adjoint.jl:1519`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)