### PR TITLE
EnzymeAdjoint: unthunk the cotangent (fixes Zygote-over-EnzymeAdjoint, Core1 ≤1.11)

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -1817,6 +1817,10 @@ function SciMLBase._concrete_solve_adjoint(
     )
 
     function enzyme_sensitivity_backpass(Δ)
+        # Zygote/ChainRules can hand back a thunked cotangent (e.g. an
+        # `InplaceableThunk`); materialize it so the VectorOfArray/array handling
+        # below applies instead of hitting the unsupported-type `error`.
+        Δ = Δ isa AbstractThunk ? unthunk(Δ) : Δ
         if (Δ isa AbstractArray{<:AbstractArray} || Δ isa AbstractVectorOfArray)
             for (x, y) in zip(shadow_result.u, Δ.u)
                 x .= y


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

`enzyme_sensitivity_backpass` errored with `typeof(Δ) = …InplaceableThunk… is not currently handled in EnzymeAdjoint` when the outer AD (Zygote/ChainRules) hands it a *thunked* cotangent. Materialize it with `Δ = Δ isa AbstractThunk ? unthunk(Δ) : Δ` (the same pattern already used a few lines up).

Fixes the Core1 (Julia ≤1.11) `sensealg = EnzymeAdjoint` × Zygote errors. **Verified locally:** Zygote gradient through `EnzymeAdjoint` now matches ForwardDiff (was an error).

The separate `VecOfArray - Zygote` zero-gradient failure is fixed **upstream** by the `sol[:, j]` getindex adjoint in **SciMLBase#1415** (issue #1522) — not marked `@test_broken` here; it goes green once that SciMLBase fix releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)