### PR TITLE
Restore SDE/RODE InterpolatingAdjoint accuracy via grid tstops (fix #1486 regression)

### DIFF
--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -475,7 +475,16 @@ function _adjoint_sensitivities(
         error("Continuous adjoint sensitivities are only supported for ODE/SDE/RODE problems.")
     end
 
-    tstops = ischeckpointing(sensealg, sol) ? checkpoints : similar(current_time(sol), 0)
+    # SDE/RODE solutions only carry a linear interpolation, so they are never
+    # checkpointed (re-solving an interval recovers nothing better than the saved
+    # trajectory). Their reverse adjoint must nevertheless step on the saved
+    # grid: integrating it at a coarser, requested `dt` resolves the driving
+    # noise increments too coarsely and the gradient drifts. Forcing `tstops` at
+    # the checkpoints restores the accuracy the per-interval re-solve used to
+    # provide (removed in #1486), without its O(N^2) per-step `deepcopy`.
+    needs_grid_tstops = ischeckpointing(sensealg, sol) ||
+        sol.prob isa Union{SDEProblem, RODEProblem}
+    tstops = needs_grid_tstops ? checkpoints : similar(current_time(sol), 0)
     adj_sol = solve(
         adj_prob, alg;
         save_everystep = false, save_start = false, saveat = eltype(state_values(sol, 1))[],

--- a/test/SDE3/rode.jl
+++ b/test/SDE3/rode.jl
@@ -710,3 +710,38 @@ end
     @test du0c ≈ du0i
     @test dpc ≈ dpi
 end
+
+@testset "InterpolatingAdjoint RODE coarse-adjoint-dt accuracy" begin
+    # Regression for the SDE/RODE InterpolatingAdjoint accuracy loss from #1486.
+    # Disabling checkpointing also stopped forcing the reverse adjoint to step on
+    # the saved grid, so with an adjoint `dt` coarser than the forward grid the
+    # adjoint SDE was integrated too coarsely and the gradient drifted away from
+    # the reference. The grid is now restored via `tstops` (still without the
+    # O(N^2) per-interval re-solve), so the coarse-`dt` gradient matches again.
+    function frep(du, u, p, t, W)
+        du[1] = p[1] * u[1] * sin(W[1])
+        return nothing
+    end
+    u0r = [1.0]
+    tspanr = (0.0, 0.2)
+    fwd_dt = 1.0e-3
+    coarse_dt = 1.0e-2            # 10x coarser reverse step than the saved grid
+    tr = tspanr[1]:0.02:tspanr[2]
+    pr = [1.5]
+    probr = RODEProblem(frep, u0r, tspanr, pr)
+
+    Random.seed!(seed)
+    sol = solve(probr, RandomEM(); dt = fwd_dt, save_noise = true, dense = true)
+
+    du0b, dpb = adjoint_sensitivities(
+        sol, RandomEM(); t = Array(tr), dgdu_discrete = dg!,
+        dt = fwd_dt, adaptive = false, sensealg = BacksolveAdjoint()
+    )
+    du0i, dpi = adjoint_sensitivities(
+        sol, RandomEM(); t = Array(tr), dgdu_discrete = dg!,
+        dt = coarse_dt, adaptive = false,
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    )
+    @test du0i ≈ du0b rtol = 1.0e-4
+    @test dpi ≈ dpb rtol = 1.0e-4
+end


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

## What this fixes

#1486 disabled checkpointing for SDE/RODE `InterpolatingAdjoint`/`Gauss*Adjoint` to remove an O(N²) per-step `deepcopy` that hung the SDE3/RODE tests. That was the right call for the cost problem, but `ischeckpointing` *also* gated the reverse adjoint's `tstops` (`src/sensitivity_interface.jl:478`). Turning checkpointing off therefore stopped forcing the reverse solve onto the saved grid.

When the adjoint `dt` is coarser than the forward grid, the reverse adjoint SDE is then integrated too coarsely — its driving noise increments are only resolved at the saved grid — and the gradient drifts. This left `master` red on the `SDE1`/`SDE2` groups (flagged in https://github.com/SciML/SciMLSensitivity.jl/issues/1488#issuecomment-4752809472):

| file:line | assertion | err on master |
|---|---|---|
| `SDE1/sde_scalar_stratonovich.jl:96` | `res_sde_p ≈ res_sde_p2 rtol=1e-4` | relerr 1.0e-3 (was 2.8e-5) |
| `SDE1/sde_stratonovich.jl:85` | `res_sde_p ≈ res_sde_pa rtol=1e-6` | ~6e-6 |
| `SDE2/sde_nondiag_stratonovich.jl:764` | `≈ res_sde_p' atol=1e-14` | ~1.4e-13 |

This is genuine accuracy loss, not FP reassociation: against ForwardDiff/`BacksolveAdjoint` the regressed gradient is ~30× further from the reference, so the tolerances must **not** be loosened.

## Root cause (verified empirically)

The accuracy difference between the old (checkpointing-on) and new (off) paths is **not** the per-interval state re-solve — it's the `tstops`. On a clean checkout:

- Parent `2d13e8ec` (checkpointing on): `ischeckpointing == true` → `tstops = checkpoints` → scalar relerr vs Backsolve **2.78e-5** (passes).
- `df654c61`/#1486 (off): `tstops` empty → reverse steps at the coarse requested `dt` → relerr **1.0e-3** (fails).

## The fix

Decouple the two concerns. SDE/RODE are **still never checkpointed** (no per-interval re-solve, no `deepcopy`, so the #1486 hang cannot return), but their reverse adjoint is again stepped on the saved grid by passing `tstops = checkpoints`:

```julia
needs_grid_tstops = ischeckpointing(sensealg, sol) ||
                    sol.prob isa Union{SDEProblem, RODEProblem}
tstops = needs_grid_tstops ? checkpoints : similar(current_time(sol), 0)
```

This restores the previous accuracy **bit-for-bit** (scalar case back to relerr 2.78e-5) with none of the O(N²) cost — the only added work is the extra reverse steps the checkpointed path already performed.

## Tests (run locally, Julia 1.10 / lts)

- `SDE1`: `sde_stratonovich` (7/7, 33/33, 28+1 pre-existing broken, 1/1, 2/2), `sde_scalar_stratonovich` (17/17, 15/15), `sde_checkpointing` (10/10) — **all pass** (were red before).
- `SDE2`: `sde_nondiag_stratonovich` (22/22, 32/32, 14/14, 6+1 broken, 5/5, 2/2) — **all pass** (incl. the `atol=1e-14` case).
- `SDE3`: `rode.jl` **~5.7 min, no hang** (was killed at the 2 h wall pre-#1486), `sde_transformation_test`, `sde_scalar_ito` — **all pass**.

Adds `InterpolatingAdjoint RODE coarse-adjoint-dt accuracy` to `test/SDE3/rode.jl`, which **fails without this change** (du0 ~0.8%, dp ~5.7% off) and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)