### PR TITLE
Re-enable downgrade workflow (strict, intentionally red pending #1326)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,8 +12,7 @@ on:
       - 'docs/**'
 jobs:
   test:
-    # Temporarily disabled - see https://github.com/SciML/SciMLSensitivity.jl/issues/1326
-    if: false
+    # Runs strict (allow_reresolve=false); expected RED until StatsBase resolves (#1326).
     name: Downgrade
     strategy:
       matrix:


### PR DESCRIPTION
Re-enables the Downgrade CI job by removing the \`if: false\` guard.

The downgrade job now runs strict (allow_reresolve=false); floors are unchanged and julia stays at 1.10. It is intentionally RED — this is a natural failure (the resolver genuinely cannot satisfy the downgrade bounds), not a disabled/skipped job — pending StatsBase (SciML/SciMLSensitivity.jl#1326). It will auto-green once that resolves.

Please ignore until reviewed by @ChrisRackauckas.