### PR TITLE
Shift VCC test u0[4] off saveat-coincident event time

### DIFF
--- a/test/callbacks/vector_continuous_callbacks.jl
+++ b/test/callbacks/vector_continuous_callbacks.jl
@@ -15,7 +15,12 @@ function test_vector_continuous_callback(cb, g)
         return nothing
     end
 
-    u0 = [50.0, 0.0, 0.0, 2.0]
+    # u0[4] = 2.01 (not 2.0) so the "linear affect" event (u[3]=10) lands at
+    # τ = 10/2.01 ≈ 4.975 instead of exactly 5.0 — off the saveat grid. At
+    # τ = saveat the cost is jump-discontinuous in u0[3], u0[4] (the post-event
+    # state propagates to that saveat sample), so FD and adjoint legitimately
+    # compute different one-sided derivatives and rtol comparisons fail.
+    u0 = [50.0, 0.0, 0.0, 2.01]
     tspan = (0.0, 10.0)
     p = [9.8, 0.9]
     prob = ODEProblem(f, u0, tspan, p)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

In `test_vector_continuous_callback` (`test/callbacks/vector_continuous_callbacks.jl`), shift `u0[4]` from `2.0` to `2.01` so the "callback with linear affect" event (condition `u[3] = 10`) lands at τ ≈ 4.975 instead of exactly 5.0 — off the `saveat = 0.5` grid.

At τ = saveat, the cost has a true jump discontinuity in `u0[3]` and `u0[4]`: the post-affect state (`u[4] ← -p[2]·u[4] = -1.8`) propagates to the saveat-5.0 sample on one side of the corner and the pre-affect state (`u[4] = 2.0`) on the other. The Float64 forward rootfinder converges 1 ULP below 5.0; ForwardDiff's Dual rootfinder converges ~6 ULPs above. Both compute valid one-sided derivatives, but `BS ≈ FD rtol=1e-5` then compares opposite-side derivatives and fails by design — not an algorithmic bug.

## Verification

Central finite differences (`(L(+h) − L(−h)) / 2h`) at `u0 = [50, 0, 0, 2.0]`:
- Smooth components 1, 2, 5, 6: FD ≈ BS ≈ CFD ✓
- Components 3, 4: CFD ∝ `1/h` — classic jump signature (`[323, 1.70e5, 1.70e7]` for h ∈ {1e-3, 1e-5, 1e-7})

At `u0[4] = 2.01` (τ ≈ 4.975, off-grid): FD ≈ BS ≈ GA ≈ CFD to 5–6 digits across all components.

Full FD writeup in closed issue #1447.

## Relationship to #1446

#1446 fixes a `MethodError` in the VCC tracking constructor that masked these tests entirely. Once #1446 lands, the constructor works but this testset numerically fails at the corner. This PR is the right resolution for the numerical failure.

The two PRs can land in either order — this one is a pure test-data tweak with no functional impact; #1446 is an `src/` fix that's still correct without this change.

## Refs

- Closed #1447 — full FD analysis showing the formula is not broken
- PR #1446 — unmasks this test by fixing the constructor MethodError

## Test plan
- [x] All 11 testsets in `test/callbacks/vector_continuous_callbacks.jl` pass on Julia 1.12.6 locally with this change applied on top of #1446
- [x] Runic.jl clean