### PR TITLE
Fix EnzymeVJP shadow-parameter aliasing at the source (adjoint_common); revert #1507 workaround

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -250,7 +250,15 @@ function adjointdiffcache(
         _needs_shadow = !(p isa SciMLBase.NullParameters) &&
             isscimlstructure(p) && !(p isa AbstractArray)
         _shadow_p = if _needs_shadow
-            repack(zero(tunables))
+            # `repack` only writes the tunable fields and copies the rest of the
+            # parameter object (e.g. `initials`, `discrete`) *by reference* from
+            # `p`, so `repack(zero(tunables))` would alias the primal's non-tunable
+            # arrays. `_vecjacobian!` then `Enzyme.remake_zero!`s this shadow, which
+            # would zero the user's `p.initials` and corrupt the problem across
+            # repeated differentiation (#1470). `make_zero(p)` allocates a fully
+            # disjoint zeroed shadow; `canonicalize(Tunable(), _shadow_p)` still
+            # reads back the accumulated tunable gradient.
+            Enzyme.make_zero(p)
         elseif !(p isa SciMLBase.NullParameters) && p isa AbstractArray &&
                 typeof(tunables) !== typeof(zero(tunables))
             # tunables is a view-backed array (e.g. ComponentArray with SubArray data).

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -776,15 +776,6 @@ function _adjoint_sensitivities(
         callback = CallbackSet(), no_start = false,
         kwargs...
     )
-    # Defensive copy of the parameters: the adjoint solve writes in place through
-    # the problem's parameters (notably EnzymeVJP's reverse pass, which writes the
-    # `MTKParameters` `Initials` buffer — a read-only violation, #1470 /
-    # EnzymeAD/Enzyme.jl#3247). Operating on a copy keeps the user's `prob` clean,
-    # so a subsequent `solve`/adjoint of the same problem is not corrupted.
-    _adj_p = SymbolicIndexingInterface.parameter_values(sol.prob)
-    if !(_adj_p === nothing || _adj_p isa SciMLBase.NullParameters)
-        @reset sol.prob = remake(sol.prob; p = deepcopy(_adj_p))
-    end
     p = SymbolicIndexingInterface.parameter_values(sol)
     if !isscimlstructure(p) && !isfunctor(p) &&
             !(p isa Union{Nothing, SciMLBase.NullParameters, AbstractArray})

--- a/test/Core8/enzyme_vjp_repeated_adjoint.jl
+++ b/test/Core8/enzyme_vjp_repeated_adjoint.jl
@@ -9,13 +9,15 @@ using SciMLSensitivity: parameter_values
 using Enzyme
 using Test
 
-# Regression test for #1470 / EnzymeAD/Enzyme.jl#3247. Repeatedly differentiating
-# a `solve` of an MTK DAE with `GaussAdjoint(EnzymeVJP())` must not corrupt the
-# problem across calls. `EnzymeVJP`'s reverse pass writes in place through the
-# `MTKParameters` `Initials` buffer; without the defensive parameter copy in
-# `_adjoint_sensitivities`, the first gradient is correct but the next solve's DAE
-# init reads the corrupted `Initials` and throws `CheckInitFailureError`. With the
-# copy, every repeated differentiation is correct and identical.
+# Regression test for #1470. Repeatedly differentiating a `solve` of an MTK DAE
+# with `GaussAdjoint(EnzymeVJP())` must not corrupt the problem across calls. The
+# EnzymeVJP shadow parameters (`adjoint_common.jl`) used to be built with
+# `repack(zero(tunables))`, which aliases the primal's non-tunable arrays
+# (`initials`) by reference; `_vecjacobian!` then `remake_zero!`s the shadow,
+# zeroing the user's `p.initials`. The first gradient was correct, but the next
+# solve's DAE init read the corrupted `Initials` and threw `CheckInitFailureError`.
+# Fixed by allocating a disjoint shadow with `make_zero(p)`; every repeated
+# differentiation is now correct and identical.
 
 @parameters σ ρ β
 @variables x(t) y(t) z(t) w(t) w2(t)


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft.

## Root cause (proper fix for #1470 — supersedes the #1507 workaround)

The EnzymeVJP corruption that #1507 worked around is a **primal–shadow aliasing bug**, diagnosed by @wsmoses on EnzymeAD/Enzyme.jl#3247 (now closed — it is *not* an Enzyme bug).

In `adjoint_common.jl` the EnzymeVJP shadow parameters were built as:

```julia
_shadow_p = repack(zero(tunables))
```

`repack` (from `SciMLStructures.canonicalize`) only writes the **tunable** fields and copies the rest of the parameter object — `initials`, `discrete` — **by reference** from the primal `p`. So `_shadow_p.initials === p.initials`. `_vecjacobian!` then calls `Enzyme.remake_zero!(_shadow_p)`, which zeroes the aliased array, i.e. it **zeroes the user's `p.initials`**. The first gradient is still correct, but the dirtied `initials` is shared (via `repack`) into the next `solve`, whose DAE `CheckInit` reads the corrupted algebraic-variable initial → `CheckInitFailureError` (or `SingularException` / zero gradient). Enzyme was doing the right thing on the buffer it was handed; the buffer just aliased read-only input.

## Fix

Allocate a fully disjoint shadow with `Enzyme.make_zero(p)` (recursively zeroes every field into fresh arrays); `canonicalize(Tunable(), _shadow_p)` still reads back the accumulated tunable gradient.

```diff
-            repack(zero(tunables))
+            Enzyme.make_zero(p)
```

This is in `adjoint_common.jl`, which builds the EnzymeVJP `paramjac_config` for **every** adjoint method — so it fixes `GaussAdjoint`, `InterpolatingAdjoint`, `QuadratureAdjoint` and `BacksolveAdjoint` at once, not just GaussAdjoint.

Also **reverts the #1507 `_adjoint_sensitivities` `deepcopy`** — that was an entry-level workaround (a full per-gradient param copy on the Gauss path only); with the aliasing fixed at the source it is redundant.

## Verification

- The #1507 regression test (`test/Core8/enzyme_vjp_repeated_adjoint.jl`, repeated EnzymeVJP adjoint of an MTK DAE) still passes with `make_zero` and the `deepcopy` removed.
- Repeated EnzymeVJP differentiation is correct/identical across `GaussAdjoint`/`InterpolatingAdjoint`/`QuadratureAdjoint`/`BacksolveAdjoint` (was first-correct-then-`CheckInitFailureError` before).

(Comment also corrected: the regression test no longer calls this an Enzyme bug.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
