### PR TITLE
forward sensitivity: fix ForwardDiffSensitivity extract param count under RAT-4 (last Core1 failure)

### DIFF
--- a/src/forward_sensitivity.jl
+++ b/src/forward_sensitivity.jl
@@ -766,9 +766,13 @@ end
 function extract_local_sensitivities(sol, ::ForwardDiffSensitivity, ::Val{false})
     u = ForwardDiff.value.(sol)
     du_full = ForwardDiff.partials.(sol)
-    firststate = first(du_full)
-    firstparam = first(firststate)
-    Js = map(1:length(firstparam)) do j
+    # `du_full` is the (flat) array of `ForwardDiff.Partials` — RecursiveArrayTools 4
+    # broadcasts `sol` over its scalar elements, so `first(du_full)` is already a
+    # `Partials`, and the number of sensitivity parameters is its length (not
+    # `length(first(first(du_full)))`, which used to reach a `Partials` through the
+    # old nested vector-of-vectors layout and now returns a scalar's length, 1).
+    nparams = length(first(du_full))
+    Js = map(1:nparams) do j
         map(CartesianIndices(du_full)) do II
             du_full[II][j]
         end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.** The last Core1 failure (`forward.jl:166`).

`extract_local_sensitivities(sol, ::ForwardDiffSensitivity, Val(false))` counted parameters as `length(first(first(du_full)))`. That reached a `ForwardDiff.Partials` via the old nested vector-of-vectors layout, but **RecursiveArrayTools 4** broadcasts `sol` over scalar elements, so `du_full = ForwardDiff.partials.(sol)` is a flat array of `Partials` and `first(first(du_full))` is a scalar (length 1). The extract returned only one parameter's sensitivities.

Fix: use `length(first(du_full))` (a `Partials`'s length = number of parameters).

**Verified locally:** `dpall` now has one matrix per parameter and `test/Core1/forward.jl` **passes in full**. Combined with #1520 (Logging compat → QA), this makes Core1 + QA green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)