### PR TITLE
mtk.jl: use the default EnzymeVJP inner VJP (Enzyme-over-Enzyme) now that #1507 fixed the corruption

### DIFF
--- a/test/Core8/mtk.jl
+++ b/test/Core8/mtk.jl
@@ -182,15 +182,15 @@ setups = [
 # init gradient is Enzyme-native again (#1467 routed it through Zygote until the
 # upstream fix landed; #1469).
 #
-# The inner VJP is `ReverseDiffVJP`, not `EnzymeVJP`: `EnzymeVJP._vecjacobian!`
-# runs a *nested* `Enzyme.autodiff` on the MTK-generated DAE RHS, which both
-# mishandles that RHS for some DAEs and corrupts Enzyme's global state across the
-# many `Enzyme.autodiff` calls this `setups` sweep makes (first call OK, later
-# calls `SingularException`). Using a non-Enzyme inner VJP is the established
-# workaround until that EnzymeVJP nested-Enzyme issue is fixed; the *outer* AD is
-# still Enzyme, which is what this test covers — Enzyme reverse-mode through MTK
-# DAE initialization.
-const _MTK_SENSEALG = GaussAdjoint(; autojacvec = SciMLSensitivity.ReverseDiffVJP())
+# The inner VJP is `EnzymeVJP` — the default `autojacvec` for this in-place MTK
+# DAE — so this is a true Enzyme-over-Enzyme test. `EnzymeVJP._vecjacobian!` runs
+# a *nested* `Enzyme.autodiff` on the MTK-generated DAE RHS whose reverse pass
+# writes the `MTKParameters` `Initials` buffer in place; that used to corrupt the
+# problem across the repeated `Enzyme.autodiff` calls of this `setups` sweep
+# (first call OK, later calls `SingularException` / `CheckInitFailureError`).
+# Fixed in #1507 (the GaussAdjoint adjoint now runs on a copy of the parameters);
+# the underlying Enzyme read-only violation is EnzymeAD/Enzyme.jl#3247.
+const _MTK_SENSEALG = GaussAdjoint(; autojacvec = SciMLSensitivity.EnzymeVJP())
 
 function _mtk_enzyme_solve_loss_with_init(t, prob_, init_)
     _, repack_, _ = SS.canonicalize(SS.Tunable(), parameter_values(prob_))


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft.

## What

Flips `test/Core8/mtk.jl`'s `_MTK_SENSEALG` from `ReverseDiffVJP` to the **default `EnzymeVJP`**, making the 15-setup MTK DAE-initialization sweep a genuine **Enzyme-over-Enzyme** test (outer AD Enzyme, inner VJP Enzyme).

Rebased on top of #1507. (Supersedes the earlier `@test_broken` version of this PR — with #1507 merged, the EnzymeVJP sweep is no longer broken, so it's just `@test`.)

## Why this is now possible

The sweep previously pinned `ReverseDiffVJP` to dodge the EnzymeVJP corruption: `EnzymeVJP._vecjacobian!`'s reverse pass writes the `MTKParameters` `Initials` buffer in place, so after the first (correct) gradient the next solve's DAE init read corrupted data → `SingularException` / `CheckInitFailureError`. **#1507 fixed that** (the GaussAdjoint adjoint now runs on a copy of the parameters; underlying Enzyme read-only violation is EnzymeAD/Enzyme.jl#3247). `EnzymeVJP` is also the *default* `autojacvec` for an in-place MTK DAE, so this makes the test cover the default path.

The diff is just the `_MTK_SENSEALG` constant + its explanatory comment; the sweep `@test` and the `Mooncake` `@test` are unchanged. No `runtests.jl` reorder (the previous version moved `mtk.jl` last to contain the corruption — unnecessary now that it's fixed).

## Verification status — please note

I have **not** run the full `Core8` group with this flip (skipped at the maintainer's request). What I *have* verified locally (Enzyme 0.13.169, Julia 1.12.6, dev'd master + #1507):

- The #1507 fix makes repeated EnzymeVJP adjoints of an MTK DAE correct (its regression test, and a 6×-repeat reproducer: 6/6 identical vs erroring on the 2nd call before the fix).
- The EnzymeVJP sweep over the first 5 of the 15 `mtk.jl` setups (including `DefaultInit` and `nothing`, which previously threw `SingularException`) now returns the correct gradient on every one (the run was cut off by a timeout before finishing all 15, not by a failure).

So the full 15/15 sweep is **expected** to pass but is **CI-unverified** here. Worth a green `Core8` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
