### PR TITLE
Switch feedback_control tutorial outer AD from Zygote to Enzyme

### DIFF
--- a/docs/src/examples/optimal_control/feedback_control.md
+++ b/docs/src/examples/optimal_control/feedback_control.md
@@ -16,7 +16,7 @@ import Optimization as OPT
 import OptimizationPolyalgorithms as OPA
 import ComponentArrays as CA
 import SciMLSensitivity as SMS
-import Zygote
+import Enzyme
 import OrdinaryDiffEq as ODE
 import Plots
 import Random
@@ -89,7 +89,7 @@ end
 ```
 
 ```@example udeneuralcontrol
-adtype = OPT.AutoZygote()
+adtype = OPT.AutoEnzyme()
 optf = OPT.OptimizationFunction((x, p) -> loss_univ(x), adtype)
 optprob = OPT.OptimizationProblem(optf, θ)
 result_univ = OPT.solve(optprob, OPA.PolyOpt(), callback = cb)


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft.

Closes the actionable part of #1426.

## What

Switch the `feedback_control` UDE neural-control tutorial's **outer** AD from `AutoZygote` to `AutoEnzyme` (`import Zygote` → `import Enzyme`, `OPT.AutoZygote()` → `OPT.AutoEnzyme()`). Inner sensealg stays `InterpolatingAdjoint(ReverseDiffVJP(true))`.

## Why this is now possible

#1426 documented that this tutorial was stuck on Zygote because the optimization variable nests `u0` inside a larger ComponentVector (`θ = CA.ComponentArray(; u0, p_all)`), so `θ.p_all` is a **partial-cover `SubArray`-backed** sub-CV (positions 2:340 of length 340). When @wsmoses asked to re-check on the Enzyme path, Enzyme initially failed earlier, at the shared kwarg-NamedTuple bug ([EnzymeAD/Enzyme.jl#2212](https://github.com/EnzymeAD/Enzyme.jl/issues/2212)), so the partial-cover cotangent question couldn't even be reached.

As of **Enzyme 0.13.163** that bug is fixed, and re-evaluation ([comment](https://github.com/SciML/SciMLSensitivity.jl/issues/1426#issuecomment-4774988677)) shows the outer Enzyme path now works: Enzyme routes through the SciMLSensitivity adjoint rrule and aggregates the nested partial-cover ComponentVector cotangent into `θ` correctly.

## Verification (run locally)

Julia 1.11.9 / Enzyme 0.13.163 / SciMLSensitivity 7.112.0 / ComponentArrays 0.15.39 / Lux 1.31.4 / DifferentiationInterface 0.7.18.

- **Standalone gradient** — `AutoEnzyme` (runtime-activity and plain) and direct `Duplicated` all give a gradient **bit-identical** to the Zygote baseline (norm `9.298112700781726e11`).
- **Full tutorial path** — the exact code in this PR (`OPT.AutoEnzyme()` → `OPT.OptimizationFunction` → `OPT.solve(..., OPA.PolyOpt(), callback = cb)`) runs end to end and converges:

  ```
  initial loss = 0.83...
  ...
  FINAL objective = 6.61002284490735e-13
  retcode = Success
  ```

`Enzyme` is already a `docs/Project.toml` dependency (compat `0.12, 0.13`), so no manifest changes are required. `Zygote` stays in `docs/Project.toml` (still used by `SDE_control.md`).

## Out of scope (separate follow-up)

Inner `EnzymeVJP` (`InterpolatingAdjoint(autojacvec = EnzymeVJP())`) still errors on this nested partial-cover CV — but as a **SciMLSensitivity-side** type mismatch at `derivative_wrappers.jl:1035` (`Duplicated(p, _sp)` with a `SubArray`-backed primal and a `Vector`-backed shadow), not an Enzyme or Mooncake-aggregation bug. The tutorial doesn't use inner `EnzymeVJP`, so it's unaffected; details in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
