### PR TITLE
Fix QuadratureAdjoint(EnzymeVJP()) for immutable SVector state (#1460)

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -918,6 +918,13 @@ function _vecjacobian(
     return dy, dλ, dgrad
 end
 
+# `λ ⋅ f(u, p, t)`, differentiated by Enzyme with respect to `u` and `p` while
+# holding `f`, `t`, `λ` (and `W`) constant. Kept as top-level methods so the
+# out-of-place EnzymeVJP path can call `Enzyme.gradient` without a capturing
+# closure.
+_enzyme_vecjac_dot(f, u, p, t, λ) = dot(vec(f(u, p, t)), vec(λ))
+_enzyme_vecjac_dot(f, u, p, t, λ, W) = dot(vec(f(u, p, t, W)), vec(λ))
+
 function _vecjacobian(
         y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, dy,
         W
@@ -932,20 +939,21 @@ function _vecjacobian(
     enzyme_mode = isautojacvec.mode
     if W === nothing
         _dy = f(y, p, t)
-        vecjacfun = let f = f, t = t, λ = λ
-            (u, p) -> dot(vec(f(u, p, t)), vec(λ))
-        end
+        res = Enzyme.gradient(
+            enzyme_mode, _enzyme_vecjac_dot, Enzyme.Const(f), y, p,
+            Enzyme.Const(t), Enzyme.Const(λ)
+        )
     else
         _dy = f(y, p, t, W)
-        vecjacfun = let f = f, t = t, λ = λ, W = W
-            (u, p) -> dot(vec(f(u, p, t, W)), vec(λ))
-        end
+        res = Enzyme.gradient(
+            enzyme_mode, _enzyme_vecjac_dot, Enzyme.Const(f), y, p,
+            Enzyme.Const(t), Enzyme.Const(λ), Enzyme.Const(W)
+        )
     end
-    tmp1, tmp2 = Enzyme.gradient(enzyme_mode, vecjacfun, y, p)
 
     dy !== nothing && recursive_copyto!(dy, vec(_dy))
-    dλ = vec(tmp1)
-    dgrad !== nothing && recursive_copyto!(dgrad, tmp2)
+    dλ = vec(res[2])
+    dgrad !== nothing && recursive_copyto!(dgrad, res[3])
     return dy, dλ, dgrad
 end
 

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -918,6 +918,37 @@ function _vecjacobian(
     return dy, dλ, dgrad
 end
 
+function _vecjacobian(
+        y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, dy,
+        W
+    ) where {TS <: SensitivityFunction}
+    prob = getprob(S)
+    f = unwrapped_f(S.f)
+
+    # Out-of-place EnzymeVJP. The state may be immutable (e.g. a
+    # `StaticArrays.SVector`), so the in-place `Duplicated`-mutation path used by
+    # the in-place `_vecjacobian!` does not apply. Form the vjp as the
+    # reverse-mode gradient of `λ ⋅ f(u, p, t)` with respect to `(u, p)`.
+    enzyme_mode = isautojacvec.mode
+    if W === nothing
+        _dy = f(y, p, t)
+        vecjacfun = let f = f, t = t, λ = λ
+            (u, p) -> dot(vec(f(u, p, t)), vec(λ))
+        end
+    else
+        _dy = f(y, p, t, W)
+        vecjacfun = let f = f, t = t, λ = λ, W = W
+            (u, p) -> dot(vec(f(u, p, t, W)), vec(λ))
+        end
+    end
+    tmp1, tmp2 = Enzyme.gradient(enzyme_mode, vecjacfun, y, p)
+
+    dy !== nothing && recursive_copyto!(dy, vec(_dy))
+    dλ = vec(tmp1)
+    dgrad !== nothing && recursive_copyto!(dgrad, tmp2)
+    return dy, dλ, dgrad
+end
+
 function gclosure1(f, du, u, p, t)
     Base.copyto!(du, f(u, p, t))
     return nothing

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -332,6 +332,11 @@ function gclosure4(f, du, u, p, t)
     return nothing
 end
 
+# `λ ⋅ f(y, repack(tunables), t)`, differentiated by Enzyme with respect to
+# `tunables` only (everything else held constant). Top-level so the out-of-place
+# immutable-state parameter vjp can call `Enzyme.gradient` without a closure.
+_enzyme_vecpjac_dot(f, repack, y, tunables, t, λ) = dot(vec(f(y, repack(tunables), t)), vec(λ))
+
 # out = λ df(u, p, t)/dp at u=y, p=p, t=t
 function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
     (; pJ, pf, p, f_cache, dgdp_cache, paramjac_config, sensealg, sol, adj_sol, tunables, repack) = S
@@ -407,12 +412,14 @@ function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
             # Out-of-place immutable state (e.g. `SVector`): the buffered
             # `Duplicated` path below needs mutable temporaries built from
             # `zero(y)`, so instead form the parameter vjp `(∂f/∂p)^T λ` as the
-            # gradient of `λ ⋅ f(y, p, t)` with respect to the tunables.
-            vecpjacfun = let f = f, y = y, t = t, λ = λ, repack = repack
-                tunables -> dot(vec(f(y, repack(tunables), t)), vec(λ))
-            end
-            dp = Enzyme.gradient(sensealg.autojacvec.mode, vecpjacfun, tunables)[1]
-            recursive_copyto!(out, dp)
+            # gradient of `λ ⋅ f(y, repack(tunables), t)` with respect to the
+            # tunables, holding `f`, `repack`, `y`, `t`, `λ` constant.
+            res = Enzyme.gradient(
+                sensealg.autojacvec.mode, _enzyme_vecpjac_dot, Enzyme.Const(f),
+                Enzyme.Const(repack), Enzyme.Const(y), tunables,
+                Enzyme.Const(t), Enzyme.Const(λ)
+            )
+            recursive_copyto!(out, res[4])
         else
             tmp3, tmp4, tmp6 = paramjac_config
             vtmp4 = vec(tmp4)

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -403,48 +403,60 @@ function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
     elseif sensealg.autojacvec isa ReactantVJP
         reactant_run_ad!(nothing, out, nothing, paramjac_config, y, p, t, λ)
     elseif sensealg.autojacvec isa EnzymeVJP
-        tmp3, tmp4, tmp6 = paramjac_config
-        vtmp4 = vec(tmp4)
-
-        Enzyme.remake_zero!(out)
-        Enzyme.remake_zero!(tmp3)
-        vtmp4 .= λ
-
-        _shadow_enzyme = nothing
-        if !(p isa AbstractArray)
-            _shadow_enzyme = repack(out)
-            dup = Enzyme.Duplicated(p, _shadow_enzyme)
-        else
-            dup = Enzyme.Duplicated(p, out)
-        end
-
-        if SciMLBase.isinplace(sol.prob.f)
-            Enzyme.remake_zero!(tmp6)
-            Enzyme.autodiff(
-                sensealg.autojacvec.mode,
-                Enzyme.Duplicated(SciMLBase.Void(f), tmp6), Enzyme.Const,
-                Enzyme.Duplicated(tmp3, tmp4),
-                Enzyme.Const(y), dup, Enzyme.Const(t)
-            )
-        else
-            tmp6 = Enzyme.make_zero(f)
-            Enzyme.autodiff(
-                sensealg.autojacvec.mode, Enzyme.Const(gclosure4), Enzyme.Const,
-                Enzyme.Duplicated(f, tmp6),
-                Enzyme.Duplicated(tmp3, tmp4),
-                Enzyme.Const(y), dup, Enzyme.Const(t)
-            )
-        end
-
-        if _shadow_enzyme !== nothing && _shadow_enzyme !== out
-            _use_full_p_enzyme = hasproperty(sensealg, :diff_tunables) &&
-                sensealg.diff_tunables isa Val{false}
-            if !_use_full_p_enzyme && isscimlstructure(_shadow_enzyme)
-                grad_tunables, _, _ = canonicalize(Tunable(), _shadow_enzyme)
-            else
-                grad_tunables = _shadow_enzyme
+        if !ArrayInterface.ismutable(y)
+            # Out-of-place immutable state (e.g. `SVector`): the buffered
+            # `Duplicated` path below needs mutable temporaries built from
+            # `zero(y)`, so instead form the parameter vjp `(∂f/∂p)^T λ` as the
+            # gradient of `λ ⋅ f(y, p, t)` with respect to the tunables.
+            vecpjacfun = let f = f, y = y, t = t, λ = λ, repack = repack
+                tunables -> dot(vec(f(y, repack(tunables), t)), vec(λ))
             end
-            copyto!(out, grad_tunables)
+            dp = Enzyme.gradient(sensealg.autojacvec.mode, vecpjacfun, tunables)[1]
+            recursive_copyto!(out, dp)
+        else
+            tmp3, tmp4, tmp6 = paramjac_config
+            vtmp4 = vec(tmp4)
+
+            Enzyme.remake_zero!(out)
+            Enzyme.remake_zero!(tmp3)
+            vtmp4 .= λ
+
+            _shadow_enzyme = nothing
+            if !(p isa AbstractArray)
+                _shadow_enzyme = repack(out)
+                dup = Enzyme.Duplicated(p, _shadow_enzyme)
+            else
+                dup = Enzyme.Duplicated(p, out)
+            end
+
+            if SciMLBase.isinplace(sol.prob.f)
+                Enzyme.remake_zero!(tmp6)
+                Enzyme.autodiff(
+                    sensealg.autojacvec.mode,
+                    Enzyme.Duplicated(SciMLBase.Void(f), tmp6), Enzyme.Const,
+                    Enzyme.Duplicated(tmp3, tmp4),
+                    Enzyme.Const(y), dup, Enzyme.Const(t)
+                )
+            else
+                tmp6 = Enzyme.make_zero(f)
+                Enzyme.autodiff(
+                    sensealg.autojacvec.mode, Enzyme.Const(gclosure4), Enzyme.Const,
+                    Enzyme.Duplicated(f, tmp6),
+                    Enzyme.Duplicated(tmp3, tmp4),
+                    Enzyme.Const(y), dup, Enzyme.Const(t)
+                )
+            end
+
+            if _shadow_enzyme !== nothing && _shadow_enzyme !== out
+                _use_full_p_enzyme = hasproperty(sensealg, :diff_tunables) &&
+                    sensealg.diff_tunables isa Val{false}
+                if !_use_full_p_enzyme && isscimlstructure(_shadow_enzyme)
+                    grad_tunables, _, _ = canonicalize(Tunable(), _shadow_enzyme)
+                else
+                    grad_tunables = _shadow_enzyme
+                end
+                copyto!(out, grad_tunables)
+            end
         end
     end
 

--- a/test/adjoint_oop.jl
+++ b/test/adjoint_oop.jl
@@ -228,3 +228,31 @@ du0, dp = Zygote.gradient(
 
 @test !iszero(du0)
 @test !iszero(dp)
+
+## QuadratureAdjoint with EnzymeVJP on immutable SVector state (issue #1460)
+# Out-of-place SVector states must dispatch to the out-of-place `_vecjacobian` and
+# `vec_pjac!` EnzymeVJP paths; the result must match the ZygoteVJP path.
+du0_cont_z, dp_cont_z = adjoint_sensitivities(
+    sol, Tsit5(); dgdu_continuous = dg, g,
+    sensealg = QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = ZygoteVJP())
+)
+du0_cont_e, dp_cont_e = adjoint_sensitivities(
+    sol, Tsit5(); dgdu_continuous = dg, g,
+    sensealg = QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = EnzymeVJP())
+)
+@test !iszero(du0_cont_e)
+@test !iszero(dp_cont_e)
+@test du0_cont_e ≈ du0_cont_z rtol = 1.0e-10
+@test dp_cont_e ≈ dp_cont_z rtol = 1.0e-10
+
+dg_disc_oop(u, p, t, i; outtype = nothing) = u
+du0_disc_z, dp_disc_z = adjoint_sensitivities(
+    sol, Tsit5(); t = tsteps, dgdu_discrete = dg_disc_oop,
+    sensealg = QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = ZygoteVJP())
+)
+du0_disc_e, dp_disc_e = adjoint_sensitivities(
+    sol, Tsit5(); t = tsteps, dgdu_discrete = dg_disc_oop,
+    sensealg = QuadratureAdjoint(abstol = 1.0e-14, reltol = 1.0e-14, autojacvec = EnzymeVJP())
+)
+@test du0_disc_e ≈ du0_disc_z rtol = 1.0e-10
+@test dp_disc_e ≈ dp_disc_z rtol = 1.0e-10


### PR DESCRIPTION
## Summary

Fixes #1460: `QuadratureAdjoint(autojacvec = EnzymeVJP())` errored on out-of-place ODEs with an immutable `StaticArrays.SVector` state because the out-of-place EnzymeVJP code paths were missing / assumed mutable buffers.

Two consecutive failures occur on this path:

1. **`src/derivative_wrappers.jl`** had no out-of-place `_vecjacobian(..., ::EnzymeVJP, ...)` method (only `ZygoteVJP`). This is the exact `MethodError` reported in the issue — the non-mutating `vecjacobian(y, λ, p, t, S; dgrad, dy)` used for the out-of-place adjoint RHS had nothing to dispatch to for Enzyme.

2. **`src/quadrature_adjoint.jl`** `vec_pjac!` `EnzymeVJP` branch then failed inside the QuadGK parameter-gradient integrand with `setindex!(::SVector, …)`. Its temporaries come from `paramjac_config = (zero(y), zero(y), …)`, which are immutable `SVector`s for `SVector` state, so the in-place `Duplicated` / `vtmp4 .= λ` mutation path is invalid.

## Changes

- Add an out-of-place `_vecjacobian(::EnzymeVJP)` forming the state/parameter vjp as `Enzyme.gradient(mode, (u, p) -> dot(vec(f(u, p, t)), vec(λ)), y, p)`, returning `(dy, dλ, dgrad)`, mirroring the out-of-place `ZygoteVJP` method (incl. the `W !== nothing` SDE signature).
- In `vec_pjac!` (`QuadratureAdjoint`), branch on `ArrayInterface.ismutable(y)`: immutable state computes the parameter vjp via `Enzyme.gradient(mode, tunables -> dot(vec(f(y, repack(tunables), t)), vec(λ)), tunables)`; the original buffered `Duplicated` path is unchanged for mutable state.

## Verification (local, Julia 1.11.9, Enzyme 0.13.x)

- New regression tests in `test/adjoint_oop.jl` (registered via `runtests.jl`): continuous (`dgdu_continuous`) and discrete (`dgdu_discrete`) `adjoint_sensitivities` with `QuadratureAdjoint(EnzymeVJP())` on an `SVector` Lotka–Volterra ODE, asserted `≈` the `ZygoteVJP` result (`rtol = 1e-10`).
- Direct EnzymeVJP vs ZygoteVJP: continuous `du0`/`dp` agree to `~3e-12`/`7e-13`, discrete to `~1e-14`.
- End-to-end through an outer `Enzyme.gradient` over `solve(...; sensealg = QuadratureAdjoint(EnzymeVJP()))`: out-of-place `SVector` gradient matches the `ZygoteVJP` reference (rel. diff `~4e-6`), matching the already-working in-place `Vector` path.
- `Runic` reports no formatting changes on the touched files.

## Notes / scope

- The original issue MWE uses **SimpleChains**. With these fixes the reported `_vecjacobian` `MethodError` is gone, but that exact MWE then fails further down inside Enzyme with `from_tape_type(::Type{VecElement{Float32}})` — a SIMD/`VecElement` interaction between Enzyme and SimpleChains, not in SciMLSensitivity (a single-level `Enzyme.gradient` over a bare `SimpleChain` reproduces it with no SciMLSensitivity involved). A plain `SVector` RHS differentiates correctly through the full `QuadratureAdjoint(EnzymeVJP())` path, so this PR makes that path work for Enzyme-differentiable RHS functions; the SimpleChains MWE is blocked by a separate Enzyme/SimpleChains limitation.
- `GaussAdjoint` / `GaussKronrodAdjoint` have an analogous immutable-state issue in their own `vec_pjac!` (`gauss_adjoint.jl`); left as a focused follow-up since this issue is specifically about `QuadratureAdjoint`.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
