### PR TITLE
Restore SDE/RODE InterpolatingAdjoint checkpointing without the O(N^2) deepcopy

### DIFF
--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -43,26 +43,54 @@ function ODEInterpolatingAdjointSensitivityFunction(
         cursor = lastindex(intervals)
         interval = intervals[cursor]
 
-        # SDE/RODE solutions only have a linear interpolation, so they are never
-        # checkpointed (see `ischeckpointing`); only ODE-type problems reach here.
-        if tstops === nothing
-            cpsol = solve(
-                remake(sol.prob, tspan = interval, u0 = sol(interval[1])),
-                sol.alg; tols...
-            )
-        else
-            if maximum(interval[1] .< tstops .< interval[2])
-                # callback might have changed p
-                _p = reset_p(sol.prob.kwargs[:callback], interval)
-                cpsol = solve(
-                    remake(sol.prob, tspan = interval, u0 = sol(interval[1]));
-                    tstops, p = _p, sol.alg, tols...
+        if sol.prob isa Union{SDEProblem, RODEProblem}
+            # Re-solve the interval driven by the recorded forward noise so the
+            # reverse adjoint steps at the forward grid. The noise is referenced
+            # (NoiseWrapper/NoiseGrid keep a handle to `sol.W`), not copied per
+            # step, so this is O(interval) rather than the former O(N) deepcopy.
+            idx1 = searchsortedfirst(sol.W.t, interval[1] - 1000eps(interval[1]))
+            if sol.W isa DiffEqNoiseProcess.NoiseProcess
+                sol.W.save_everystep = false
+                forwardnoise = DiffEqNoiseProcess.NoiseWrapper(sol.W, indx = idx1)
+            elseif sol.W isa DiffEqNoiseProcess.NoiseGrid
+                forwardnoise = DiffEqNoiseProcess.NoiseGrid(
+                    sol.W.t[idx1:end],
+                    sol.W.W[idx1:end]
                 )
             else
+                error("NoiseProcess type not implemented.")
+            end
+            dt = choose_dt((sol.W.t[idx1] - sol.W.t[idx1 + 1]), sol.W.t, interval)
+
+            _ts = current_time(sol)
+            cpsol = solve(
+                remake(
+                    sol.prob, tspan = interval, u0 = sol(interval[1]),
+                    noise = forwardnoise
+                ),
+                sol.alg, save_noise = false; dt, tstops = _ts[idx1:end],
+                tols...
+            )
+        else
+            if tstops === nothing
                 cpsol = solve(
-                    remake(sol.prob, tspan = interval, u0 = sol(interval[1]));
-                    tstops, sol.alg, tols...
+                    remake(sol.prob, tspan = interval, u0 = sol(interval[1])),
+                    sol.alg; tols...
                 )
+            else
+                if maximum(interval[1] .< tstops .< interval[2])
+                    # callback might have changed p
+                    _p = reset_p(sol.prob.kwargs[:callback], interval)
+                    cpsol = solve(
+                        remake(sol.prob, tspan = interval, u0 = sol(interval[1]));
+                        tstops, p = _p, sol.alg, tols...
+                    )
+                else
+                    cpsol = solve(
+                        remake(sol.prob, tspan = interval, u0 = sol(interval[1]));
+                        tstops, sol.alg, tols...
+                    )
+                end
             end
         end
         CheckpointSolution(cpsol, intervals, cursor, tols, tstops)
@@ -174,35 +202,71 @@ function split_states(
                 else
                     sol(y, interval[1])
                 end
-                # SDE/RODE solutions only have a linear interpolation and are
-                # never checkpointed (see `ischeckpointing`); only ODE-type
-                # problems reach here.
-                if checkpoint_sol.tstops === nothing
-                    prob′ = remake(prob, tspan = intervals[cursor′], u0 = y)
-                    cpsol′ = solve(
-                        prob′, sol.alg;
-                        dt = abs(cpsol_t[end] - cpsol_t[end - 1]),
-                        checkpoint_sol.tols...
+                if sol.prob isa Union{SDEProblem, RODEProblem}
+                    # Re-integrate this checkpoint interval driven by the recorded
+                    # forward noise so the reverse adjoint steps at the forward
+                    # grid. `sol.W` is referenced by the NoiseWrapper/NoiseGrid,
+                    # not deep-copied per step, so each cursor move is O(interval)
+                    # rather than the former O(N) `deepcopy(sol)` (which made the
+                    # whole reverse pass O(N^2) and hung large RODE/SDE problems).
+                    _ts = current_time(sol)
+                    idx1 = searchsortedfirst(_ts, interval[1] - 100eps(interval[1]))
+                    idx2 = searchsortedfirst(_ts, interval[2] + 100eps(interval[2]))
+                    idx_noise = searchsortedfirst(
+                        sol.W.t,
+                        interval[1] - 100eps(interval[1])
                     )
-                else
-                    if maximum(interval[1] .< checkpoint_sol.tstops .< interval[2])
-                        # callback might have changed p
-                        _p = reset_p(prob.kwargs[:callback], interval)
-                        prob′ = remake(prob, tspan = intervals[cursor′], u0 = y, p = _p)
-                        cpsol′ = solve(
-                            prob′, sol.alg;
-                            dt = abs(cpsol_t[end] - cpsol_t[end - 1]),
-                            tstops = checkpoint_sol.tstops,
-                            checkpoint_sol.tols...
+                    if sol.W isa DiffEqNoiseProcess.NoiseProcess
+                        sol.W.save_everystep = false
+                        forwardnoise = DiffEqNoiseProcess.NoiseWrapper(
+                            sol.W,
+                            indx = idx_noise
+                        )
+                    elseif sol.W isa DiffEqNoiseProcess.NoiseGrid
+                        forwardnoise = DiffEqNoiseProcess.NoiseGrid(
+                            sol.W.t[idx_noise:end],
+                            sol.W.W[idx_noise:end]
                         )
                     else
+                        error("NoiseProcess type not implemented.")
+                    end
+                    prob′ = remake(
+                        prob, tspan = intervals[cursor′], u0 = y,
+                        noise = forwardnoise
+                    )
+                    dt = choose_dt(abs(cpsol_t[1] - cpsol_t[2]), cpsol_t, interval)
+                    cpsol′ = solve(
+                        prob′, sol.alg, save_noise = false; dt,
+                        tstops = _ts[idx1:idx2], checkpoint_sol.tols...
+                    )
+                else
+                    if checkpoint_sol.tstops === nothing
                         prob′ = remake(prob, tspan = intervals[cursor′], u0 = y)
                         cpsol′ = solve(
                             prob′, sol.alg;
                             dt = abs(cpsol_t[end] - cpsol_t[end - 1]),
-                            tstops = checkpoint_sol.tstops,
                             checkpoint_sol.tols...
                         )
+                    else
+                        if maximum(interval[1] .< checkpoint_sol.tstops .< interval[2])
+                            # callback might have changed p
+                            _p = reset_p(prob.kwargs[:callback], interval)
+                            prob′ = remake(prob, tspan = intervals[cursor′], u0 = y, p = _p)
+                            cpsol′ = solve(
+                                prob′, sol.alg;
+                                dt = abs(cpsol_t[end] - cpsol_t[end - 1]),
+                                tstops = checkpoint_sol.tstops,
+                                checkpoint_sol.tols...
+                            )
+                        else
+                            prob′ = remake(prob, tspan = intervals[cursor′], u0 = y)
+                            cpsol′ = solve(
+                                prob′, sol.alg;
+                                dt = abs(cpsol_t[end] - cpsol_t[end - 1]),
+                                tstops = checkpoint_sol.tstops,
+                                checkpoint_sol.tols...
+                            )
+                        end
                     end
                 end
                 checkpoint_sol.cpsol = cpsol′

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -1649,16 +1649,15 @@ end
     return alg.autojacmat isa Bool ? alg.autojacmat : true
 end
 # Checkpointing re-solves the forward pass to reconstruct the state during the
-# reverse pass. It only helps when the algorithm has a dense (higher-than-linear)
-# interpolation that wasn't saved. For methods whose only interpolation is linear
-# (RODE/SDE, where `default_linear_interpolation(prob, alg) == true` forces
-# `sol.dense == false`), re-solving recovers nothing better than the stored linear
-# interpolation — verified to leave the adjoint gradient unchanged — so they are
-# never checkpointed, even when `checkpointing = true` is requested.
-@inline function needs_checkpointing(alg, sol)
-    OrdinaryDiffEqCore.default_linear_interpolation(sol.prob, sol.alg) && return false
-    return alg.checkpointing || !sol.dense
-end
+# reverse pass. It is required whenever the saved solution lacks a dense
+# interpolation (`!sol.dense`). For SDE/RODE this is always the case
+# (`default_linear_interpolation(prob, alg) == true` forces `sol.dense == false`),
+# and the re-solve is not merely state reconstruction: it re-integrates each
+# checkpoint interval at the recorded-noise grid so the reverse adjoint steps at
+# the forward step size. Skipping it makes the reverse SDE integrate at the coarse
+# user `dt`, which materially changes (degrades) the gradient — hence it must stay
+# on for linear-interpolation methods.
+@inline needs_checkpointing(alg, sol) = alg.checkpointing || !sol.dense
 
 @inline ischeckpointing(alg::AbstractSensitivityAlgorithm, sol = nothing) = false
 @inline ischeckpointing(alg::InterpolatingAdjoint) = alg.checkpointing

--- a/test/SDE3/rode.jl
+++ b/test/SDE3/rode.jl
@@ -662,12 +662,13 @@ end
     @test dpReverseDiff ≈ dp' rtol = 1.0e-2
 end
 
-@testset "InterpolatingAdjoint RODE never checkpoints (linear interp)" begin
-    # RODE solutions only have a linear interpolation, so `InterpolatingAdjoint`
-    # never checkpoints them — `default_linear_interpolation(prob, alg)` is true,
-    # so `ischeckpointing` returns false even when `checkpointing = true`. This
-    # avoids the pointless per-step re-solve (and the former per-step
-    # `deepcopy(sol)`) that has no effect on the gradient.
+@testset "InterpolatingAdjoint RODE checkpointing (linear interp)" begin
+    # RODE/SDE solutions only have a linear interpolation (`sol.dense == false`),
+    # so `InterpolatingAdjoint` always checkpoints them: the per-interval re-solve
+    # re-integrates with the recorded noise at the forward step size, which the
+    # reverse adjoint needs to match the forward path. The re-solve must therefore
+    # stay on, but it does so without the former per-step `deepcopy(sol)` that made
+    # the reverse pass O(N^2) and hung large problems.
     function frep(du, u, p, t, W)
         du[1] = p[1] * u[1] * sin(W[1])
         return nothing
@@ -681,14 +682,14 @@ end
 
     Random.seed!(seed)
     soli = solve(probr, RandomEM(); dt = dtr, save_noise = true, dense = true)
-    # Never checkpoint a linear-interpolation method, even on explicit request.
-    @test !SciMLSensitivity.ischeckpointing(InterpolatingAdjoint(), soli)
-    @test !SciMLSensitivity.ischeckpointing(
+    # Linear-interpolation methods are checkpointed (sol.dense is false for RODE).
+    @test SciMLSensitivity.ischeckpointing(InterpolatingAdjoint(), soli)
+    @test SciMLSensitivity.ischeckpointing(
         InterpolatingAdjoint(checkpointing = true), soli
     )
 
-    # Gradient is still correct against an independent adjoint method, and the
-    # `checkpointing = true` request gives the same (non-checkpointed) result.
+    # Gradient is correct against an independent adjoint method, and the explicit
+    # `checkpointing = true` request gives the same result as the default.
     Random.seed!(seed)
     solb = solve(probr, RandomEM(); dt = dtr, save_noise = true, saveat = tr)
     du0b, dpb = adjoint_sensitivities(


### PR DESCRIPTION
## Problem

The `tests / SDE1` and `tests / SDE2` CI groups have been failing on `master` (all Julia versions) since `df654c61` (PR #1486, "Don't checkpoint linear-interpolation-only methods").

PR #1486 made `ischeckpointing(::InterpolatingAdjoint, sol)` return `false` for SDE/RODE solutions unconditionally — even when `checkpointing = true` is explicitly requested — on the premise that the per-interval re-solve "recovers nothing better than the stored linear interpolation, so it cannot change the adjoint gradient."

**That premise is wrong for SDE/RODE.** The checkpoint re-solve does not merely reconstruct the forward state for interpolation: it re-integrates each checkpoint interval driven by the *recorded forward noise* at the forward step size, so the reverse adjoint steps on the forward grid. With checkpointing disabled, the reverse SDE integrates at the coarse user `dt`, which materially degrades the gradient. The failing assertions are exactly the InterpolatingAdjoint-vs-BacksolveAdjoint comparisons:

- `test/SDE1/sde_scalar_stratonovich.jl:96` (rtol = 1e-4)
- `test/SDE1/sde_stratonovich.jl:85` (rtol = 1e-6)
- `test/SDE2/sde_nondiag_stratonovich.jl:764` (atol = 1e-14)

## Root cause of the original hang #1486 was fixing

The real bug #1486 addressed was a performance hang, not an accuracy issue: the SDE/RODE checkpoint path did `_sol = deepcopy(sol)` **once per reverse step** (O(N) copy × O(N) steps = O(N²); ~40 min, ~26e9 allocations on `test/SDE3/rode.jl`). That deepcopy was unnecessary — `NoiseWrapper`/`NoiseGrid` only hold a handle to `sol.W` and do not mutate it.

## Fix

- Revert `ischeckpointing(::InterpolatingAdjoint, sol)` to `alg.checkpointing || !sol.dense` (true for SDE/RODE, whose interpolation is linear so `sol.dense == false`).
- Restore the SDE/RODE checkpoint branches in the `ODEInterpolatingAdjointSensitivityFunction` constructor and in `split_states`, but build the forward `NoiseWrapper`/`NoiseGrid` and `tstops` directly from `sol`/`sol.W` instead of deep-copying the whole solution each step. Each cursor move is now O(interval) rather than O(N).
- Update the #1486 RODE regression testset to assert the restored (checkpointing-on) contract while keeping the gradient-correctness checks against `BacksolveAdjoint`.

## Local verification (Julia 1.12.6)

- `sde_scalar_stratonovich.jl`: 17/17 + 15/15 pass (was failing at `:96`).
- `sde_nondiag_stratonovich.jl` (SDE2): all testsets pass, exit 0 (was failing at `:764`).
- `sde_stratonovich.jl` `:85` mechanism: InterpolatingAdjoint vs BacksolveAdjoint now agree to rtol 2.5e-9 (was drifting past rtol = 1e-6).
- Rewritten RODE testset passes; gradients still match `BacksolveAdjoint`.
- **No hang:** heavy RODE problem (tspan (0, 5), dt = 1e-4, 50001-point noise grid) adjoint with checkpointing completes in ~1 s of runtime (20 s including compilation, 2.7 GiB) vs the former ~40 min — the O(N²) deepcopy is gone.

Please ignore until reviewed by @ChrisRackauckas.