### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,32 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
-  test:
-    name: Tests
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Core1
-          - Core2
-          - Core3
-          - Core4
-          - Core5
-          - Core6
-          - Core7
-          - Core8
-          - QA
-          - SDE1
-          - SDE2
-          - SDE3
-          - Callbacks1
-          - Callbacks2
-        version:
-          - '1'
-          - '1.11'
-          - 'lts'
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,41 @@
+[Core1]
+versions = ["1", "1.11", "lts"]
+
+[Core2]
+versions = ["1", "1.11", "lts"]
+
+[Core3]
+versions = ["1", "1.11", "lts"]
+
+[Core4]
+versions = ["1", "1.11", "lts"]
+
+[Core5]
+versions = ["1", "1.11", "lts"]
+
+[Core6]
+versions = ["1", "1.11", "lts"]
+
+[Core7]
+versions = ["1", "1.11", "lts"]
+
+[Core8]
+versions = ["1", "1.11", "lts"]
+
+[QA]
+versions = ["1", "1.11", "lts"]
+
+[SDE1]
+versions = ["1", "1.11", "lts"]
+
+[SDE2]
+versions = ["1", "1.11", "lts"]
+
+[SDE3]
+versions = ["1", "1.11", "lts"]
+
+[Callbacks1]
+versions = ["1", "1.11", "lts"]
+
+[Callbacks2]
+versions = ["1", "1.11", "lts"]


### PR DESCRIPTION
Converts the root test workflow (`.github/workflows/CI.yml`) to the canonical [`SciML/.github` `grouped-tests.yml@v1`](https://github.com/SciML/.github/blob/v1/.github/workflows/grouped-tests.yml) thin caller, declaring the group × version matrix once in a new root `test/test_groups.toml`.

## What changed

- **`.github/workflows/CI.yml`** — the matrix `test` job is replaced by a thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
  The `on:` triggers (push/PR on `master`, `paths-ignore: docs/**`) and `concurrency:` block are preserved verbatim, and the filename + `name: CI` are kept so branch-protection status checks remain valid.
- **`test/test_groups.toml`** (new) — declares all 14 groups (`Core1`–`Core8`, `QA`, `SDE1`–`SDE3`, `Callbacks1`–`Callbacks2`), each on `versions = ["1", "1.11", "lts"]`.

No `runtests.jl` change is needed: it already dispatches on the standard `GROUP` env var. No non-default `with:` inputs are needed — the package uses the standard `GROUP` variable, default `check-bounds`, and default coverage settings. Linux-only, so no `os` field. All other workflow files are left untouched.

## Matrix match

The previous CI.yml hand-maintained a `14 groups × 3 versions` matrix = **42 jobs**. Running the canonical matrix computer:

```
julia scripts/compute_affected_sublibraries.jl . --root-matrix
```

reproduces exactly that set — **42/42 exact match**, all `ubuntu-latest`, all `continue_on_error=false`, matching the old defaults. TOML and YAML both parse cleanly.

## QA

Category A: `QA` group dispatch (`aqua.jl`) already exists in `runtests.jl` and is preserved in the matrix on all three versions (matching the old workflow exactly). No QA source changes were made and no new exclusions were added.

Ignore until reviewed by @ChrisRackauckas.