### PR TITLE
Use SciMLLogging.Standard() instead of Bool for verbose defaults

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -408,7 +408,7 @@ function SciMLBase._concrete_solve_adjoint(
         },
         alg, sensealg::Nothing, u0, p,
         originator::SciMLBase.ADOriginator, args...;
-        verbose = true, kwargs...
+        verbose = SciMLLogging.Standard(), kwargs...
     )
     if haskey(kwargs, :callback)
         has_cb = kwargs[:callback] !== nothing
@@ -448,7 +448,7 @@ function SciMLBase._concrete_solve_adjoint(
         prob::ConcreteNonlinearProblem, alg,
         sensealg::Nothing, u0, p,
         originator::SciMLBase.ADOriginator, args...;
-        verbose = true, kwargs...
+        verbose = SciMLLogging.Standard(), kwargs...
     )
     if !(p === nothing || p isa SciMLBase.NullParameters)
         if !isscimlstructure(p) && !isfunctor(p)

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -373,7 +373,7 @@ res3 = Calculus.gradient(G,[1.5,1.0,3.0])
 function adjoint_sensitivities(
         sol, args...;
         sensealg = InterpolatingAdjoint(),
-        verbose = true, kwargs...
+        verbose = SciMLLogging.Standard(), kwargs...
     )
     p = SymbolicIndexingInterface.parameter_values(sol)
     if !(p === nothing || p isa SciMLBase.NullParameters)


### PR DESCRIPTION
## Summary

- Replace `verbose = true` with `verbose = SciMLLogging.Standard()` in 3 function signatures that pass verbose through to ODE solvers
- OrdinaryDiffEq v7 rejects `verbose::Bool`, requiring `SciMLLogging.AbstractVerbosityPreset` or `DEVerbosity`
- Backwards compatible: OrdinaryDiffEq master already accepts `Standard()` via `_process_verbose_param(::AbstractVerbosityPreset)`
- `_get_sensitivity_vjp_verbose` already handles non-Bool types (falls back to `true` for warning display)

## Changed files

- `src/concrete_solve.jl`: 2 default changes in `_concrete_solve_adjoint` methods
- `src/sensitivity_interface.jl`: 1 default change in `adjoint_sensitivities`

## Test plan

- [ ] Existing tests pass (no behavioral change — `Standard()` is equivalent to `true`)
- [ ] Compatible with OrdinaryDiffEq v7 (`Standard()` accepted by `_process_verbose_param`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)