### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/test/QA/aqua.jl
+++ b/test/QA/aqua.jl
@@ -36,22 +36,21 @@ run_qa(
                 :BrownFullBasicInit, :DefaultInit, :default_nlsolve, :has_autodiff,
                 # SciMLBase
                 :AbstractAdjointSensitivityAlgorithm, :AbstractDiffEqFunction,
-                :AbstractForwardSensitivityAlgorithm, :AbstractNonlinearProblem,
-                :AbstractODEFunction, :AbstractOptimizationProblem,
-                :AbstractOverloadingSensitivityAlgorithm,
+                :AbstractForwardSensitivityAlgorithm, :AbstractODEFunction,
+                :AbstractOptimizationProblem, :AbstractOverloadingSensitivityAlgorithm,
                 :AbstractSecondOrderSensitivityAlgorithm, :AbstractSensitivityAlgorithm,
                 :AbstractShadowingSensitivityAlgorithm, :AbstractTimeseriesSolution,
                 :OverrideInit, :unwrapped_f,
                 # SciMLStructures
                 :Tunable, :canonicalize, :isscimlstructure,
-                # SciMLSensitivityMooncakeExt: imports of the parent's own
-                # (non-public) internals + names re-imported through the parent.
-                :DiffEqBase, :FakeIntegrator, :FunctionWrappersWrappers,
-                :MooncakeLoaded, :MooncakeVJP, :ODEFunction, :SciMLBase,
-                :SciMLStructures, :SciMLStructuresCompatibilityError,
-                :_init_originator_gradient, :convert_tspan, :current_time,
-                :get_cb_paramjac_config, :get_paramjac_config,
-                :has_continuous_callback, :mooncake_run_ad, :state_values,
+                # SciMLSensitivityMooncakeExt: the parent's own (non-public) internals
+                # + names re-imported through the parent module.
+                :DiffEqBase, :FakeIntegrator, :FunctionWrappersWrappers, :MooncakeLoaded,
+                :MooncakeVJP, :ODEFunction, :SciMLBase, :SciMLStructures,
+                :SciMLStructuresCompatibilityError, :_init_originator_gradient,
+                :convert_tspan, :current_time, :get_cb_paramjac_config,
+                :get_paramjac_config, :has_continuous_callback, :mooncake_run_ad,
+                :state_values,
             ),
         ),
         # Non-public names of upstream deps accessed qualified in the source; ignore
