### PR TITLE
Enzyme: restore Enzyme-native init-sensitivity gradient (gate on Enzyme ≥ 0.13.163)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.112.2"
+version = "7.112.3"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]
@@ -73,7 +73,7 @@ DiffEqNoiseProcess = "5.32"
 DifferentiationInterface = "0.7.17"
 Distributed = "1"
 Distributions = "0.25.127"
-Enzyme = "0.13.162"
+Enzyme = "0.13.163"
 ExplicitImports = "1"
 FastBroadcast = "1.3.2"
 FiniteDiff = "2.31"

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -356,26 +356,37 @@ function _init_originator_gradient(::SciMLBase.ADOriginator, f, tunables)
     return back(one(iy))[1]
 end
 
-# Init-path gradient for the `EnzymeOriginator` (outer-Enzyme) case.
+# Enzyme-native init-path gradient. `Const(f)` is required because the
+# closure built by the caller captures references to `_prob` / `repack` /
+# `kwargs_init`, which Enzyme would otherwise reject with
+# `EnzymeMutabilityException` ("Function argument passed to autodiff
+# cannot be proven readonly").
 #
-# This runs in the adjoint backpass of the `solve` rrule — ordinary primal code
-# inside the outer Enzyme reverse pass that is NOT itself differentiated by
-# Enzyme — so a Zygote pullback here is safe and yields the same result as the
-# generic `ADOriginator` fallback above.
-#
-# It deliberately does NOT use a nested `Enzyme.gradient` for the init step. A
-# nested Enzyme reverse pass (under `set_runtime_activity`) inside the outer
-# Enzyme reverse pass corrupts Enzyme's global compilation/runtime state: the
-# first outer `Enzyme.autodiff` call succeeds, but every subsequent call on the
-# same (or a related) MTK DAE-initialization problem throws
-# `LinearAlgebra.SingularException` out of the semi-explicit DAE adjoint. Routing
-# the init gradient through Zygote removes that nesting, so repeated and
-# multi-problem outer-Enzyme differentiation through MTK DAE init works (the init
-# sub-VJP it calls may still be `EnzymeVJP`; only the outer init differentiation
-# is moved off Enzyme). See #1415 for the prior Enzyme-native attempt.
+# This nests an `Enzyme.gradient` reverse pass for the init step inside the
+# outer Enzyme reverse pass. That nesting previously corrupted Enzyme's global
+# compilation/runtime state (the first outer `Enzyme.autodiff` succeeded but
+# every subsequent call through an MTK DAE-init problem threw
+# `LinearAlgebra.SingularException` out of the semi-explicit DAE adjoint), so
+# #1467 routed this through Zygote as a workaround. The root cause was an
+# upstream Enzyme bug in nested reverse-over-BLAS under `set_runtime_activity`
+# (EnzymeAD/Enzyme.jl#3139), fixed in Enzyme 0.13.163 — which the `[compat]`
+# lower bound now requires. With that fix the Enzyme-native path is correct and
+# repeatable, so the init differentiation no longer pulls in Zygote when Enzyme
+# is the outer AD. See #1415 and #1469.
 function _init_originator_gradient(::SciMLBase.EnzymeOriginator, f, tunables)
