### PR TITLE
Fix Runic formatting in concrete_solve_derivatives.jl

### DIFF
--- a/test/Core1/concrete_solve_derivatives.jl
+++ b/test/Core1/concrete_solve_derivatives.jl
@@ -456,12 +456,12 @@ Tests callable structs with different AD backends
     # does not evaluate its argument, so it cannot hang. See #1510.
     @testset "Mooncake with ReverseDiffAdjoint" begin
         @test_skip gradient_mooncake(senseloss(ReverseDiffAdjoint()), u0p) ≈
-                   ref_grad_senseloss
+            ref_grad_senseloss
     end
 
     @testset "Mooncake with TrackerAdjoint" begin
         @test_skip gradient_mooncake(senseloss(TrackerAdjoint()), u0p) ≈
-                   ref_grad_senseloss
+            ref_grad_senseloss
     end
 
     # Test with p-only differentiation (senseloss3 and senseloss4 from alternative_ad_frontend.jl)
@@ -504,7 +504,7 @@ Tests callable structs with different AD backends
     # side — chalk-lab/Mooncake.jl#1208. Skipped permanently. See #1510.
     @testset "Mooncake with ForwardSensitivity (p-only)" begin
         @test_skip gradient_mooncake(senseloss_p(ForwardSensitivity()), p_only) ≈
-                   ref_grad_p
+            ref_grad_p
     end
 end
 


### PR DESCRIPTION
## Summary

The repo-wide `format-check` (Runic) CI job has been failing on **every push and PR since #1511**, including direct pushes to `master`. The cause is three `@test_skip … ≈` continuation lines in `test/Core1/concrete_solve_derivatives.jl` that are over-indented relative to what Runic (the version the FormatCheck action pins) wants:

```diff
         @test_skip gradient_mooncake(senseloss(ReverseDiffAdjoint()), u0p) ≈
-                   ref_grad_senseloss
+            ref_grad_senseloss
```

(same for the `TrackerAdjoint` and `ForwardSensitivity (p-only)` `@test_skip`s).

This is a pure formatting change — no logic change — produced by running Runic in-place on just that file. After the fix, `Runic --check test/Core1/concrete_solve_derivatives.jl` returns 0.

Unblocks the `format-check` job for the whole repo.

---

**This PR should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)