### PR TITLE
_init_originator_gradient: wrap nested Enzyme.gradient with set_runtime_activity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.111.0"
+version = "7.111.1"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -374,7 +374,10 @@ end
 # for problems that previously succeeded via the Zygote fallback —
 # see #1415 for context.
 function _init_originator_gradient(::SciMLBase.EnzymeOriginator, f, tunables)
-    return Enzyme.gradient(Enzyme.Reverse, Enzyme.Const(f), tunables)[1]
+    return Enzyme.gradient(
+        Enzyme.set_runtime_activity(Enzyme.Reverse),
+        Enzyme.Const(f), tunables,
+    )[1]
 end
 
 function SciMLBase._concrete_solve_adjoint(


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Summary

The `EnzymeOriginator` overload of `_init_originator_gradient` (`src/concrete_solve.jl:377`) called

```julia
Enzyme.gradient(Enzyme.Reverse, Enzyme.Const(f), tunables)
```

without `set_runtime_activity`. The outer user-level `Enzyme.autodiff(set_runtime_activity(Reverse), ...)` call's runtime-activity relaxation does **not** propagate into this nested gradient, so the inner Enzyme call raised `EnzymeRuntimeActivityError` at MTK's init `remake` even when the caller used the documented pattern (see PR #1455).

This patch wraps the inner gradient with `set_runtime_activity(Reverse)` so the nested gradient inherits the same activity relaxation as the outer call.

## Diff

```julia
function _init_originator_gradient(::SciMLBase.EnzymeOriginator, f, tunables)
    return Enzyme.gradient(
        Enzyme.set_runtime_activity(Enzyme.Reverse),
        Enzyme.Const(f), tunables,
    )[1]
end
```

## Effect on #1455

After this patch the `EnzymeRuntimeActivityError` is gone, but the `@test_broken` Enzyme block in `test/parameter_initialization.jl` still trips a **different** downstream error: `MethodError: no method matching MixedDuplicated(::ODESolution{...})` inside Enzyme's runtime-activity wrapping of the `ODESolution` type. That is a separate Enzyme/MTK problem unrelated to the inner-`gradient`-activity issue this PR fixes. So #1455 stays `@test_broken` for now; this PR is independently useful for anyone hitting the runtime-activity error from a clean Enzyme call path.

## Test plan

- [ ] CI green on master.
- [ ] Reproduction of #1455's Enzyme block locally now fails with the `MixedDuplicated`/`ODESolution` MethodError rather than `EnzymeRuntimeActivityError`, confirming this PR moves past the inner-activity wall.