@@ -59,15 +58,19 @@ run_qa(
         all_qualified_accesses_are_public = (;
             ignore = (
                 # ArrayInterface
-                :aos_to_soa, :ismutable, :parameterless_type, :restructure,
+                :parameterless_type,
                 # Base
                 :(var"@pure"), :_nt_names, :diff_names,
                 # DiffEqCallbacks
                 :PeriodicCallbackAffect,
                 # DiffEqNoiseProcess
                 :vec_NoiseProcess,
-                # Enzyme / EnzymeCore / EnzymeCore.EnzymeRules
-                :EnzymeCore, :Mode, :inactive_type,
+                # Enzyme
+                :EnzymeCore,
+                # EnzymeCore
+                :Mode,
+                # EnzymeCore.EnzymeRules
+                :inactive_type,
                 # FiniteDiff
                 :DerivativeCache, :GradientCache, :JacobianCache,
                 :finite_difference_derivative!, :finite_difference_gradient!,
@@ -78,26 +81,28 @@ run_qa(
                 :jacobian!, :npartials, :partials, :pickchunksize, :value,
                 # LinearSolve
                 :needs_concrete_A,
+                # Mooncake (accessed in SciMLSensitivityMooncakeExt)
+                :CoDual, :NoFData, :Tangent, :build_rrule, :tangent_to_primal!!,
+                :zero_rdata,
                 # OrdinaryDiffEqCore
                 :alg_autodiff, :default_linear_interpolation,
                 # ReverseDiff
-                :GradientTape, :TrackedArray, :compile, :deriv, :forward_pass!,
-                :gradient, :increment_deriv!, :input_hook, :output_hook, :pull_value!,
-                :reverse_pass!, :unseed!, :value!,
+                :GradientTape, :TrackedArray, :compile, :deriv, :forward_pass!, :gradient,
+                :increment_deriv!, :input_hook, :output_hook, :pull_value!, :reverse_pass!,
+                :unseed!, :value, :value!,
                 # SciMLBase
                 :ADOriginator, :AbstractDAEProblem, :AbstractDDEProblem,
-                :AbstractDiscreteProblem, :AbstractODEProblem, :AbstractRODEProblem,
-                :AbstractSDDEProblem, :AbstractSDEProblem, :AbstractSciMLFunction,
-                :AlgorithmInterpretation, :AutoSpecialize, :ChainRulesOriginator,
-                :EnzymeOriginator, :FullSpecialize, :ImmutableNonlinearProblem,
-                :MooncakeOriginator, :NullParameters, :OVERDETERMINED, :OverrideInit,
-                :ParamJacobianWrapper, :ReverseDiffOriginator, :TrackerOriginator,
-                :UDerivativeWrapper, :UJacobianWrapper, :Void,
+                :AbstractDiscreteProblem, :AbstractRODEProblem, :AbstractSDDEProblem,
+                :AbstractSDEProblem, :AbstractSciMLFunction, :AlgorithmInterpretation,
+                :ChainRulesOriginator, :EnzymeOriginator, :FullSpecialize,
+                :ImmutableNonlinearProblem, :MooncakeOriginator, :OVERDETERMINED,
+                :OverrideInit, :ParamJacobianWrapper, :ReverseDiffOriginator,
+                :TrackerOriginator, :UDerivativeWrapper, :UJacobianWrapper, :Void,
                 :_concrete_solve_adjoint, :_concrete_solve_forward, :alg_interpretation,
-                :build_solution, :forwarddiffs_model, :forwarddiffs_model_time,
-                :get_initial_values, :has_initialization_data, :has_jac, :has_observed,
-                :has_paramjac, :has_vjp, :has_vjp_p, :initialization_status,
-                :is_diagonal_noise, :sensitivity_solution, :specialization,
+                :forwarddiffs_model, :forwarddiffs_model_time, :get_initial_values,
+                :has_initialization_data, :has_observed, :has_paramjac, :has_vjp_p,
+                :initialization_status, :is_diagonal_noise, :sensitivity_solution,
+                :specialization,
                 # SciMLStructures
                 :replace,
                 # SparseArrays
@@ -106,13 +111,6 @@ run_qa(
                 :TrackedReal, :collect, :data, :forward,
                 # Zygote
                 :Buffer, :accum,
-                # Mooncake (accessed in SciMLSensitivityMooncakeExt)
-                :CoDual, :NoFData, :Tangent, :build_rrule,
-                :tangent_to_primal!!, :zero_rdata,
-                # Flagged only on Julia LTS (1.10); public on 1.11+:
-                :Fix1, :Fix2, :depwarn,             # Base
-                :Stratonovich, :Terminated,         # SciMLBase enum modules
-                :children, :functor,                # Functors
             ),
         ),
     ),

--- a/test/QA/aqua.jl
+++ b/test/QA/aqua.jl
@@ -43,6 +43,17 @@ run_qa(
                 :unwrapped_f,
                 # SciMLStructures
                 :Tunable, :canonicalize, :isscimlstructure,
+                # SciMLSensitivityMooncakeExt re-imports these internal/non-public
+                # names through the parent module (`using/import SciMLSensitivity: ...`),
+                # the intentional extension idiom. They are SciMLSensitivity internals
+                # or deps re-exported by the parent, so they are not public in
+                # SciMLSensitivity and never will be.
+                :DiffEqBase, :FakeIntegrator, :FunctionWrappersWrappers, :MooncakeLoaded,
+                :MooncakeVJP, :ODEFunction, :SciMLBase, :SciMLStructures,
+                :SciMLStructuresCompatibilityError, :_init_originator_gradient,
+                :convert_tspan, :current_time, :get_cb_paramjac_config,
+                :get_paramjac_config, :has_continuous_callback, :mooncake_run_ad,
+                :state_values,
             ),
         ),
         # Non-public names of upstream deps accessed qualified in the source; ignore
@@ -73,6 +84,9 @@ run_qa(
                 :jacobian!, :npartials, :partials, :pickchunksize, :value,
                 # LinearSolve
                 :needs_concrete_A,
+                # Mooncake (internal tangent/rrule API used by SciMLSensitivityMooncakeExt)
+                :CoDual, :NoFData, :Tangent, :build_rrule, :tangent_to_primal!!,
+                :zero_rdata,
                 # OrdinaryDiffEqCore
                 :alg_autodiff, :default_linear_interpolation,
                 # ReverseDiff

--- a/test/QA/aqua.jl
+++ b/test/QA/aqua.jl
@@ -1,34 +1,119 @@
-using SciMLSensitivity, Aqua, SciMLBase, ExplicitImports
+using SciMLTesting, SciMLSensitivity, SciMLBase, Test
 
-@testset "Aqua" begin
-    # find_persistent_tasks_deps may fail on Julia 1.12+ due to OrdinaryDiffEqCore's
-    # [sources] section containing monorepo-relative paths that don't resolve when
-    # the package is installed from the registry.
-    try
-        Aqua.find_persistent_tasks_deps(SciMLSensitivity)
-    catch e
-        @warn "Aqua.find_persistent_tasks_deps failed (likely upstream [sources] issue)" exception = e
-    end
-    Aqua.test_ambiguities(SciMLSensitivity, recursive = false)
-    Aqua.test_deps_compat(SciMLSensitivity)
-    Aqua.test_piracies(
-        SciMLSensitivity;
-        treat_as_own = [
-            SciMLBase._concrete_solve_adjoint,
-            SciMLBase._concrete_solve_forward,
-        ]
-    )
-    Aqua.test_project_extras(SciMLSensitivity)
-    Aqua.test_stale_deps(SciMLSensitivity)
-    Aqua.test_unbound_args(SciMLSensitivity)
-    Aqua.test_undefined_exports(SciMLSensitivity)
-end
-
-@testset "ExplicitImports" begin
-    @test ExplicitImports.check_no_implicit_imports(
-        SciMLSensitivity; skip = (Base, Core, SciMLBase)
-    ) === nothing
-    @test ExplicitImports.check_no_stale_explicit_imports(SciMLSensitivity) === nothing
-    @test ExplicitImports.check_all_qualified_accesses_via_owners(SciMLSensitivity) ===
-        nothing
-end
+run_qa(
+    SciMLSensitivity;
+    explicit_imports = true,
+    aqua_kwargs = (;
+        ambiguities = (; recursive = false),
+        piracies = (;
+            treat_as_own = [
+                SciMLBase._concrete_solve_adjoint,
+                SciMLBase._concrete_solve_forward,
+            ],
+        ),
+    ),
+    ei_kwargs = (;
+        # `BrownFullBasicInit`/`DefaultInit` are owned by DiffEqBase but re-exported
+        # through OrdinaryDiffEqCore, which is where SciMLSensitivity imports them.
+        # The rest are re-imported through the parent `SciMLSensitivity` by the
+        # Mooncake extension (`using SciMLSensitivity: ...`), an intentional idiom.
+        all_explicit_imports_via_owners = (;
+            ignore = (
+                :BrownFullBasicInit, :DefaultInit,
+                # SciMLSensitivityMooncakeExt: re-imported through the parent module
+                :DiffEqBase, :FunctionWrappersWrappers, :ODEFunction, :SciMLBase,
+                :SciMLStructures, :Tunable, :canonicalize, :current_time,
+                :isscimlstructure, :state_values, :unwrapped_f,
+            ),
+        ),
+        # Non-public names of upstream deps imported explicitly here; ignore until
+        # those packages mark them public (each grouped by its source package).
+        all_explicit_imports_are_public = (;
+            ignore = (
+                # ChainRulesCore
+                :AbstractTangent,
+                # OrdinaryDiffEqCore
+                :BrownFullBasicInit, :DefaultInit, :default_nlsolve, :has_autodiff,
+                # SciMLBase
+                :AbstractAdjointSensitivityAlgorithm, :AbstractDiffEqFunction,
+                :AbstractForwardSensitivityAlgorithm, :AbstractNonlinearProblem,
+                :AbstractODEFunction, :AbstractOptimizationProblem,
+                :AbstractOverloadingSensitivityAlgorithm,
+                :AbstractSecondOrderSensitivityAlgorithm, :AbstractSensitivityAlgorithm,
+                :AbstractShadowingSensitivityAlgorithm, :AbstractTimeseriesSolution,
+                :OverrideInit, :unwrapped_f,
+                # SciMLStructures
+                :Tunable, :canonicalize, :isscimlstructure,
+                # SciMLSensitivityMooncakeExt: imports of the parent's own
+                # (non-public) internals + names re-imported through the parent.
+                :DiffEqBase, :FakeIntegrator, :FunctionWrappersWrappers,
+                :MooncakeLoaded, :MooncakeVJP, :ODEFunction, :SciMLBase,
+                :SciMLStructures, :SciMLStructuresCompatibilityError,
+                :_init_originator_gradient, :convert_tspan, :current_time,
+                :get_cb_paramjac_config, :get_paramjac_config,
+                :has_continuous_callback, :mooncake_run_ad, :state_values,
+            ),
+        ),
+        # Non-public names of upstream deps accessed qualified in the source; ignore
+        # until those packages mark them public (each grouped by its source package).
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                # ArrayInterface
+                :aos_to_soa, :ismutable, :parameterless_type, :restructure,
+                # Base
+                :(var"@pure"), :_nt_names, :diff_names,
+                # DiffEqCallbacks
+                :PeriodicCallbackAffect,
+                # DiffEqNoiseProcess
+                :vec_NoiseProcess,
+                # Enzyme / EnzymeCore / EnzymeCore.EnzymeRules
+                :EnzymeCore, :Mode, :inactive_type,
+                # FiniteDiff
+                :DerivativeCache, :GradientCache, :JacobianCache,
+                :finite_difference_derivative!, :finite_difference_gradient!,
+                :finite_difference_jacobian, :finite_difference_jacobian!,
+                # ForwardDiff
+                :Chunk, :DerivativeConfig, :Dual, :GradientConfig, :JacobianConfig,
+                :Partials, :Tag, :construct_seeds, :derivative!, :gradient!, :jacobian,
+                :jacobian!, :npartials, :partials, :pickchunksize, :value,
+                # LinearSolve
+                :needs_concrete_A,
+                # OrdinaryDiffEqCore
+                :alg_autodiff, :default_linear_interpolation,
+                # ReverseDiff
+                :GradientTape, :TrackedArray, :compile, :deriv, :forward_pass!,
+                :gradient, :increment_deriv!, :input_hook, :output_hook, :pull_value!,
+                :reverse_pass!, :unseed!, :value!,
+                # SciMLBase
+                :ADOriginator, :AbstractDAEProblem, :AbstractDDEProblem,
+                :AbstractDiscreteProblem, :AbstractODEProblem, :AbstractRODEProblem,
+                :AbstractSDDEProblem, :AbstractSDEProblem, :AbstractSciMLFunction,
+                :AlgorithmInterpretation, :AutoSpecialize, :ChainRulesOriginator,
+                :EnzymeOriginator, :FullSpecialize, :ImmutableNonlinearProblem,
+                :MooncakeOriginator, :NullParameters, :OVERDETERMINED, :OverrideInit,
+                :ParamJacobianWrapper, :ReverseDiffOriginator, :TrackerOriginator,
+                :UDerivativeWrapper, :UJacobianWrapper, :Void,
+                :_concrete_solve_adjoint, :_concrete_solve_forward, :alg_interpretation,
+                :build_solution, :forwarddiffs_model, :forwarddiffs_model_time,
+                :get_initial_values, :has_initialization_data, :has_jac, :has_observed,
+                :has_paramjac, :has_vjp, :has_vjp_p, :initialization_status,
+                :is_diagonal_noise, :sensitivity_solution, :specialization,
+                # SciMLStructures
+                :replace,
+                # SparseArrays
+                :AbstractSparseMatrixCSC,
+                # Tracker
+                :TrackedReal, :collect, :data, :forward,
+                # Zygote
+                :Buffer, :accum,
+                # Mooncake (accessed in SciMLSensitivityMooncakeExt)
+                :CoDual, :NoFData, :Tangent, :build_rrule,
+                :tangent_to_primal!!, :zero_rdata,
+                # Flagged only on Julia LTS (1.10); public on 1.11+:
+                :Fix1, :Fix2, :depwarn,             # Base
+                :Stratonovich, :Terminated,         # SciMLBase enum modules
+                :children, :functor,                # Functors
+            ),
+        ),
+    ),
+)

