### PR TITLE
Fix master test failures: verbose Bool, EnzymeVJP _jacNoise!, broken assignments

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -1346,6 +1346,13 @@ function _jacNoise!(
     return
 end
 
+function _jacNoise!(
+        λ, y, p, t, S::TS, isnoise::EnzymeVJP, dgrad, dλ,
+        dy
+    ) where {TS <: SensitivityFunction}
+    _jacNoise!(λ, y, p, t, S, false, dgrad, dλ, dy)
+end
+
 function accumulate_cost!(
         dλ, y, p, t, S::TS,
         dgrad = nothing

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -409,7 +409,7 @@ function adjoint_sensitivities(
         return try
             _adjoint_sensitivities(sol, _sensealg, args...; verbose, kwargs...)
         catch e
-            verbose &&
+            _get_sensitivity_vjp_verbose(verbose) &&
                 @warn "Automatic AD choice of autojacvec failed in ODE adjoint, failing back to ODE adjoint + numerical vjp"
             _adjoint_sensitivities(
                 sol, setvjp(sensealg, false), args...; verbose,

--- a/test/autodiff_events.jl
+++ b/test/autodiff_events.jl
@@ -60,13 +60,17 @@ g4 = Zygote.gradient(
     θ -> test_f2(θ, ReverseDiffAdjoint(), PIController(7 // 50, 2 // 25)),
     p
 )
-@test_broken g5 = Zygote.gradient(
-    θ -> test_f2(
-        θ, ReverseDiffAdjoint(),
-        PIDController(1 / 18.0, 1 / 9.0, 1 / 18.0)
-    ),
-    p
-)
+g5 = try
+    Zygote.gradient(
+        θ -> test_f2(
+            θ, ReverseDiffAdjoint(),
+            PIDController(1 / 18.0, 1 / 9.0, 1 / 18.0)
+        ),
+        p
+    )
+catch
+    nothing
+end
 g6 = Zygote.gradient(
     θ -> test_f2(
         θ, ForwardDiffSensitivity(),
@@ -74,19 +78,23 @@ g6 = Zygote.gradient(
     ),
     p
 )
-@test_broken g7 = Zygote.gradient(
-    θ -> test_f2(
-        θ, ReverseDiffAdjoint(),
-        OrdinaryDiffEqCore.PredictiveController(),
-        TRBDF2()
-    ),
-    p
-)
+g7 = try
+    Zygote.gradient(
+        θ -> test_f2(
+            θ, ReverseDiffAdjoint(),
+            OrdinaryDiffEqCore.PredictiveController(),
+            TRBDF2()
+        ),
+        p
+    )
+catch
+    nothing
+end
 
 @test g1[1] ≈ findiff[2, 1:2]
 @test g2[1] ≈ findiff[2, 1:2]
 @test g3[1] ≈ findiff[2, 1:2]
 @test g4[1] ≈ findiff[2, 1:2]
-@test_broken g5[1] ≈ findiff[2, 1:2]
+@test_broken g5 !== nothing && g5[1] ≈ findiff[2, 1:2]
 @test g6[1] ≈ findiff[2, 1:2]
-@test_broken g7[1] ≈ findiff[2, 1:2]
+@test_broken g7 !== nothing && g7[1] ≈ findiff[2, 1:2]


### PR DESCRIPTION
## Summary

Master CI has been failing across multiple groups (Core1, Core2, Core6, Core7, SDE1, SDE2, SDE3) for several runs. Triage shows three independent bugs in this repo plus a few that require upstream fixes. This PR fixes the three that are local.

## Fixes

1. **`src/sensitivity_interface.jl:412`** — `verbose && @warn ...` used `verbose` directly in a boolean context, but `verbose` defaults to `SciMLLogging.Standard()` which is not a `Bool`. This threw `TypeError: non-boolean (SciMLLogging.Standard) used in boolean context` and shadowed the actual `ErrorException` the surrounding `@test_throws` cases expected. Convert via `_get_sensitivity_vjp_verbose(verbose)` (the same helper already used in `src/concrete_solve.jl`).
   - Fixes: Core7 (`test/mixed_costs.jl`) and SDE1 (`test/sde_stratonovich.jl`).

2. **`src/derivative_wrappers.jl`** — add an `_jacNoise!` method for `isnoise::EnzymeVJP` that falls back to the `Bool`/ForwardDiff path. Dispatch was previously failing for `BacksolveAdjoint` + `EnzymeVJP` on non-diagonal noise.
   - Fixes: SDE2 (`test/sde_nondiag_stratonovich.jl`).

3. **`test/autodiff_events.jl`** — `@test_broken g5 = Zygote.gradient(...)` evaluates the assignment to a tuple, which `Test.jl` rejects as non-Boolean (\"Expression evaluated to non-Boolean: ([-0.59, 4.42],)\"). Replace with `try`/`catch` so `g5`/`g7` are populated (or `nothing` on failure) and guard the downstream `@test_broken g[N][1] ≈ findiff[2, 1:2]` against `nothing`.
   - Fixes: Core2 (`test/autodiff_events.jl`).

## Out of scope

These remain on master and are upstream / AD-framework issues:
- **Core1** `EnzymeNoDerivativeError` on `__ode_init_72` — Enzyme can't differentiate the ODE init helper. Needs Enzyme/SciMLBase work.
- **Core6** `MethodError: no method matching increment!!(::Mooncake.RData{...}, ::Mooncake.NoRData)` in steady-state Mooncake tests — looks like a Mooncake tangent dispatch gap. Re-enabling these was done in #1329 on the assumption that NonlinearSolve.jl PR #719 was sufficient; it's not.
- **SDE3** `SystemError: opening file ... sde_transformation_test.jl: No such file` — self-hosted runner workspace cleanup issue, the file is present in the repo.

## Test plan

- [ ] Core7 (`mixed_costs`) passes the `@test_throws ErrorException` cases instead of TypeError-ing.
- [ ] SDE1 (`sde_stratonovich`) progresses past the `verbose &&` site.
- [ ] SDE2 (`sde_nondiag_stratonovich`) finds an `_jacNoise!` method when EnzymeVJP is used.
- [ ] Core2 (`autodiff_events`) loads `g5`/`g7` without erroring on the assignment.