### PR TITLE
Fix GaussAdjoint(EnzymeVJP()) on out-of-place ODEs (UndefVarError gclosure3, #1462)

### DIFF
--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -648,13 +648,12 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
             recursive_copyto!(out, tmp[1])
         end
     elseif sensealg.autojacvec isa EnzymeVJP
-        tmp3, tmp4, tmp6 = paramjac_config
-        vtmp4 = vec(tmp4)
-        vtmp4 .= λ
-        Enzyme.remake_zero!(tmp3)
-        Enzyme.remake_zero!(out)
-
         if SciMLBase.isinplace(sol.prob.f)
+            tmp3, tmp4, tmp6 = paramjac_config
+            vtmp4 = vec(tmp4)
+            vtmp4 .= λ
+            Enzyme.remake_zero!(tmp3)
+            Enzyme.remake_zero!(out)
             Enzyme.remake_zero!(tmp6)
 
             Enzyme.autodiff(
@@ -663,12 +662,17 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
                 Enzyme.Const(y), Enzyme.Duplicated(tunables, out), Enzyme.Const(t)
             )
         else
-            tmp6 = Enzyme.make_zero(f)
-            Enzyme.autodiff(
-                sensealg.autojacvec.mode, Enzyme.Const(gclosure3), Enzyme.Duplicated(f, tmp6), Enzyme.Const,
-                Enzyme.Duplicated(tmp3, tmp4),
-                Enzyme.Const(y), Enzyme.Duplicated(p, out), Enzyme.Const(t)
+            # Out-of-place: form the parameter vjp `(∂f/∂p)^T λ` as the gradient of
+            # `λ ⋅ f(y, repack(tunables), t)` with respect to the tunables, holding
+            # `f`, `repack`, `y`, `t`, `λ` constant. This avoids the mutable
+            # `Duplicated` buffers the in-place path needs (and does not depend on
+            # mutability of the state), mirroring the `QuadratureAdjoint` fix.
+            res = Enzyme.gradient(
+                sensealg.autojacvec.mode, _enzyme_vecpjac_dot, Enzyme.Const(f),
+                Enzyme.Const(repack), Enzyme.Const(y), tunables,
+                Enzyme.Const(t), Enzyme.Const(λ)
             )
+            recursive_copyto!(out, res[4])
         end
     elseif sensealg.autojacvec isa MooncakeVJP
         _, _, p_grad = mooncake_run_ad(paramjac_config, y, p, t, λ)

--- a/test/gauss_zygote_inplace.jl
+++ b/test/gauss_zygote_inplace.jl
@@ -1,4 +1,4 @@
-using SciMLSensitivity, OrdinaryDiffEq, Zygote, SciMLBase
+using SciMLSensitivity, OrdinaryDiffEq, Zygote, SciMLBase, ForwardDiff
 using OrdinaryDiffEqSDIRK: KenCarp4
 using Test
 
@@ -83,4 +83,47 @@ end
     @test dp !== nothing
     @test length(du0) == 2
     @test length(dp) == 4
+end
+
+# Test for issue #1462: GaussAdjoint(EnzymeVJP()) on an out-of-place ODE hit an
+# `UndefVarError: gclosure3` because the out-of-place branch of `vec_pjac!`
+# referenced an undefined variable. The gradient must match both the ZygoteVJP
+# path and ForwardDiff.
+@testset "GaussAdjoint with EnzymeVJP and out-of-place ODE (#1462)" begin
+    function foop(u, p, t)
+        dx = p[1] * u[1] - p[2] * u[1] * u[2]
+        dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+        [dx, dy]
+    end
+
+    p = [1.5, 1.0, 3.0, 1.0]
+    u0 = [1.0, 1.0]
+    prob = ODEProblem(foop, u0, (0.0, 10.0), p)
+
+    enzyme_loss(p) = sum(
+        solve(
+            prob, Tsit5(); p = p, saveat = 0.1, abstol = 1.0e-10, reltol = 1.0e-10,
+            sensealg = GaussAdjoint(autojacvec = EnzymeVJP())
+        )
+    )
+    zygote_loss(p) = sum(
+        solve(
+            prob, Tsit5(); p = p, saveat = 0.1, abstol = 1.0e-10, reltol = 1.0e-10,
+            sensealg = GaussAdjoint(autojacvec = ZygoteVJP())
+        )
+    )
+    fd_loss(p) = sum(
+        solve(
+            remake(prob; p = p), Tsit5(); saveat = 0.1, abstol = 1.0e-12, reltol = 1.0e-12
+        )
+    )
+
+    dp_enzyme = Zygote.gradient(enzyme_loss, p)[1]
+    dp_zygote = Zygote.gradient(zygote_loss, p)[1]
+    dp_fd = ForwardDiff.gradient(fd_loss, p)
+
+    @test dp_enzyme !== nothing
+    @test length(dp_enzyme) == 4
+    @test dp_enzyme ≈ dp_zygote rtol = 1.0e-6
+    @test dp_enzyme ≈ dp_fd rtol = 1.0e-6
 end


### PR DESCRIPTION
## Summary

Fixes #1462: `GaussAdjoint(autojacvec = EnzymeVJP())` on an **out-of-place** ODE threw `UndefVarError: gclosure3 not defined in SciMLSensitivity` at `src/gauss_adjoint.jl:652`. The in-place branch worked.

The out-of-place branch of `vec_pjac!`'s `EnzymeVJP` path was a copy/refactor leftover: it referenced an undefined `gclosure3` and reused the in-place calling convention (a `du` buffer via `Duplicated(tmp3, tmp4)`, and `Duplicated(p, out)`), which is invalid for an out-of-place RHS that returns a fresh array.

## Change

Replace the broken branch with the same approach #1464 used for the `QuadratureAdjoint` out-of-place `EnzymeVJP` path: form the parameter vjp `(∂f/∂p)^T λ` as the gradient of `λ ⋅ f(y, repack(tunables), t)` w.r.t. the tunables via the multi-argument `Enzyme.gradient`, holding `f`, `repack`, `y`, `t`, `λ` constant. This reuses the existing top-level `_enzyme_vecpjac_dot` helper (defined in `quadrature_adjoint.jl`, same module) and needs no mutable `Duplicated` buffers.

The in-place branch is unchanged; its buffer setup (`tmp3, tmp4, tmp6 = paramjac_config`, etc.) is moved inside the in-place branch since the out-of-place path no longer touches `paramjac_config`.

## Verification (local, Julia 1.11.9, SciMLSensitivity master, Enzyme 0.13.152)

- The exact issue MWE no longer errors.
- Driven via `Zygote.gradient` through `solve(...; sensealg = GaussAdjoint(EnzymeVJP()))` on an out-of-place Lotka-Volterra ODE, the parameter gradient matches **ForwardDiff** and the **ZygoteVJP** path to `~1e-8`, and is stable across repeated calls.
- The in-place `EnzymeVJP` path still matches ForwardDiff (refactor didn't change it).
- Existing `test/gauss_zygote_inplace.jl` tests pass; the new `(#1462)` testset passes (4/4).
- `Runic` reports no formatting changes on the touched files.

## Scope / follow-ups (not addressed here)

- **Immutable `SVector` state**: a separate immutable-state bug remains in the GaussAdjoint integrand accumulation (`recursive_zero!`/`internal_zero!` does `setindex!` on an `SVector` `out` buffer inside the saving callback). This `vec_pjac!` branch itself supports immutable `y`, but the end-to-end `SVector` path still fails further down — the analogous follow-up #1464 already flagged for `gauss_adjoint.jl`.
- **Nested `Enzyme.gradient` over `solve`**: the issue MWE uses an outer `Enzyme.gradient` over a `solve` that itself uses `GaussAdjoint`. With this fix the first evaluation is correct, but repeated calls in the same session drift. That drift reproduces **identically on the in-place path**, so it is a pre-existing, separate issue (nested-Enzyme/caching), not introduced here. The regression test therefore drives the adjoint via `Zygote.gradient`, matching how the rest of the GaussAdjoint suite tests.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)