--- a/test/QA/aqua.jl
+++ b/test/QA/aqua.jl
@@ -35,22 +35,14 @@ run_qa(
                 # OrdinaryDiffEqCore
                 :BrownFullBasicInit, :DefaultInit, :default_nlsolve, :has_autodiff,
                 # SciMLBase
-                :AbstractAdjointSensitivityAlgorithm, :AbstractDiffEqFunction,
-                :AbstractForwardSensitivityAlgorithm, :AbstractODEFunction,
-                :AbstractOptimizationProblem, :AbstractOverloadingSensitivityAlgorithm,
+                :AbstractAdjointSensitivityAlgorithm,
+                :AbstractForwardSensitivityAlgorithm, :AbstractOptimizationProblem,
+                :AbstractOverloadingSensitivityAlgorithm,
                 :AbstractSecondOrderSensitivityAlgorithm, :AbstractSensitivityAlgorithm,
                 :AbstractShadowingSensitivityAlgorithm, :AbstractTimeseriesSolution,
-                :OverrideInit, :unwrapped_f,
+                :unwrapped_f,
                 # SciMLStructures
                 :Tunable, :canonicalize, :isscimlstructure,
-                # SciMLSensitivityMooncakeExt: the parent's own (non-public) internals
-                # + names re-imported through the parent module.
-                :DiffEqBase, :FakeIntegrator, :FunctionWrappersWrappers, :MooncakeLoaded,
-                :MooncakeVJP, :ODEFunction, :SciMLBase, :SciMLStructures,
-                :SciMLStructuresCompatibilityError, :_init_originator_gradient,
-                :convert_tspan, :current_time, :get_cb_paramjac_config,
-                :get_paramjac_config, :has_continuous_callback, :mooncake_run_ad,
-                :state_values,
             ),
         ),
         # Non-public names of upstream deps accessed qualified in the source; ignore
