### PR TITLE
Enzyme: make GaussAdjoint(EnzymeVJP()) work with MTKParameters (unblocks parameter_initialization Enzyme test)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.111.0"
+version = "7.111.1"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -374,10 +374,16 @@ end
 # for problems that previously succeeded via the Zygote fallback —
 # see #1415 for context.
 function _init_originator_gradient(::SciMLBase.EnzymeOriginator, f, tunables)
-    # `f` (a `remake` + `solve` over MTK init) stores the inactive sensealg/init
-    # config into differentiable parameter memory, which static activity analysis
-    # rejects. The outer reverse pass is already under runtime activity, so enable
-    # it here too rather than erroring with EnzymeRuntimeActivityError.
+    # `f` differentiates an MTK DAE initialization. Inside it,
+    # `remake(_prob, p = repack(t))` builds one `ODEProblem` allocation mixing
+    # constant memory (the captured `_prob`'s `u0`/`f`/`tspan`/caches) with active
+    # memory (the new parameters) — a partially-active object that Enzyme's static
+    # activity analysis rejects ("constant memory stored to a differentiable
+    # variable", inside `remake`, not the let-captured config). Dropping this
+    # re-raises EnzymeRuntimeActivityError; `set_runtime_activity` is Enzyme's
+    # correctness-preserving fix (the gradient still matches ForwardDiff). A static
+    # fix would need `remake`/SciMLBase to stop aliasing constant structure into
+    # the active problem.
     return Enzyme.gradient(
         Enzyme.set_runtime_activity(Enzyme.Reverse), Enzyme.Const(f), tunables,
     )[1]

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -374,7 +374,13 @@ end
 # for problems that previously succeeded via the Zygote fallback —
 # see #1415 for context.
 function _init_originator_gradient(::SciMLBase.EnzymeOriginator, f, tunables)
