### PR TITLE
Use single-affect VCC constructor in _track_callback

### DIFF
--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -169,14 +169,18 @@ end
 
 function _track_callback(cb::VectorContinuousCallback, t, u, p, sensealg)
     correction = ImplicitCorrection(cb, t, u, p, sensealg)
+    # VCC has only a single affect! (no affect_neg!) — the per-fire
+    # mask carries directionality through to the reverse pass, so we
+    # use the standard positional VCC constructor.
     return VectorContinuousCallback(
         cb.condition,
         TrackedAffect_vcc(t, u, p, cb.affect!, correction),
-        nothing,
         cb.len, cb.initialize, cb.finalize, cb.idxs,
         cb.rootfind, cb.interp_points,
         collect(cb.save_positions),
-        cb.dtrelax, cb.abstol, cb.reltol, cb.repeat_nudge
+        cb.dtrelax, cb.abstol, cb.reltol, cb.repeat_nudge,
+        cb.initializealg, cb.saved_clock_partitions,
+        cb.maybe_discontinuity, cb.initialize_save_discretes
     )
 end
 


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

- `_track_callback(cb::VectorContinuousCallback, ...)` was still calling the VCC constructor with a leftover `nothing` argument in the old `affect_neg!` slot. After the recent refactor that dropped `affect_neg!` from VCC, the constructor signature is `(condition, affect!, len, ...)` — the stray `nothing` made `len::Nothing` instead of `Int`, so the constructor threw a `MethodError` on every adjoint pass through any VCC, regardless of Julia version.
- Drop the stray `nothing` and forward `initializealg`, `saved_clock_partitions`, `maybe_discontinuity`, and `initialize_save_discretes` from the original callback so the tracked VCC round-trips all the user-supplied configuration.

## Test plan

Reproduced the failure locally on Julia 1.12 via `test/callbacks/vector_continuous_callbacks.jl`. Before the fix: all 4 sub-testsets in this file error with `MethodError: no method matching SciMLBase.VectorContinuousCallback(...)`. After the fix:

- `MSE loss function bouncing-ball like → callback with linear affect` — runs, with 4 numerical assertion failures (separate latent issue, see note below).
- `Test condition function that depends on time only` — passes.
- `Structural simultaneous fire (algebraically tied conditions)` — passes.
- `Coincidental simultaneous fire (corner trap)` — passes.

## Note on remaining numerical failure

The `callback with linear affect` testset now reaches its assertions but they fail with ~7% mismatch on the u[3]/u[4] gradient components vs ForwardDiff. Both `BacksolveAdjoint` and `GaussAdjoint` agree with each other and disagree with ForwardDiff in exactly the same way, so this is a latent issue in the implicit ∇τ correction for VCC, not a regression from this PR. Master has been red on `Callbacks2` for over a month and the MethodError was masking this. I deliberately kept this PR small and focused on the constructor fix per CLAUDE.md "small, focused PRs" guidance — the numerical issue deserves its own investigation and PR.