### PR TITLE
Migrate CI to centralized SciML/.github reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
       - "/test"
+      - "/test/gpu"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,12 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: Tests
     strategy:
       fail-fast: false
       matrix:
@@ -35,28 +38,8 @@ jobs:
           - '1'
           - '1.11'
           - 'lts'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      group: "${{ matrix.group }}"
+      julia-version: "${{ matrix.version }}"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,23 +14,15 @@ jobs:
   test:
     # Temporarily disabled - see https://github.com/SciML/SciMLSensitivity.jl/issues/1326
     if: false
-    runs-on: ubuntu-latest
+    name: Downgrade
     strategy:
       matrix:
-        downgrade_mode: ['alldeps']
         julia-version: ['1.10']
         group: ['Core1']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,51 +7,16 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: DiffEqFlux.jl, group: All}
           - {user: SciML, repo: DeepEquilibriumNetworks.jl, group: CPU}
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: Runic formatting
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -5,9 +5,5 @@ on: [pull_request]
 jobs:
   typos-check:
     name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.1 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Normalizes CI to the centralized SciML/.github reusable workflows (all pinned `@v1`).

## Workflows converted
- **CI.yml** -> `tests.yml@v1`. Preserves the exact matrix: 14 groups (Core1-8, QA, SDE1-3, Callbacks1-2) x 3 versions (`1`, `1.11`, `lts`), coverage on.
- **Downgrade.yml** -> `downgrade.yml@v1`. Preserves julia `1.10` / group `Core1` / `skip: Pkg,TOML` / `allow-reresolve: false`. Kept disabled via `if: false` per #1326 (the `downgrade_mode: alldeps` matrix axis maps to the action's default mode).
- **Downstream.yml** -> matrix of `downstream.yml@v1`. Preserves `SciML/DiffEqFlux.jl` (group `All`) and `SciML/DeepEquilibriumNetworks.jl` (group `CPU`).
- **FormatCheck.yml** -> `runic.yml@v1`. Repo already ran Runic (`fredrikekre/runic-action`), so no reformatting was applied.
- **SpellCheck.yml** -> `spellcheck.yml@v1`.

## Not changed / not added
- **GPU.yml** (self-hosted shadowing + GPU tests + GPU docs build): left unchanged (non-standard, hardware-specific).
- **No standalone Documentation.yml added.** The docs depend on `LuxCUDA` and are built on the self-hosted `gpu-v100` runner inside GPU.yml. A standard ubuntu-latest `documentation.yml@v1` caller would lack a GPU and would also conflict with the existing GPU docs deploy, so it was intentionally omitted.
- **TagBot.yml**: unchanged.
- No CompatHelper workflow existed (nothing to remove).
- No benchmark/AirspeedVelocity, downstream-beyond-existing, or QA (`test/jet`) workflows present, so none added.

## Dependabot
- Removed the `crate-ci/typos` ignore block (standing policy: no per-dependency version ignores).
- Preserved the existing `julia` directories (`/`, `/docs`, `/test`) and added `/test/gpu` (it has its own `Project.toml`).
- `github-actions` block retained (`directory: /`, weekly).

## Spellcheck findings (real, not silenced)
The centralized check uses a newer `typos` (1.47 vs the previously pinned 1.18.1) and flags pre-existing items. I did **not** add a `_typos.toml` or edit code/prose; listing for the maintainer to decide:
- `indx` -> `index`: ~145 hits, but these are an in-code identifier (`indx`, `get_indx`) in `src/callback_tracking.jl`. Likely needs a `_typos.toml` allow-list rather than a rename.
- `Lamba` -> `Lambda`: variable name in `test/sde_neural.jl` (lines 236, 250).
- `euqation` -> `equation`: prose typo in `docs/src/examples/pde/brusselator.md:205`.
The SpellCheck job is expected to be red until one of the above is addressed.

## Heads-up: branch protection
Job/check names change with this migration (e.g. the test jobs are now reported via the reusable `tests.yml`). Update the repo's required-status-checks in branch protection accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
