### PR TITLE
Fix typos and add _typos.toml so the spell check workflow passes

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -81,3 +81,7 @@ hom = "hom"  # Homogeneous (mathematical term)
 pn = "pn"  # Parameter n (mathematical variable)
 iy = "iy"  # Legitimate variable name
 Chater = "Chater"  # Author surname in references
+indx = "indx"  # Keyword argument of DiffEqNoiseProcess.NoiseWrapper; also internal callback-tracking helpers
+
+[default.extend-identifiers]
+LambaEM = "LambaEM"  # StochasticDiffEq.jl solver (Lamba's Euler-Maruyama method)

--- a/docs/src/examples/pde/brusselator.md
+++ b/docs/src/examples/pde/brusselator.md
@@ -202,7 +202,7 @@ prob_ude_template = ODE.ODEProblem(pde_ude!, u0, tspan, ps_init)
 To train the neural network
 $\mathcal{N}_\theta(U, V)$ embedded in the UDE, we define a loss function that measures how closely the solution of the UDE matches the ground truth data generated earlier.
 
-The loss is computed as the sum of squared errors between the predicted solution from the UDE and the true solution at each saved time point. If the solver fails (e.g., due to numerical instability or incorrect parameters), we return an infinite loss to discard that configuration during optimization. We use `FBDF()` as the solver due to the stiff nature of the brusselators euqation. Other solvers like `KenCarp47()` could also be used.
+The loss is computed as the sum of squared errors between the predicted solution from the UDE and the true solution at each saved time point. If the solver fails (e.g., due to numerical instability or incorrect parameters), we return an infinite loss to discard that configuration during optimization. We use `FBDF()` as the solver due to the stiff nature of the brusselator equations. Other solvers like `KenCarp47()` could also be used.
 
 To efficiently compute gradients of the loss with respect to the neural network parameters, we use an adjoint sensitivity method (`GaussAdjoint`), which performs high-accuracy quadrature-based integration of the adjoint equations. This approach enables scalable and memory-efficient training for stiff PDEs by avoiding full trajectory storage while maintaining accurate gradient estimates.
 

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -321,21 +321,21 @@ function adjointdiffcache(
             m = noise_rate_prototype === nothing ? numindvar : size(noise_rate_prototype)[2]
             if isinplace
                 for i in 1:m
-                    function noisetape(indx)
+                    function noisetape(idx)
                         return if SciMLBase.is_diagonal_noise(prob)
                             ReverseDiff.GradientTape((y, _p, [_t])) do u, p, t
                                 du1 = p !== nothing && p !== SciMLBase.NullParameters() ?
                                     similar(p, size(u)) : similar(u)
                                 copyto!(du1, false)
                                 unwrappedf(du1, u, p, first(t))
-                                return du1[indx]
+                                return du1[idx]
                             end
                         else
                             ReverseDiff.GradientTape((y, _p, [_t])) do u, p, t
                                 du1 = similar(p, size(noise_rate_prototype))
                                 du1 .= false
                                 unwrappedf(du1, u, p, first(t))
-                                return du1[:, indx]
+                                return du1[:, idx]
                             end
                         end
                     end
@@ -348,14 +348,14 @@ function adjointdiffcache(
                 end
             else
                 for i in 1:m
-                    function noisetapeoop(indx)
+                    function noisetapeoop(idx)
                         return if SciMLBase.is_diagonal_noise(prob)
                             ReverseDiff.GradientTape((y, _p, [_t])) do u, p, t
-                                unwrappedf(u, p, first(t))[indx]
+                                unwrappedf(u, p, first(t))[idx]
                             end
                         else
                             ReverseDiff.GradientTape((y, _p, [_t])) do u, p, t
-                                unwrappedf(u, p, first(t))[:, indx]
+                                unwrappedf(u, p, first(t))[:, idx]
                             end
                         end
                     end

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -1421,20 +1421,20 @@ function SciMLBase._concrete_solve_adjoint(
                         # First step: filter all values, so that only time steps that actually occur
                         # in the primal are left. This is for example necessary when `terminate!`
                         # is used.
-                        indxs = findall(t -> t ∈ ts, current_time(_sol))
-                        _ts = current_time(_sol, indxs)
+                        idxs = findall(t -> t ∈ ts, current_time(_sol))
+                        _ts = current_time(_sol, idxs)
                         # after this filtering step, we might end up with a too large amount of indices.
                         # For example, if a callback saved values in the primal, then we now potentially
                         # save it by `saveat` and by `save_positions` of the callback.
                         # Second step. Drop these duplicates values.
-                        if length(indxs) != length(ts)
+                        if length(idxs) != length(ts)
                             for i in (length(_ts) - 1):-1:2
                                 if _ts[i] == _ts[i + 1] && _ts[i] == _ts[i - 1]
-                                    deleteat!(indxs, i)
+                                    deleteat!(idxs, i)
                                 end
                             end
                         end
-                        _du = @view du[indxs]
+                        _du = @view du[idxs]
                     else
                         _du = du
                     end
@@ -1622,20 +1622,20 @@ function SciMLBase._concrete_solve_adjoint(
                     # First step: filter all values, so that only time steps that actually occur
                     # in the primal are left. This is for example necessary when `terminate!`
                     # is used.
-                    indxs = findall(t -> t ∈ ts, current_time(_sol))
-                    _ts = current_time(_sol, indxs)
+                    idxs = findall(t -> t ∈ ts, current_time(_sol))
+                    _ts = current_time(_sol, idxs)
                     # after this filtering step, we might end up with a too large amount of indices.
                     # For example, if a callback saved values in the primal, then we now potentially
                     # save it by `saveat` and by `save_positions` of the callback.
                     # Second step. Drop these duplicates values.
-                    if length(indxs) != length(ts)
+                    if length(idxs) != length(ts)
                         for i in (length(_ts) - 1):-1:2
                             if _ts[i] == _ts[i + 1] && _ts[i] == _ts[i - 1]
-                                deleteat!(indxs, i)
+                                deleteat!(idxs, i)
                             end
                         end
                     end
-                    _du = @view du[indxs]
+                    _du = @view du[idxs]
                 else
                     _du = du
                 end

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -276,9 +276,9 @@ function wB!(S::LSSSchur, Δt, Nt, numindvar, dt)
     tmp ./= dt[1]
     tmp = @view wBinv[(dim - 2):end]
     tmp ./= dt[end]
-    for indx in 2:(Nt - 1)
-        tmp = @view wBinv[((indx - 1) * numindvar + 1):(indx * numindvar)]
-        tmp ./= (dt[indx] + dt[indx - 1])
+    for idx in 2:(Nt - 1)
+        tmp = @view wBinv[((idx - 1) * numindvar + 1):(idx * numindvar)]
+        tmp ./= (dt[idx] + dt[idx - 1])
     end
 
     wBinv .*= 2 * Δt
@@ -493,7 +493,7 @@ function shadow_forward(
     return res
 end
 
-function lss_accumulate_cost!(u, p, t, sensealg::ForwardLSS, diffcache, indx)
+function lss_accumulate_cost!(u, p, t, sensealg::ForwardLSS, diffcache, idx)
     (; dgdu, dgdp, dg_val, pgpu, pgpu_config, pgpp, pgpp_config, uf) = diffcache
 
     if dgdu === nothing
@@ -505,10 +505,10 @@ function lss_accumulate_cost!(u, p, t, sensealg::ForwardLSS, diffcache, indx)
         end
     else
         if dg_val isa Tuple
-            dgdu(dg_val[1], u, p, t, indx) # indx = n0 + j - 1 for LSSregularizer and j for windowing
-            dgdp(dg_val[2], u, p, t, indx)
+            dgdu(dg_val[1], u, p, t, idx) # idx = n0 + j - 1 for LSSregularizer and j for windowing
+            dgdp(dg_val[2], u, p, t, idx)
         else
-            dgdu(dg_val, u, p, t, indx)
+            dgdu(dg_val, u, p, t, idx)
         end
     end
 

--- a/src/nilsas.jl
+++ b/src/nilsas.jl
@@ -188,18 +188,18 @@ function split_states(du, u, t, NS::NILSASSensitivityFunction, j; update = true)
     (; nilss, S) = NS
     (; numindvar, numparams) = nilss
 
-    indx1 = (j - 1) * (numindvar) + 1
-    indx2 = indx1 + (numindvar - 1)
-    indx3 = (j - 1) * (numparams) + 1
-    indx4 = indx3 + (numparams - 1)
+    idx1 = (j - 1) * (numindvar) + 1
+    idx2 = idx1 + (numindvar - 1)
+    idx3 = (j - 1) * (numparams) + 1
+    idx4 = idx3 + (numparams - 1)
 
-    λ = @view u.x[1][indx1:indx2]
-    grad = @view u.x[2][indx3:indx4]
+    λ = @view u.x[1][idx1:idx2]
+    grad = @view u.x[2][idx3:idx4]
     _y = u.x[3]
 
     # like ODE/Drift term and scalar noise
-    dλ = @view du.x[1][indx1:indx2]
-    dgrad = @view du.x[2][indx3:indx4]
+    dλ = @view du.x[1][idx1:idx2]
+    dgrad = @view du.x[2][idx3:idx4]
     dy = du.x[3]
 
     return λ, grad, _y, dλ, dgrad, dy

--- a/src/nilss.jl
+++ b/src/nilss.jl
@@ -284,10 +284,10 @@ function (NS::NILSSForwardSensitivityFunction)(du, u, p, t)
     # Compute the parameter derivatives
     for j in 1:(nus + 1)
         for i in eachindex(p)
-            indx1 = (j - 1) * S.numindvar * 1 + i * S.numindvar + 1
-            indx2 = (j - 1) * S.numindvar * 1 + (i + 1) * S.numindvar
-            Sj = @view u[indx1:indx2]
-            dp = @view du[indx1:indx2]
+            idx1 = (j - 1) * S.numindvar * 1 + i * S.numindvar + 1
+            idx2 = (j - 1) * S.numindvar * 1 + (i + 1) * S.numindvar
+            Sj = @view u[idx1:idx2]
+            dp = @view du[idx1:idx2]
             if !S.isautojacvec
                 mul!(dp, S.J, Sj)
             else
@@ -360,19 +360,19 @@ function store_y_w_vstar!(y, w, vstar, sol, nus, numindvar, numparams, iseg)
     # fill w
     # only calculate w one time, w can be reused for each parameter
     for j in 1:nus
-        indx1 = (j - 1) * numindvar * 1 + numindvar + 1
-        indx2 = (j - 1) * numindvar * 1 + 2 * numindvar
+        idx1 = (j - 1) * numindvar * 1 + numindvar + 1
+        idx2 = (j - 1) * numindvar * 1 + 2 * numindvar
 
         _w = @view w[:, :, iseg, j]
-        copyto!(_w, (@view sol[indx1:indx2, :]))
+        copyto!(_w, (@view sol[idx1:idx2, :]))
     end
 
     # fill vstar
     for i in 1:numparams
-        indx1 = nus * numindvar * 1 + i * numindvar + 1
-        indx2 = nus * numindvar * 1 + (i + 1) * numindvar
+        idx1 = nus * numindvar * 1 + i * numindvar + 1
+        idx2 = nus * numindvar * 1 + (i + 1) * numindvar
         _vstar = @view vstar[i, :, :, iseg]
-        copyto!(_vstar, (@view sol[indx1:indx2, :]))
+        copyto!(_vstar, (@view sol[idx1:idx2, :]))
     end
 
     return nothing
@@ -418,16 +418,16 @@ function dudt_g_dgdu!(dudt, dgdu_val, gsave, nilssprob::NILSSProblem, y, p, iseg
 end
 
 function perp!(w_perp, vstar_perp, w, vstar, dudt, iseg, numparams, nsteps, nus)
-    for indx_steps in 1:nsteps
-        _dudt = @view dudt[:, indx_steps, iseg]
-        for indx_nus in 1:nus
-            _w_perp = @view w_perp[:, indx_steps, iseg, indx_nus]
-            _w = @view w[:, indx_steps, iseg, indx_nus]
+    for idx_steps in 1:nsteps
+        _dudt = @view dudt[:, idx_steps, iseg]
+        for idx_nus in 1:nus
+            _w_perp = @view w_perp[:, idx_steps, iseg, idx_nus]
+            _w = @view w[:, idx_steps, iseg, idx_nus]
             perp!(_w_perp, _w, _dudt)
         end
-        for indx_params in 1:numparams
-            _vstar_perp = @view vstar_perp[indx_params, :, indx_steps, iseg]
-            _vstar = @view vstar[indx_params, :, indx_steps, iseg]
+        for idx_params in 1:numparams
+            _vstar_perp = @view vstar_perp[idx_params, :, idx_steps, iseg]
+            _vstar = @view vstar[idx_params, :, idx_steps, iseg]
             perp!(_vstar_perp, _vstar, _dudt)
         end
     end
@@ -464,7 +464,7 @@ function renormalize!(R, b, w_perp, vstar_perp, y, vstar, w, iseg, numparams, nu
     return nothing
 end
 
-function compute_Cinv!(Cinv, w_perp, weight, nseg, nus, indxp)
+function compute_Cinv!(Cinv, w_perp, weight, nseg, nus, idxp)
     # construct Schur complement of Lagrange multiplier
     _weight = @view weight[1, :]
     for iseg in 1:nseg
@@ -485,12 +485,12 @@ function compute_Cinv!(Cinv, w_perp, weight, nseg, nus, indxp)
     return nothing
 end
 
-function compute_d!(d, w_perp, vstar_perp, weight, nseg, nus, indxp)
+function compute_d!(d, w_perp, vstar_perp, weight, nseg, nus, idxp)
     # construct d
     _weight = @view weight[1, :]
     for iseg in 1:nseg
         _d = @view d[((iseg - 1) * nus + 1):(iseg * nus)]
-        vi = @view vstar_perp[indxp, :, :, iseg]
+        vi = @view vstar_perp[idxp, :, :, iseg]
         for i in 1:nus
             wi = @view w_perp[:, :, iseg, i]
             _d[i] = sum(wi .* vi * _weight)
@@ -499,13 +499,13 @@ function compute_d!(d, w_perp, vstar_perp, weight, nseg, nus, indxp)
     return nothing
 end
 
-function compute_B!(B, R, nseg, nus, indxp)
+function compute_B!(B, R, nseg, nus, idxp)
     for iseg in 1:(nseg - 1)
         _B = @view B[
             ((iseg - 1) * nus + 1):(iseg * nus),
             ((iseg - 1) * nus + 1):(iseg * nus),
         ]
-        _R = @view R[indxp, iseg, :, :]
+        _R = @view R[idxp, iseg, :, :]
         copyto!(_B, -_R)
         # off diagonal one
         for i in 1:nus
@@ -515,17 +515,17 @@ function compute_B!(B, R, nseg, nus, indxp)
     return nothing
 end
 
-function compute_a!(a, B, Cinv, b, d, indxp)
-    _b = @view b[indxp, :]
+function compute_a!(a, B, Cinv, b, d, idxp)
+    _b = @view b[idxp, :]
 
     lbd = (-B * Cinv * B') \ (B * Cinv * d + _b)
     a .= -Cinv * (B' * lbd + d)
     return nothing
 end
 
-function compute_v!(v, v_perp, vstar, vstar_perp, w, w_perp, a, nseg, nus, indxp)
-    _vstar = @view vstar[indxp, :, :, :]
-    _vstar_perp = @view vstar_perp[indxp, :, :, :]
+function compute_v!(v, v_perp, vstar, vstar_perp, w, w_perp, a, nseg, nus, idxp)
+    _vstar = @view vstar[idxp, :, :, :]
+    _vstar_perp = @view vstar_perp[idxp, :, :, :]
 
     copyto!(v, _vstar)
     copyto!(v_perp, _vstar_perp)

--- a/test/HybridNODE.jl
+++ b/test/HybridNODE.jl
@@ -130,8 +130,8 @@ mutable struct Affect{T}
 end
 compute_index(t) = round(Int, t) + 1
 function (cb::Affect)(integrator)
-    indx = compute_index(integrator.t)
-    return integrator.u .= integrator.u .+ @view(cb.callback_data[:, indx, 1]) * (integrator.t - integrator.tprev)
+    idx = compute_index(integrator.t)
+    return integrator.u .= integrator.u .+ @view(cb.callback_data[:, idx, 1]) * (integrator.t - integrator.tprev)
 end
 function test_hybridNODE3(sensealg)
     u0 = Float32[2.0; 0.0]

--- a/test/mtk.jl
+++ b/test/mtk.jl
@@ -181,7 +181,7 @@ setups = [
 #
 # The inner VJP is `ReverseDiffVJP`, not `EnzymeVJP`: `EnzymeVJP._vecjacobian!`
 # runs a *nested* `Enzyme.autodiff` on the MTK-generated DAE RHS, which both
-# mis-handles that RHS for some DAEs and corrupts Enzyme's global state across the
+# mishandles that RHS for some DAEs and corrupts Enzyme's global state across the
 # many `Enzyme.autodiff` calls this `setups` sweep makes (first call OK, later
 # calls `SingularException`). Using a non-Enzyme inner VJP is the established
 # workaround until that EnzymeVJP nested-Enzyme issue is fixed; the *outer* AD is


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

The canonical-CI "Spell Check with Typos" workflow fails on **every** branch (including master push runs) because of ~149 pre-existing typos flagged by crate-ci/typos v1.47.0.

## What was fixed vs ignored

**Renamed (genuine misspellings, local scope only):**
- `indx`/`indxs` → `idx`/`idxs` local variables in `src/adjoint_common.jl` (the `noisetape` closures), `src/concrete_solve.jl`, `src/lss.jl`, `src/nilsas.jl`, `src/nilss.jl`, `test/HybridNODE.jl`, `test/mtk.jl` — checked each scope for collisions.
- Prose typos in docs/comments (e.g. "brusselators euqation" → "brusselator equations").

**Ignored via `_typos.toml` (cannot be renamed):**
- `indx` — keyword argument of `DiffEqNoiseProcess.NoiseWrapper` (external API), and the internal `get_indx` callback-tracking helper family shared across `interpolating_adjoint.jl`/`backsolve_adjoint.jl`/`callback_tracking.jl` (left consistently named rather than churning a cross-file internal interface).
- `LambaEM` — StochasticDiffEq.jl solver name (Lamba's Euler–Maruyama method).

The existing `.typos.toml` was renamed to `_typos.toml` (the filename the typos CLI actually picks up by default) and extended.

## Verification (local)

- `typos .` exits clean (0 errors, previously 149).
- All renamed files parse (`Meta.parseall`).
- Remaining `indx` occurrences audited one-by-one: only the NoiseWrapper kwarg and the `get_indx` helpers.
- Full `Pkg.test` was attempted but currently fails at *dependency resolution* on this machine (`Unsatisfiable requirements for OrdinaryDiffEqDifferentiation`) — unrelated to these mechanical renames; CI on this PR will exercise the affected Shadowing/adjoint test groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
