### PR TITLE
Fix OrdinaryDiffEq 7.0.0 re-export breakage in tests

### DIFF
--- a/test/concrete_solve_derivatives.jl
+++ b/test/concrete_solve_derivatives.jl
@@ -1,4 +1,5 @@
 using SciMLSensitivity, OrdinaryDiffEq, StochasticDiffEq, ADTypes
+using OrdinaryDiffEqLowOrderRK: Euler
 using Test, ForwardDiff, Random
 import Tracker, ReverseDiff, ChainRulesCore, Mooncake, Enzyme
 

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -1,5 +1,6 @@
 using SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, Calculus, ADTypes
 using OrdinaryDiffEqRosenbrock: Rodas4
+using OrdinaryDiffEqSDIRK: KenCarp4
 using Test
 function fb(du, u, p, t)
     du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]

--- a/test/sparse_adjoint.jl
+++ b/test/sparse_adjoint.jl
@@ -1,5 +1,6 @@
 using SciMLSensitivity, OrdinaryDiffEq, LinearAlgebra, SparseArrays, Zygote, LinearSolve
 using AlgebraicMultigrid
+using OrdinaryDiffEqSDIRK: ImplicitEuler
 using Test
 
 foop(u, p, t) = jac(u, p, t) * u


### PR DESCRIPTION
## Summary

OrdinaryDiffEq 7.0.0 intentionally dropped the blanket solver re-exports (documented in its NEWS.md; deps reduced 30 -> 6 for faster time-to-first-solve). The documented downstream migration is to import non-default solvers from their sub-packages.

Three test files still referenced solvers that ODE7 no longer exports under a plain `using OrdinaryDiffEq`, producing `UndefVarError` at latest deps:

| File | Solver | Sub-package import added |
|------|--------|--------------------------|
| `test/sparse_adjoint.jl` | `ImplicitEuler` | `using OrdinaryDiffEqSDIRK: ImplicitEuler` |
| `test/forward.jl` | `KenCarp4` | `using OrdinaryDiffEqSDIRK: KenCarp4` |
| `test/concrete_solve_derivatives.jl` | `Euler` | `using OrdinaryDiffEqLowOrderRK: Euler` |

The needed sub-packages (`OrdinaryDiffEqSDIRK`, `OrdinaryDiffEqLowOrderRK`, `OrdinaryDiffEqRosenbrock`) are already present in `[extras]`, the `test` target, and `[compat]`, so only the import lines are added. No `Project.toml` change is required.

## Reproduction (Julia 1.10.11, latest deps, OrdinaryDiffEq v7.0.0)

Confirmed before the fix:
- `forward.jl`: `UndefVarError: \`KenCarp4\` not defined`
- `sparse_adjoint.jl`: `UndefVarError: \`ImplicitEuler\` not defined`
- Verified `OrdinaryDiffEq` no longer exports `Euler`/`ImplicitEuler`/`KenCarp4`, and that the sub-package imports resolve them.

## Verification (after the fix, same env)

- `test/sparse_adjoint.jl`: **Pass 10 / Total 10** (full file).
- `test/forward.jl`: `KenCarp4` UndefVarError gone (17 pass). Two errors remain at lines 141 and 159, but these are **pre-existing and unrelated** to this PR: line 141 is a `BoundsError` in `extract_local_sensitivities(sol, length(sol), true)` and line 159 is a `FunctionWrappersWrappers.NoFunctionWrapperFoundError` in a `ForwardDiffSensitivity` `solve` with `Tsit5`. Both reproduce in a standalone script using only `OrdinaryDiffEq`/`Tsit5`/`ForwardSensitivity`/`ForwardDiffSensitivity` with no SDIRK/Rosenbrock/LowOrderRK import involved. They were previously masked because the unmodified file crashed earlier at the `KenCarp4` UndefVarError (line 61).
- `test/concrete_solve_derivatives.jl`: the `Euler` line (line 653, "Recursion Test" testset) now **passes 1 / 1** in isolation. Remaining errors in the full file are in the Enzyme/Mooncake AD-backend sections (lines 28-451, 1697), all before the `Euler` reference and structurally independent of a name import.

## Downgrade CI

`Downgrade.yml` is currently disabled (`if: false`) due to a **separate** StatsBase version-resolution blocker (issue #1326), unrelated to the ODE7 re-export issue. This PR therefore does the import fix only and does not re-enable Downgrade.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