-    iy, back = Zygote.pullback(f, tunables)
-    return back(one(iy))[1]
+    # `f` differentiates an MTK DAE initialization. Inside it,
+    # `remake(_prob, p = repack(t))` builds one `ODEProblem` allocation mixing
+    # constant memory (the captured `_prob`'s `u0`/`f`/`tspan`/caches) with active
+    # memory (the new parameters) — a partially-active object that Enzyme's static
+    # activity analysis rejects ("constant memory stored to a differentiable
+    # variable", inside `remake`, not the let-captured config). Dropping this
+    # re-raises EnzymeRuntimeActivityError; `set_runtime_activity` is Enzyme's
+    # correctness-preserving fix (the gradient still matches ForwardDiff). A static
+    # fix would need `remake`/SciMLBase to stop aliasing constant structure into
+    # the active problem.
+    return Enzyme.gradient(
+        Enzyme.set_runtime_activity(Enzyme.Reverse), Enzyme.Const(f), tunables,
+    )[1]
 end
 
 function SciMLBase._concrete_solve_adjoint(

--- a/test/Core8/mtk.jl
+++ b/test/Core8/mtk.jl
@@ -176,8 +176,9 @@ setups = [
 # mismatch, and the `NonlinearSolvePolyAlgorithm` runtime-activity assertion) are
 # fixed in NonlinearSolveBase (`inactive_kwarg`, the `within_autodiff` wrap-skip,
 # and `inactive_type`); and the repeated-call state corruption caused by a nested
-# `Enzyme.gradient` in the init sensitivity is fixed in this PR by routing
-# `_init_originator_gradient(::EnzymeOriginator)` through Zygote.
+# `Enzyme.gradient` in the init sensitivity (`_init_originator_gradient(::EnzymeOriginator)`)
+# is fixed upstream in Enzyme 0.13.163 (EnzymeAD/Enzyme.jl#3139), which the
+# `[compat]` lower bound now requires, so that path is Enzyme-native again (#1469).
 #
 # The inner VJP is `ReverseDiffVJP`, not `EnzymeVJP`: `EnzymeVJP._vecjacobian!`
 # runs a *nested* `Enzyme.autodiff` on the MTK-generated DAE RHS, which both


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft, opened by an agent.

Closes the SciMLSensitivity side of #1469.

## What

Reverts the #1467 workaround that routed `_init_originator_gradient(::EnzymeOriginator)` through `Zygote.pullback`, restoring the **Enzyme-native** nested-gradient init path:

```julia
Enzyme.gradient(Enzyme.set_runtime_activity(Enzyme.Reverse), Enzyme.Const(f), tunables)[1]
```

The revert is **gated** by raising the Enzyme `[compat]` lower bound `0.13.162 → 0.13.163`.

## Why

#1467 worked around an upstream Enzyme bug (#1469): a nested `Enzyme.gradient` reverse pass for the MTK DAE init step, run inside the outer Enzyme reverse pass under `set_runtime_activity`, corrupted Enzyme's global compilation/runtime state — the *first* outer `Enzyme.autodiff` through an MTK DAE-init problem succeeded, but every subsequent call threw `LinearAlgebra.SingularException` out of the semi-explicit DAE adjoint.

That was isolated to a pure-Enzyme nested-reverse-over-BLAS MWE and **fixed upstream in Enzyme 0.13.163** ([EnzymeAD/Enzyme.jl#3139](https://github.com/EnzymeAD/Enzyme.jl/issues/3139)). With the fix, the Enzyme-native path is correct and repeatable, so the init differentiation no longer pulls Zygote into the Enzyme path (cf. #1415).

## Changes

- **`src/concrete_solve.jl`** — `_init_originator_gradient(::SciMLBase.EnzymeOriginator, …)` back to the Enzyme-native nested `Enzyme.gradient`, with an updated comment pointing at the upstream fix.
- **`Project.toml`** — Enzyme compat `0.13.162 → 0.13.163` (the gate); package version `7.112.2 → 7.112.3`.
- **`test/Core8/mtk.jl`** — updated the stale comment that described the Zygote routing. The 15-setup Enzyme-outer DAE-init sweep is unchanged and stays the regression guard (inner VJP remains `ReverseDiffVJP`; the EnzymeVJP-inner nesting is a separate follow-up).

## Verification (local, Julia 1.11.9, Enzyme 0.13.164)

Ran `test/Core8/mtk.jl` against a local checkout with this change:

- **15/15-setup Enzyme-outer sweep passes** — consistent gradient across all `CheckInit` / `BrownFullBasicInit` / `DefaultInit` / `NoInit` / `OverrideInit` / overdetermined setups (the first `@test`). This is the exact repeated-call path that previously hit iter-1-OK-then-`SingularException`.
- **Mooncake nonzero-gradient check passes** (the second `@test`).
- 0 failure/error markers in the run.

One environment note that does **not** involve this change: a same-process run with `DiffEqBase 7.5.6` + the current latest `OrdinaryDiffEqCore` failed in the **forward-solve callback path** with `type ODEIntegrator has no field user_set_discontinuity` (an unrelated DiffEqBase/OrdinaryDiffEqCore field skew, before `_init_originator_gradient` is ever reached). Pinning `DiffEqBase 7.5.5` (still within this package's `≥ 7.5.5` compat) gives a consistent env where the change is exercised cleanly. Flagging separately so it can be tracked upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
