### PR TITLE
Core1: skip unsupported Mooncake-over-other-AD testsets (won't-fix, Mooncake#1208)

### DIFF
--- a/test/Core1/concrete_solve_derivatives.jl
+++ b/test/Core1/concrete_solve_derivatives.jl
@@ -443,18 +443,25 @@ Tests callable structs with different AD backends
         end
     end
 
-    # Mooncake is not in `REVERSE_BACKENDS` because it doesn't yet compose
-    # with every sensealg, but it does compose with `ReverseDiffAdjoint` and
-    # `TrackerAdjoint` via the dedicated `MooncakeOriginator` dispatches
-    # added in #1420 (the hybrid_diffeq.md pattern from #1419).
+    # Mooncake over another AD's adjoint (`ReverseDiffAdjoint`/`TrackerAdjoint`,
+    # and `ForwardSensitivity` below) is unsupported and won't be fixed: the
+    # `DiffEqBase.solve` overlay returns an `ODESolution{TrackedReal/Dual,…}`
+    # under these sensealgs, but Mooncake's inference is overlay-blind and
+    # records `ODESolution{Float64,…}`, so `build_rrule`'s typeassert fails. It
+    # surfaces as a fast `TypeError` or, under coverage instrumentation (the CI
+    # config), a multi-hour compile/inference hang that times out Core1. This is
+    # a documented Mooncake known-limitation (chalk-lab/Mooncake.jl#1208, closed
+    # won't-fix; the suggested workaround is a hand-written `rrule!!`). These
+    # AD-mixing testsets (added in #1420) are skipped permanently. `@test_skip`
+    # does not evaluate its argument, so it cannot hang. See #1510.
     @testset "Mooncake with ReverseDiffAdjoint" begin
-        result = gradient_mooncake(senseloss(ReverseDiffAdjoint()), u0p)
-        @test result ≈ ref_grad_senseloss
+        @test_skip gradient_mooncake(senseloss(ReverseDiffAdjoint()), u0p) ≈
+                   ref_grad_senseloss
     end
 
     @testset "Mooncake with TrackerAdjoint" begin
-        result = gradient_mooncake(senseloss(TrackerAdjoint()), u0p)
-        @test result ≈ ref_grad_senseloss
+        @test_skip gradient_mooncake(senseloss(TrackerAdjoint()), u0p) ≈
+                   ref_grad_senseloss
     end
 
     # Test with p-only differentiation (senseloss3 and senseloss4 from alternative_ad_frontend.jl)
@@ -491,9 +498,13 @@ Tests callable structs with different AD backends
     # differentiate `u0`, and the Mooncake dispatch rewrites the `du0`
     # slot to `NoTangent()` so Mooncake's cotangent threading doesn't trip
     # on the main method's `@not_implemented` stub for `du0`.
+    # Same unsupported Mooncake-over-another-AD pattern as the ReverseDiffAdjoint/
+    # TrackerAdjoint testsets above (here over a `ForwardSensitivity` solve, whose
+    # overlay returns an `ODESolution{Dual,…}`). Won't be fixed on the Mooncake
+    # side — chalk-lab/Mooncake.jl#1208. Skipped permanently. See #1510.
     @testset "Mooncake with ForwardSensitivity (p-only)" begin
-        result = gradient_mooncake(senseloss_p(ForwardSensitivity()), p_only)
-        @test result ≈ ref_grad_p
+        @test_skip gradient_mooncake(senseloss_p(ForwardSensitivity()), p_only) ≈
+                   ref_grad_p
     end
 end
 


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Context: #1510.

## Problem
`Core1` times out (2h; previously 6h) on the Mooncake-over-adjoint testsets in `test/Core1/concrete_solve_derivatives.jl` (added in #1420) — failing since ~2026-05-08, **not** from the recent Enzyme/SDE work.

These stack **Mooncake over another AD's adjoint**:
- `Mooncake with ReverseDiffAdjoint` (`:450`)
- `Mooncake with TrackerAdjoint` (`:455`)
- `Mooncake with ForwardSensitivity (p-only)` (`:494`)

The `DiffEqBase.solve` overlay returns an `ODESolution{TrackedReal/Dual,…}` under those sensealgs, but Mooncake's inference is **overlay-blind** and records `ODESolution{Float64,…}`, so `build_rrule`'s typeassert fails. It surfaces as a fast `TypeError`, or — under coverage instrumentation (the CI config) — a **multi-hour compile/inference hang** that times Core1 out (reproduced locally at 746 s / no-return on Julia 1.12.6).

## This is a Mooncake known-limitation, won't-fix
Closed upstream as a documented known-limitation: **chalk-lab/Mooncake.jl#1208** ("overlay-blind inference"; the maintainer's suggested workaround is a hand-written `rrule!!`, not a Mooncake change). Mooncake stacked over another AD is unsupported and won't be fixed on the Mooncake side.

## Change
Skip all three AD-mixing testsets **permanently** with `@test_skip` (which does not evaluate its argument — so it cannot hang, and the tests stay visible as skipped rather than silently removed). Verified locally that `@test_skip error(...)` neither runs nor errors. Runic clean.

Follow-up worth considering (not in this PR): the `MooncakeOriginator` delegations for these sensealgs at `src/concrete_solve.jl:2146` / `:2387` could likewise be dropped since the combination is unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)