@@ -81,9 +73,6 @@ run_qa(
                 :jacobian!, :npartials, :partials, :pickchunksize, :value,
                 # LinearSolve
                 :needs_concrete_A,
-                # Mooncake (accessed in SciMLSensitivityMooncakeExt)
-                :CoDual, :NoFData, :Tangent, :build_rrule, :tangent_to_primal!!,
-                :zero_rdata,
                 # OrdinaryDiffEqCore
                 :alg_autodiff, :default_linear_interpolation,
                 # ReverseDiff
@@ -91,18 +80,14 @@ run_qa(
                 :increment_deriv!, :input_hook, :output_hook, :pull_value!, :reverse_pass!,
                 :unseed!, :value, :value!,
                 # SciMLBase
-                :ADOriginator, :AbstractDAEProblem, :AbstractDDEProblem,
-                :AbstractDiscreteProblem, :AbstractRODEProblem, :AbstractSDDEProblem,
-                :AbstractSDEProblem, :AbstractSciMLFunction, :AlgorithmInterpretation,
-                :ChainRulesOriginator, :EnzymeOriginator, :FullSpecialize,
-                :ImmutableNonlinearProblem, :MooncakeOriginator, :OVERDETERMINED,
-                :OverrideInit, :ParamJacobianWrapper, :ReverseDiffOriginator,
+                :ADOriginator, :AbstractRODEProblem, :AbstractSDDEProblem,
+                :AlgorithmInterpretation, :ChainRulesOriginator, :EnzymeOriginator,
+                :FullSpecialize, :ImmutableNonlinearProblem, :MooncakeOriginator,
+                :OVERDETERMINED, :ParamJacobianWrapper, :ReverseDiffOriginator,
                 :TrackerOriginator, :UDerivativeWrapper, :UJacobianWrapper, :Void,
                 :_concrete_solve_adjoint, :_concrete_solve_forward, :alg_interpretation,
-                :forwarddiffs_model, :forwarddiffs_model_time, :get_initial_values,
                 :has_initialization_data, :has_observed, :has_paramjac, :has_vjp_p,
-                :initialization_status, :is_diagonal_noise, :sensitivity_solution,
-                :specialization,
+                :initialization_status, :sensitivity_solution, :specialization,
                 # SciMLStructures
                 :replace,
                 # SparseArrays


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts `test/QA/aqua.jl` to the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled (`explicit_imports = true`, all 6 checks).

## Aqua
Preserved the genuine per-repo tweaks:
- `piracies = (; treat_as_own = [SciMLBase._concrete_solve_adjoint, SciMLBase._concrete_solve_forward])`
- `ambiguities = (; recursive = false)`

The old `find_persistent_tasks_deps` `try`/`catch` workaround is removed. `run_qa`'s `clean_sources = true` (default) strips broken monorepo `[sources]` for the duration of the persistent-tasks check, so that check now runs for real (no swallowed error) and passes.

## ExplicitImports
No `@test_broken`, no `ei_broken`, no hard FAIL — all six checks pass or are satisfied by per-check ignore-lists of upstream/extension non-public names.

- **no_implicit_imports** — pass
- **no_stale_explicit_imports** — pass
- **all_qualified_accesses_via_owners** — pass
- **all_explicit_imports_via_owners** — `BrownFullBasicInit`/`DefaultInit` (DiffEqBase-owned, re-exported via OrdinaryDiffEqCore) + the names the Mooncake extension re-imports through the parent module (`using SciMLSensitivity: DiffEqBase, SciMLBase, ...`). Ignored.
- **all_qualified_accesses_are_public** — ~114 foreign non-public names accessed qualified in the source (SciMLBase originators/abstract types, ForwardDiff/ReverseDiff/FiniteDiff/Tracker/Zygote internals, Mooncake internals in the extension, a few Base/Functors names flagged only on LTS). Ignored, grouped by source package.
- **all_explicit_imports_are_public** — ~38 non-public explicit imports (SciMLBase/SciMLStructures/OrdinaryDiffEqCore/ChainRulesCore internals + the Mooncake extension's imports of the parent's own non-public internals). Ignored.

These are deliberate reach-into-internals that SciMLSensitivity needs as an AD-glue package; they will auto-clear from the ignore-lists once those upstream packages declare the names public.

## Deps
- `SciMLTesting` compat `"1"` -> `"1.6"`
- drop `ExplicitImports` from `[extras]`/`[targets].test`/`[compat]` (now transitive via SciMLTesting)
- keep `Aqua` as a direct test dep (the `ambiguities` sub-check spawns a child process that needs it)

## Verification
Ran the QA group via `GROUP=QA` `Pkg.test()` against released SciMLTesting 1.6.0 (resolves cleanly, no dev-from-branch):
- **Julia 1.11**: `Quality Assurance | 17 17` — all pass, 0 fail / 0 error / 0 broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
