### PR TITLE
GaussAdjoint: defensively copy parameters so the adjoint can't corrupt the user's problem (#1470)

### DIFF
--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -776,6 +776,15 @@ function _adjoint_sensitivities(
         callback = CallbackSet(), no_start = false,
         kwargs...
     )
+    # Defensive copy of the parameters: the adjoint solve writes in place through
+    # the problem's parameters (notably EnzymeVJP's reverse pass, which writes the
+    # `MTKParameters` `Initials` buffer — a read-only violation, #1470 /
+    # EnzymeAD/Enzyme.jl#3247). Operating on a copy keeps the user's `prob` clean,
+    # so a subsequent `solve`/adjoint of the same problem is not corrupted.
+    _adj_p = SymbolicIndexingInterface.parameter_values(sol.prob)
+    if !(_adj_p === nothing || _adj_p isa SciMLBase.NullParameters)
+        @reset sol.prob = remake(sol.prob; p = deepcopy(_adj_p))
+    end
     p = SymbolicIndexingInterface.parameter_values(sol)
     if !isscimlstructure(p) && !isfunctor(p) &&
             !(p isa Union{Nothing, SciMLBase.NullParameters, AbstractArray})

--- a/test/Core8/enzyme_vjp_repeated_adjoint.jl
+++ b/test/Core8/enzyme_vjp_repeated_adjoint.jl
@@ -1,0 +1,63 @@
+using ModelingToolkit
+using ModelingToolkit: t_nounits as t, D_nounits as D
+using OrdinaryDiffEqRosenbrock
+using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit
+using SciMLBase: CheckInit
+using SciMLSensitivity
+import SciMLStructures as SS
+using SciMLSensitivity: parameter_values
+using Enzyme
+using Test
+
+# Regression test for #1470 / EnzymeAD/Enzyme.jl#3247. Repeatedly differentiating
+# a `solve` of an MTK DAE with `GaussAdjoint(EnzymeVJP())` must not corrupt the
+# problem across calls. `EnzymeVJP`'s reverse pass writes in place through the
+# `MTKParameters` `Initials` buffer; without the defensive parameter copy in
+# `_adjoint_sensitivities`, the first gradient is correct but the next solve's DAE
+# init reads the corrupted `Initials` and throws `CheckInitFailureError`. With the
+# copy, every repeated differentiation is correct and identical.
+
+@parameters σ ρ β
+@variables x(t) y(t) z(t) w(t) w2(t)
+eqs = [
+    D(D(x)) ~ σ * (y - x), D(y) ~ x * (ρ - z) - y, D(z) ~ x * y - β * z,
+    w ~ x + y + z + 2β, 0 ~ x^2 + y^2 - w2^2,
+]
+@mtkbuild sys = ODESystem(eqs, t)
+prob = ODEProblem(
+    sys, [D(x) => 2.0, x => 1.0, y => 0.0, z => 0.0], (0.0, 5.0),
+    [σ => 28.0, ρ => 10.0, β => 8 / 3]; jac = true, guesses = [w2 => -1.0]
+)
+tunables, repack, _ = SS.canonicalize(SS.Tunable(), parameter_values(prob))
+
+const _RA_SENSEALG = GaussAdjoint(; autojacvec = SciMLSensitivity.EnzymeVJP())
+
+function _ra_loss(tun, prob_)
+    _, rp, _ = SS.canonicalize(SS.Tunable(), parameter_values(prob_))
+    new_prob = remake(prob_; u0 = prob_.u0, p = rp(tun))
+    new_sol = solve(
+        new_prob, Rodas5P(); initializealg = CheckInit(), sensealg = _RA_SENSEALG,
+        abstol = 1.0e-6, reltol = 1.0e-3,
+    )
+    return sum(new_sol)
+end
+
+function _ra_grad()
+    dtun = zero(tunables)
+    diprob = Enzyme.make_zero(prob)
+    Enzyme.autodiff(
+        Enzyme.set_runtime_activity(Enzyme.Reverse),
+        Enzyme.Const(_ra_loss), Enzyme.Active,
+        Enzyme.Duplicated(copy(tunables), dtun),
+        Enzyme.Duplicated(prob, diprob),
+    )
+    return dtun
+end
+
+g1 = _ra_grad()
+@test any(!iszero, g1)
+# Without the parameter copy these repeated calls throw `CheckInitFailureError`.
+g2 = _ra_grad()
+@test g2 ≈ g1
+g3 = _ra_grad()
+@test g3 ≈ g1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,6 +103,7 @@ run_tests(;
                 @time @safetestset "Initialization with MTK" include("Core8/desauty_dae_mwe.jl")
                 @time @safetestset "MTK Forward Mode" include("Core8/mtk.jl")
                 @time @safetestset "SCCNonlinearProblem" include("Core8/scc_nonlinearsolve.jl")
+                @time @safetestset "EnzymeVJP Repeated Adjoint" include("Core8/enzyme_vjp_repeated_adjoint.jl")
             end
         end,
         "SDE1" => function ()


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft.

## Problem

`_adjoint_sensitivities(::AbstractGAdjoint, …)` runs the adjoint on the user's problem parameters directly. The adjoint solve writes through those parameters **in place** — in particular `EnzymeVJP`'s reverse pass writes the `MTKParameters` `Initials` buffer (a read-only violation, upstream **EnzymeAD/Enzyme.jl#3247**).

Concretely, differentiating a `solve` of an MTK DAE with `GaussAdjoint(EnzymeVJP())` repeatedly in one process:

- The **first** gradient is correct.
- The dirtied `Initials` array (mutated by the `D(x)=>2.0` initial, `Δ=2.0`) is shared via `repack` into the next `solve`.
- The next solve's DAE `CheckInit` reads the corrupted algebraic-variable initial → `CheckInitFailureError` (or `SingularException` / a zero gradient in other init configs).

This is what forces `test/Core8/mtk.jl` to pin `ReverseDiffVJP` as the inner VJP (#1470), and it's why `EnzymeVJP` — the *default* `autojacvec` for an in-place MTK DAE — can't be used there.

### Pinpointing (diagnostics)

| after the 1st (correct) adjoint | Δ |
|---|---|
| `prob.u0` | 0 |
| `Tunable` parameters | 0 |
| **`Initials` parameters** | **2.0** ← corrupted |

A fresh-built or `deepcopy`d `prob` per call makes every iteration correct — so the corrupted state lives in the problem's `MTKParameters`, not in Enzyme global state.

## Fix

`deepcopy` the problem parameters once at the adjoint entry and run the adjoint on the copy, so the in-place writes can't reach the user's problem:

```julia
_adj_p = SymbolicIndexingInterface.parameter_values(sol.prob)
if !(_adj_p === nothing || _adj_p isa SciMLBase.NullParameters)
    @reset sol.prob = remake(sol.prob; p = deepcopy(_adj_p))
end
```

The gradient is **unchanged** (verified bit-identical with/without the copy); only the buffer is protected. An adjoint method shouldn't mutate the caller's parameters regardless, so this is correct independent of the upstream Enzyme bug — and it's a once-per-gradient copy, negligible next to the solve.

## Verification

New regression test `test/Core8/enzyme_vjp_repeated_adjoint.jl` — differentiate a small MTK DAE solve 3× with `GaussAdjoint(EnzymeVJP())`:

```
EnzymeVJP Repeated Adjoint | Pass  Total
                           |    3      3
```

Verified **both ways** locally (Enzyme 0.13.169, Julia 1.12.6): without the fix the 2nd call throws `CheckInitFailureError` (1st correct); with the fix all three calls return the same nonzero gradient. On the full `mtk.jl` 15-setup sweep, `EnzymeVJP` now matches `ReverseDiffVJP` on every setup checked (previously: `SingularException` / zeros).

## Notes

- Touches only the `AbstractGAdjoint` path (`GaussAdjoint`/`GaussKronrodAdjoint`). The same defensive copy likely belongs in the other adjoint methods (`Interpolating`/`Backsolve`/`Quadrature`) too — happy to extend if wanted.
- The underlying defect is upstream (EnzymeAD/Enzyme.jl#3247); this is the SciML-side workaround, but it also stands on its own as correct (don't mutate caller params).
- With this fix, `mtk.jl` could move its inner VJP back to the default `EnzymeVJP` — left as a follow-up so this PR stays minimal (related: #1504).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
