### PR TITLE
QA: normalize versions to [lts, 1] (drop pre)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -23,7 +23,7 @@ versions = ["1", "1.11", "lts"]
 versions = ["1", "1.11", "lts"]
 
 [QA]
-versions = ["1", "1.11", "lts"]
+versions = ["lts", "1"]
 
 [SDE1]
 versions = ["1", "1.11", "lts"]


### PR DESCRIPTION
Normalize the root `test/test_groups.toml` **[QA]** group's `versions` to the canonical set `["lts", "1"]` (Aqua/JET on LTS + latest stable; never `pre`).

- Old: `["1", "1.11", "lts"]`
- New: `["lts", "1"]`

The repo's `[compat] julia` floor is `1.10` (== lts), so the canonical two-element set applies (the floor exception for repos with a floor above lts does not apply here).

Only `[QA].versions` is changed; functional test groups are left untouched. Statically verified that the TOML parses and `QA.versions == ["lts", "1"]`.

Ignore until reviewed by @ChrisRackauckas.