### PR TITLE
Enable Enzyme tests in steady_state.jl on Julia 1.12+ (Enzyme 0.13.148)

### DIFF
--- a/test/steady_state.jl
+++ b/test/steady_state.jl
@@ -4,8 +4,9 @@ using OrdinaryDiffEq, NonlinearSolve, ForwardDiff, Calculus, Random, Reactant
 using OrdinaryDiffEqRosenbrock: Rodas5
 Random.seed!(12345)
 
+using Enzyme
+
 # Use Mooncake on Julia 1.12+ (Zygote has issues), Zygote on older versions
-# Enzyme also has issues on Julia 1.12+
 if VERSION >= v"1.12"
     using Mooncake
     function compute_gradient(f, x)
@@ -19,18 +20,16 @@ if VERSION >= v"1.12"
         grad = Mooncake.value_and_gradient!!(Mooncake.build_rrule(g, xy), g, xy)[2][2]
         return grad[1], grad[2]
     end
-    const ENZYME_AVAILABLE = false
 else
     using Zygote
-    using Enzyme
     function compute_gradient(f, x)
         return Zygote.gradient(f, x)[1]
     end
     function compute_gradient(f, x, y)
         return Zygote.gradient(f, x, y)
     end
-    const ENZYME_AVAILABLE = true
 end
+const ENZYME_AVAILABLE = true
 
 @testset "Adjoint sensitivities of steady state solver" begin
     function f!(du, u, p, t)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

`test/steady_state.jl` had `ENZYME_AVAILABLE` set to `false` on Julia 1.12+ because of NonlinearProblem + Enzyme segfaults / GC invariant violations on 1.12. Enzyme 0.13.148 (released 2026-05-21) closes:

- EnzymeAD/Enzyme.jl#3012 — LLVM GC invariant violation with in-place NonlinearProblem on 1.12
- EnzymeAD/Enzyme.jl#3026 — Intermittent GC segfault with SCCNonlinearProblem + custom rule

With those fixed, `using Enzyme` and `ENZYME_AVAILABLE = true` can be unconditional. The Zygote-vs-Mooncake split for `compute_gradient` is kept (separate concern: Zygote 0.7 has issues on 1.12).

## Verification

Locally on Julia 1.12.6 + Enzyme 0.13.148:

| Block | Result |
|---|---|
| All `enzyme_gradient` cases (NewtonRaphson/TrustRegion/Klement, iip+oop) | 4/4 PASS |
| `SteadyStateAdjoint(autojacvec = EnzymeVJP())` through `adjoint_sensitivities` (res1h, res2h, res3h) | PASS |
| Full file | **63 Pass / 1 Broken / 0 Fail** in 18m12s |

The 1 Broken is `@test_skip false` for `enzyme_gradient2` over `ZygoteVJP` — pre-existing, unrelated (Enzyme can't differentiate through Zygote's compiled code regardless of Julia version).

## Refs

- EnzymeAD/Enzyme.jl#3012, #3026 (both closed in 0.13.148)
- SciML/SciMLSensitivity.jl#1323
- SciML/SciMLSensitivity.jl#1449 (companion: enable SCC Enzyme on Julia 1.11+)

## Test plan
- [x] Local full `test/steady_state.jl` on Julia 1.12.6: 63 Pass / 1 Broken
- [x] Runic.jl clean
- [ ] CI green