### PR TITLE
Mark automatic_sensealg_choice inactive to Enzyme

### DIFF
--- a/src/enzyme_rules.jl
+++ b/src/enzyme_rules.jl
@@ -12,3 +12,11 @@ import Enzyme: EnzymeRules
 
 # VJP choice types should be inactive since they configure computation methods
 EnzymeRules.inactive_type(::Type{<:VJPChoice}) = true
+
+# `automatic_sensealg_choice` selects a sensitivity algorithm/VJP by probing
+# candidate backends (ReverseDiff, Tracker, ...) inside try/catch. Its result is
+# a discrete algorithm choice that never depends differentiably on the numeric
+# inputs, so it must be inactive. This matters for forward-over-reverse (nested
+# Enzyme), where the outer forward pass would otherwise type-analyze the
+# Union-typed probing code and fail with an IllegalTypeAnalysisException.
+EnzymeRules.inactive(::typeof(automatic_sensealg_choice), args...) = nothing

--- a/test/Core2/enzyme_vjp_inactive.jl
+++ b/test/Core2/enzyme_vjp_inactive.jl
@@ -62,4 +62,15 @@ using Test, SciMLSensitivity, Enzyme, Reactant
         )
         @test dx ≈ [4.0, 3.0]
     end
+
+    # Test 4: `automatic_sensealg_choice` is inactive to Enzyme.
+    # The sensealg selection probes candidate VJP backends inside try/catch and
+    # returns a discrete algorithm choice, so it must not be differentiated. This
+    # is required for forward-over-reverse (nested Enzyme), where the outer
+    # forward pass would otherwise type-analyze the Union-typed probing code and
+    # fail with an IllegalTypeAnalysisException (SciMLSensitivity issue #1427).
+    @testset "automatic_sensealg_choice inactive" begin
+        @test Enzyme.EnzymeRules.inactive(SciMLSensitivity.automatic_sensealg_choice) ===
+            nothing
+    end
 end


### PR DESCRIPTION
## Summary

Adds an `EnzymeRules.inactive` rule for `automatic_sensealg_choice` so Enzyme does not attempt to differentiate the sensitivity-algorithm/VJP *selection* logic.

`automatic_sensealg_choice` picks a sensealg/VJP by **probing** candidate backends (ReverseDiff, Tracker, …) inside `try`/`catch`. Its result is a discrete algorithm choice that never depends differentiably on the numeric inputs, so it should be inactive — mirroring the existing `EnzymeRules.inactive_type(::Type{<:VJPChoice})` rule in the same file.

## Motivation

This is the first blocker for the **forward-over-reverse** (nested Enzyme) path used for second-order sensitivity (Hessians / HVPs), i.e. `SecondOrder(AutoEnzyme(Forward), AutoEnzyme(Reverse))`, tracked in #1427.

Without this rule, the outer forward pass type-analyzes the `Union`-typed probing code inside `automatic_sensealg_choice` and fails at compile time:

```
IllegalTypeAnalysisException: Enzyme compilation failed due to illegal type analysis.
 This usually indicates the use of a Union type ...
 Failure within method: MethodInstance for SciMLSensitivity.automatic_sensealg_choice(...)
```

With the rule, the nested differentiation gets past sensealg selection (it then reaches a separate, Enzyme-side type-analysis limitation in `OrdinaryDiffEqCore._ode_init` for `Float32` solver init, which is being pursued upstream in Enzyme — out of scope here).

## Verification (local, Julia 1.11.9 / Enzyme 0.13.173)

- **No first-order regression:** `Enzyme.gradient(set_runtime_activity(Reverse), loss, ps)` for the docs neural-ODE loss still matches Zygote to **relerr 0.0**, state stable across repeated calls.
- **Advances the second-order path:** the docs `second_order_adjoints.md` neural-ODE `SecondOrder(AutoEnzyme(Forward), AutoEnzyme(Reverse))` HVP no longer fails inside `automatic_sensealg_choice`; it now advances to the downstream `_ode_init` Enzyme issue.
- New guard test in `test/Core2/enzyme_vjp_inactive.jl` (fails without the rule with a `MethodError`, passes with it).

Runic-formatted.

---

**This PR should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)