### PR TITLE
Enable Enzyme SCC test on Julia 1.11+ (Enzyme 0.13.148)

### DIFF
--- a/test/scc_nonlinearsolve.jl
+++ b/test/scc_nonlinearsolve.jl
@@ -70,22 +70,11 @@ p_test = [4.0, 3.0]
         @test isapprox(fwd, fd, rtol = 0.05)
     end
 
-    # Enzyme through Tuple-based SCCNonlinearProblem now works reliably on
-    # Julia 1.10 (verified across 40+ consecutive runs with the current
-    # SCCNonlinearSolve, NonlinearSolveBase, and Enzyme releases). On Julia
-    # 1.11+, Enzyme still hits an `IllegalTypeAnalysisException` on
-    # `Base._typed_vcat!` inside SCCNonlinearSolve's solution assembly,
-    # which segfaults the worker process — gate the test on the LTS until
-    # the upstream Enzyme/NonlinearSolve issues are fixed.
     # Vector-based SCC remains unsupported because heterogeneous function
     # types get erased to Any. See Enzyme.jl#3021.
     @testset "Enzyme" begin
-        if VERSION < v"1.11"
-            enz = Enzyme.gradient(Enzyme.Reverse, loss, copy(p_test))
-            @test isapprox(collect(enz[1]), fd, rtol = 0.05)
-        else
-            @test_skip true
-        end
+        enz = Enzyme.gradient(Enzyme.Reverse, loss, copy(p_test))
+        @test isapprox(collect(enz[1]), fd, rtol = 0.05)
     end
 
     @testset "Mooncake" begin


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

`test/scc_nonlinearsolve.jl`'s `Enzyme` testset was gated on `VERSION < v"1.11"` because of an `IllegalTypeAnalysisException` / SCCNonlinearProblem-worker segfault on Julia 1.11+. Enzyme 0.13.148 (released 2026-05-21) closes [EnzymeAD/Enzyme.jl#3026](https://github.com/EnzymeAD/Enzyme.jl/issues/3026) which fixes it.

Locally verified on Julia 1.12.6 + Enzyme 0.13.148: `Enzyme.gradient` over the Tuple-based SCC loss returns the correct gradient (matches FiniteDiff to 5% as the existing `rtol` expects). Full file: 8/8 passing (was 7 Pass / 1 Broken).

## Refs

- EnzymeAD/Enzyme.jl#3026 (closed in 0.13.148)
- SciML/SciMLSensitivity.jl#1323

## Test plan
- [x] `test/scc_nonlinearsolve.jl` passes 8/8 on Julia 1.12.6 locally
- [x] Runic.jl clean
- [ ] CI green