-    return Enzyme.gradient(Enzyme.Reverse, Enzyme.Const(f), tunables)[1]
+    # `f` (a `remake` + `solve` over MTK init) stores the inactive sensealg/init
+    # config into differentiable parameter memory, which static activity analysis
+    # rejects. The outer reverse pass is already under runtime activity, so enable
+    # it here too rather than erroring with EnzymeRuntimeActivityError.
+    return Enzyme.gradient(
+        Enzyme.set_runtime_activity(Enzyme.Reverse), Enzyme.Const(f), tunables,
+    )[1]
 end
 
 function SciMLBase._concrete_solve_adjoint(
@@ -1004,11 +1010,13 @@ function SciMLBase._concrete_solve_adjoint(
                 nothing, x -> (x,)
             end
 
-            if originator isa SciMLBase.EnzymeOriginator && isscimlstructure(p)
-                dp
-            else
-                repack_adjoint(dp)[1]
-            end
+            # Repack the flat tunable cotangent `dp` into the parameter's
+            # structural tangent (a NamedTuple for MTKParameters; identity for
+            # plain-array params). The EnzymeOriginator `solve_up` reverse rule
+            # accumulates structural tangents field-wise, so returning a flat
+            # vector here broadcasts against the structured shadow (e.g. an
+            # `MTKParameters`) and errors.
+            repack_adjoint(dp)[1]
         end
 
         return if originator isa SciMLBase.TrackerOriginator ||
@@ -2637,11 +2645,13 @@ function SciMLBase._concrete_solve_adjoint(
                     Δtunables
             )
 
-            if originator isa SciMLBase.EnzymeOriginator && isscimlstructure(p)
-                dp
-            else
-                repack_adjoint(dp)[1]
-            end
+            # Repack the flat tunable cotangent `dp` into the parameter's
+            # structural tangent (a NamedTuple for MTKParameters; identity for
+            # plain-array params). The EnzymeOriginator `solve_up` reverse rule
+            # accumulates structural tangents field-wise, so returning a flat
+            # vector here broadcasts against the structured shadow (e.g. an
+            # `MTKParameters`) and errors.
+            repack_adjoint(dp)[1]
         end
 
         return if originator isa SciMLBase.TrackerOriginator ||

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -518,7 +518,23 @@ function GaussIntegrand(sol, sensealg, checkpoints, dgdp = nothing)
         pf = nothing
         pJ = nothing
     elseif sensealg.autojacvec isa EnzymeVJP
-        pf = SciMLBase.isinplace(sol.prob.f) ? SciMLBase.Void(unwrappedf) : unwrappedf
+        # Differentiate w.r.t. the flat `tunables` and `repack` to the full
+        # parameter object inside `pf` (as the ReverseDiff/Mooncake branches do).
+        # Otherwise `vec_pjac!` would build `Duplicated(p, out)` with a structured
+        # `p` (e.g. MTKParameters) and a flat-vector shadow `out`, which has no
+        # matching `Enzyme.Duplicated` constructor.
+        _needs_repack = isscimlstructure(p) && !(p isa AbstractArray)
+        pf = if SciMLBase.isinplace(sol.prob.f)
+            if _needs_repack
+                let _f = unwrappedf, repack = repack
+                    SciMLBase.Void((du, u, tunables, t) -> _f(du, u, repack(tunables), t))
+                end
+            else
+                SciMLBase.Void(unwrappedf)
+            end
+        else
+            unwrappedf
+        end
         paramjac_config = zero(y), zero(y), Enzyme.make_zero(pf)
         pJ = nothing
     elseif sensealg.autojacvec isa MooncakeVJP
@@ -644,7 +660,7 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
             Enzyme.autodiff(
                 sensealg.autojacvec.mode, Enzyme.Duplicated(pf, tmp6), Enzyme.Const,
                 Enzyme.Duplicated(tmp3, tmp4),
-                Enzyme.Const(y), Enzyme.Duplicated(p, out), Enzyme.Const(t)
+                Enzyme.Const(y), Enzyme.Duplicated(tunables, out), Enzyme.Const(t)
             )
         else
             tmp6 = Enzyme.make_zero(f)

--- a/test/mtk.jl
+++ b/test/mtk.jl
@@ -170,15 +170,17 @@ setups = [
 # in `DiffEqBaseEnzymeExt` (which requires `sensealg::Const`). The inner solve
 # pins `Rodas5P()` to avoid polyalgorithm Union dispatch.
 #
-# Status: still `@test_broken`. After this restructure the chain reaches the
-# `solve_up` rule but Enzyme's `set_runtime_activity` layer promotes
-# `_MTK_SENSEALG` (and the structural fields of `ODEProblem` carrying
-# `MTKParameters`) to `Duplicated`, producing the same downstream
-# `MixedDuplicated` / `Core.SimpleVector` MethodError under MTK's
-# runtime-activity wrapping for MTK-System / NonlinearSolution types
-# tracked in SciMLSensitivity.jl#1359 (and EnzymeAD/Enzyme.jl#3117). The
-# refactor matches #1454's shape so that when #1359 lifts, only the
-# `@test_broken` → `@test` flip is needed.
+# Status: still `@test_broken`, but for a narrower reason than before. The
+# `MixedDuplicated(::ODESolution)` wall (#1359) is fixed upstream in
+# OrdinaryDiffEq#3700, and the GaussAdjoint(EnzymeVJP()) + MTKParameters
+# runtime-activity / repack issues are fixed in this PR (see the
+# parameter_initialization.jl "Adjoint through Prob (Enzyme)" block, now
+# `@test`). These `setups` additionally exercise DAE initialization via
+# `BrownFullBasicInit` / `DefaultInit` / overdetermined systems, which solve a
+# `NonlinearProblem` during init under Enzyme and hit
+# `NonConstantKeywordArgException: Custom Rule ... differentiable keyword
+# argument` in `get_initial_values` → `solve_up`. Flip to `@test` once that
+# init-path kwarg issue is resolved (e.g. via `Enzyme.EnzymeRules.inactive_kwarg`).
 const _MTK_SENSEALG = GaussAdjoint(; autojacvec = SciMLSensitivity.EnzymeVJP())
 
 function _mtk_enzyme_solve_loss_with_init(t, prob_, init_)

--- a/test/parameter_initialization.jl
+++ b/test/parameter_initialization.jl
@@ -105,7 +105,7 @@ tunables, repack, _ = SS.canonicalize(SS.Tunable(), parameter_values(prob))
             sol = solve(new_prob; sensealg)
             return sum(sol)
         end
-        @test_broken begin
+        @test begin
             dprob = Enzyme.make_zero(prob)
             dtunables = zero(tunables)
             Enzyme.autodiff(


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

Follow-up to [OrdinaryDiffEq#3700](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3700) (DiffEqBase 7.5.4), which fixed the `MethodError: MixedDuplicated(::ODESolution)` wall behind #1359. With that landed, reverse-mode Enzyme through an MTK DAE solve under `GaussAdjoint(EnzymeVJP())` reaches three further spots where the GaussAdjoint/EnzymeVJP machinery assumes flat-array parameters and breaks on a structured `MTKParameters`. Each is fixed here, and `test/parameter_initialization.jl`'s "Adjoint through Prob (Enzyme)" block now passes (`@test_broken` → `@test`).

## Fixes (each cleared one error, confirmed by stacktrace)

1. **`EnzymeRuntimeActivityError`** — `_init_originator_gradient(::EnzymeOriginator, ...)` (`concrete_solve.jl`) ran its nested `Enzyme.gradient` without runtime activity, throwing at the MTK init `remake`. → wrap with `set_runtime_activity(Reverse)`.
2. **`Duplicated(::MTKParameters, ::Vector)`** — `GaussIntegrand`'s EnzymeVJP `vec_pjac!` (`gauss_adjoint.jl`) differentiated w.r.t. the structured `p`, so it built `Duplicated(p, out)` with a flat-vector shadow. → differentiate w.r.t. the flat `tunables` and `repack` to `p` inside `pf` (mirrors the existing `ReverseDiffVJP`/`MooncakeVJP` branches).
3. **`ndims(::Type{MTKParameters})`** — `_concrete_solve_adjoint` returned the flat tunable cotangent `dp` un-repacked for the EnzymeOriginator path, so it broadcast against the `MTKParameters` shadow in the `solve_up` reverse rule. → `repack_adjoint(dp)[1]` (identity for plain-array params).

## Verification

- `test/parameter_initialization.jl` passes **3/3** (was 2 pass + 1 `@test_broken`/error).
- Correctness: the `GaussAdjoint(EnzymeVJP())` gradient through an MTK DAE `ODEProblem` (parameter-dependent init) matches `ForwardDiff.gradient` to **~2e-11** relative, with a `saveat`-pinned grid at `abstol=reltol=1e-10`. Env: Julia 1.11, Enzyme 0.13.152, DiffEqBase 7.5.4, ModelingToolkit 11.26.6, OrdinaryDiffEq 7.0.0.
- The fixes are no-ops for plain-array parameters by construction (`repack_adjoint` is identity; the `pf` wrap only triggers for `isscimlstructure(p) && !(p isa AbstractArray)`), so non-MTK Enzyme paths are unchanged.

## Not fixed here (`test/mtk.jl` stays `@test_broken`, comment updated)

`test/mtk.jl`'s setups additionally exercise DAE initialization via `BrownFullBasicInit` / `DefaultInit` / overdetermined systems, which solve a `NonlinearProblem` during init under Enzyme and hit a **separate** blocker:
```
NonConstantKeywordArgException: Custom Rule ... passed a differentiable keyword argument
solve_up(::NonlinearProblem{... MTKParameters ...})  @ get_initial_values
```
That's an Enzyme custom-rule-kwarg limitation in the init path (likely needs `Enzyme.EnzymeRules.inactive_kwarg` or stripping the differentiable kwarg at the init `solve`), unrelated to the repacks above. Left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
