### PR TITLE
Mark p Const in EnzymeVJP _vecjacobian! when no dgrad is requested

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -1033,9 +1033,18 @@ function _vecjacobian!(
     # When the caller does not request a parameter gradient (`dgrad === nothing`,
     # as in the Gauss/Quadrature adjoint rhs on every solver stage), mark `p`
     # `Const` so Enzyme skips the parameter-gradient accumulation entirely,
-    # matching the out-of-place wrapper above.
+    # matching the out-of-place wrapper above. This is only sound when the mode
+    # has runtime activity: under static activity analysis, an rhs that stores
+    # `p`-derived array references into active computation (e.g. a Lux layer
+    # reshaping a `ComponentArray`'s weights) raises `EnzymeRuntimeActivityError`
+    # — or worse, silently drops gradient terms — once `p` is `Const`. So the
+    # demotion is gated on `runtime_activity(mode)` (already enabled on the
+    # automatically selected `EnzymeVJP`) rather than forcing runtime activity
+    # on, which measurably slows small right-hand sides.
+    _skip_p_grad = dgrad === nothing &&
+        Enzyme.EnzymeCore.runtime_activity(isautojacvec.mode)
     _shadow_p = nothing
-    dup = if dgrad !== nothing && !(tmp2 isa SciMLBase.NullParameters)
+    dup = if !_skip_p_grad && !(tmp2 isa SciMLBase.NullParameters)
         # tmp2 .= 0
         Enzyme.remake_zero!(tmp2)
         if _cached_shadow isa EnzymeViewPrimalBuffer
@@ -1069,9 +1078,7 @@ function _vecjacobian!(
     #end
 
     vec(tmp4) .= vec(λ)
-    isautojacvec = get_jacvec(sensealg)
-    # Extract Enzyme mode from EnzymeVJP or use default Enzyme.Reverse
-    enzyme_mode = isautojacvec isa EnzymeVJP ? isautojacvec.mode : Enzyme.Reverse
+    enzyme_mode = isautojacvec.mode
 
     if inplace_sensitivity(S)
         Enzyme.remake_zero!(_tmp6)

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -1030,11 +1030,12 @@ function _vecjacobian!(
     Enzyme.remake_zero!(tmp1) # should be removed for dλ
     vec(ytmp) .= vec(y)
 
-    #if dgrad !== nothing
-    #  tmp2 = dgrad
-    #else
+    # When the caller does not request a parameter gradient (`dgrad === nothing`,
+    # as in the Gauss/Quadrature adjoint rhs on every solver stage), mark `p`
+    # `Const` so Enzyme skips the parameter-gradient accumulation entirely,
+    # matching the out-of-place wrapper above.
     _shadow_p = nothing
-    dup = if !(tmp2 isa SciMLBase.NullParameters)
+    dup = if dgrad !== nothing && !(tmp2 isa SciMLBase.NullParameters)
         # tmp2 .= 0
         Enzyme.remake_zero!(tmp2)
         if _cached_shadow isa EnzymeViewPrimalBuffer

--- a/test/Core3/allocation_regression.jl
+++ b/test/Core3/allocation_regression.jl
@@ -1,0 +1,94 @@
+# Allocation regression tests for the continuous adjoints.
+
+#
+# Guards the two properties measured on master (Julia 1.10, Enzyme 0.13):
+#   1. The per-call ceilings of the adjoint inner loops (vec_pjac! /
+#      the Gauss integrand) with EnzymeVJP.
+#   2. The per-step allocation slope of full adjoint solves: allocations must
+#      not grow faster than the recorded slope with integration length —
+#      catches any accidentally introduced per-step/per-stage allocation.
+#   3. With `dgrad === nothing` (Gauss/Quadrature adjoint rhs), the parameter
+#      shadow buffer must remain untouched — proves Enzyme is not computing a
+#      discarded parameter gradient on every solver stage.
+using SciMLSensitivity, OrdinaryDiffEq, LinearAlgebra, Test
+
+# Allocation counts are meaningless under coverage instrumentation.
+coverage_on = Base.JLOptions().code_coverage != 0
+
+function lv!(du, u, p, t)
+    du[1] = p[1] * u[1] - p[2] * u[1] * u[2]
+    du[2] = -p[3] * u[2] + p[4] * u[1] * u[2]
+    return nothing
+end
+dgdu(out, u, p, t, i) = (out .= 1.0)
+
+fwdsol(T) = solve(
+    ODEProblem(lv!, [1.0, 1.0], (0.0, T), [1.5, 1.0, 3.0, 1.0]),
+    Tsit5(); abstol = 1.0e-8, reltol = 1.0e-8, dense = true
+)
+
+function adjoint_allocs(T, sa)
+    sol = fwdsol(T)
+    ts = collect(range(0.0, T, length = 21))
+    f() = adjoint_sensitivities(
+        sol, Tsit5(); t = ts, dgdu_discrete = dgdu,
+        sensealg = sa, abstol = 1.0e-6, reltol = 1.0e-3
+    )
+    f(); f()  # compile + warm caches
+    return minimum(@allocated(f()) for _ in 1:5), length(sol.t)
+end
+
+@testset "adjoint allocation regressions" begin
+    if coverage_on
+        @info "coverage instrumentation active — skipping allocation regression tests"
+    else
+        @testset "per-call ceiling: GaussIntegrand vec_pjac! (EnzymeVJP)" begin
+            sol = fwdsol(10.0)
+            sa = GaussAdjoint(autojacvec = EnzymeVJP())
+            S = SciMLSensitivity.GaussIntegrand(sol, sa, collect(sol.t), nothing)
+            out = zeros(4); λ = [1.0, 2.0]; y = copy(sol.u[10]); t = sol.t[10]
+            SciMLSensitivity.vec_pjac!(out, λ, y, t, S)
+            SciMLSensitivity.vec_pjac!(out, λ, y, t, S)
+            a = minimum(@allocated(SciMLSensitivity.vec_pjac!(out, λ, y, t, S)) for _ in 1:5)
+            # measured 64 B (3 small allocs inside Enzyme.autodiff) on
+            # Julia 1.10 / Enzyme 0.13; the ceiling leaves 2x headroom.
+            @test a <= 128
+        end
+
+        @testset "per-step slope of full adjoint solves" begin
+            # slope = (allocs(T=100) - allocs(T=10)) / (fwd-steps difference).
+            # Measured on master: Gauss+Enzyme ~24 B/step, Interp+Enzyme 0 B/step.
+            for (name, sa, ceiling) in [
+                    ("Gauss+EnzymeVJP", GaussAdjoint(autojacvec = EnzymeVJP()), 64.0),
+                    ("Interp+EnzymeVJP", InterpolatingAdjoint(autojacvec = EnzymeVJP()), 8.0),
+                ]
+                a10, n10 = adjoint_allocs(10.0, sa)
+                a100, n100 = adjoint_allocs(100.0, sa)
+                slope = (a100 - a10) / (n100 - n10)
+                @test slope <= ceiling
+            end
+        end
+
+        @testset "dgrad === nothing skips the parameter gradient (EnzymeVJP)" begin
+            # The Gauss/Quadrature adjoint rhs calls vecjacobian! without dgrad on
+            # every solver stage; Enzyme must receive `Const(p)` there. If the
+            # parameter shadow were passed as `Duplicated`, it would be zeroed and
+            # written each call — the NaN sentinel would not survive.
+            sol = fwdsol(10.0)
+            sa = GaussAdjoint(autojacvec = EnzymeVJP())
+            adj_prob, _, _ = SciMLSensitivity.ODEAdjointProblem(
+                sol, sa, Tsit5(),
+                SciMLSensitivity.GaussIntegrand(sol, sa, collect(sol.t), nothing),
+                nothing, collect(range(0.0, 10.0, length = 21)), dgdu
+            )
+            S = adj_prob.f.f  # ODEGaussAdjointSensitivityFunction
+            tmp2 = S.diffcache.paramjac_config[2]
+            dλ = zeros(2); λ = [1.0, 2.0]; y = copy(sol.u[10])
+            SciMLSensitivity.vecjacobian!(dλ, y, λ, sol.prob.p, sol.t[10], S)
+            fill!(tmp2, NaN)
+            SciMLSensitivity.vecjacobian!(dλ, y, λ, sol.prob.p, sol.t[10], S)
+            @test all(isnan, tmp2)
+            @test all(isfinite, dλ)
+        end
+    end
+end

--- a/test/Core3/allocation_regression.jl
+++ b/test/Core3/allocation_regression.jl
@@ -1,18 +1,24 @@
 # Allocation regression tests for the continuous adjoints.
-
 #
-# Guards the two properties measured on master (Julia 1.10, Enzyme 0.13):
-#   1. The per-call ceilings of the adjoint inner loops (vec_pjac! /
-#      the Gauss integrand) with EnzymeVJP.
+# Guards three properties measured on Julia 1.10 / Enzyme 0.13:
+#   1. The per-call allocation ceiling of the GaussAdjoint inner loop
+#      (`vec_pjac!`) with EnzymeVJP.
 #   2. The per-step allocation slope of full adjoint solves: allocations must
 #      not grow faster than the recorded slope with integration length —
 #      catches any accidentally introduced per-step/per-stage allocation.
-#   3. With `dgrad === nothing` (Gauss/Quadrature adjoint rhs), the parameter
-#      shadow buffer must remain untouched — proves Enzyme is not computing a
-#      discarded parameter gradient on every solver stage.
+#   3. With `dgrad === nothing` (Gauss/Quadrature adjoint rhs) and a
+#      runtime-activity mode, the parameter shadow buffer must remain
+#      untouched — proves Enzyme receives `Const(p)` and is not computing a
+#      discarded parameter gradient on every stage. With the default static
+#      mode the shadow must be written (`Duplicated` kept; the demotion is
+#      unsound there).
+#
+# 1 and 2 count allocations, which is meaningless under coverage
+# instrumentation, so they are skipped when coverage is active. 3 is a
+# behavioral check and always runs.
 using SciMLSensitivity, OrdinaryDiffEq, LinearAlgebra, Test
+using Enzyme
 
-# Allocation counts are meaningless under coverage instrumentation.
 coverage_on = Base.JLOptions().code_coverage != 0
 
 function lv!(du, u, p, t)
@@ -39,10 +45,10 @@ function adjoint_allocs(T, sa)
 end
 
 @testset "adjoint allocation regressions" begin
-    if coverage_on
-        @info "coverage instrumentation active — skipping allocation regression tests"
-    else
-        @testset "per-call ceiling: GaussIntegrand vec_pjac! (EnzymeVJP)" begin
+    @testset "per-call ceiling: GaussIntegrand vec_pjac! (EnzymeVJP)" begin
+        if coverage_on
+            @info "coverage active — skipping vec_pjac! allocation ceiling"
+        else
             sol = fwdsol(10.0)
             sa = GaussAdjoint(autojacvec = EnzymeVJP())
             S = SciMLSensitivity.GaussIntegrand(sol, sa, collect(sol.t), nothing)
@@ -54,10 +60,14 @@ end
             # Julia 1.10 / Enzyme 0.13; the ceiling leaves 2x headroom.
             @test a <= 128
         end
+    end
 
-        @testset "per-step slope of full adjoint solves" begin
+    @testset "per-step slope of full adjoint solves" begin
+        if coverage_on
+            @info "coverage active — skipping adjoint allocation slope"
+        else
             # slope = (allocs(T=100) - allocs(T=10)) / (fwd-steps difference).
-            # Measured on master: Gauss+Enzyme ~24 B/step, Interp+Enzyme 0 B/step.
+            # Measured: Gauss+Enzyme ~24 B/step, Interp+Enzyme 0 B/step.
             for (name, sa, ceiling) in [
                     ("Gauss+EnzymeVJP", GaussAdjoint(autojacvec = EnzymeVJP()), 64.0),
                     ("Interp+EnzymeVJP", InterpolatingAdjoint(autojacvec = EnzymeVJP()), 8.0),
@@ -68,14 +78,20 @@ end
                 @test slope <= ceiling
             end
         end
+    end
 
-        @testset "dgrad === nothing skips the parameter gradient (EnzymeVJP)" begin
-            # The Gauss/Quadrature adjoint rhs calls vecjacobian! without dgrad on
-            # every solver stage; Enzyme must receive `Const(p)` there. If the
-            # parameter shadow were passed as `Duplicated`, it would be zeroed and
-            # written each call — the NaN sentinel would not survive.
+    @testset "dgrad === nothing skips the parameter gradient (EnzymeVJP)" begin
+        # The Gauss/Quadrature adjoint rhs calls vecjacobian! without dgrad on
+        # every solver stage. With a runtime-activity mode Enzyme must receive
+        # `Const(p)` there: if the parameter shadow were passed as
+        # `Duplicated`, it would be zeroed and written each call — the NaN
+        # sentinel would not survive. With the default static mode the
+        # demotion is unsound (p-derived array references stored into active
+        # computation), so `Duplicated` must be kept and the shadow written.
+        # Behavioral check, runs under coverage too.
+        function sentinel_survives(vjp)
             sol = fwdsol(10.0)
-            sa = GaussAdjoint(autojacvec = EnzymeVJP())
+            sa = GaussAdjoint(autojacvec = vjp)
             adj_prob, _, _ = SciMLSensitivity.ODEAdjointProblem(
                 sol, sa, Tsit5(),
                 SciMLSensitivity.GaussIntegrand(sol, sa, collect(sol.t), nothing),
@@ -87,8 +103,15 @@ end
             SciMLSensitivity.vecjacobian!(dλ, y, λ, sol.prob.p, sol.t[10], S)
             fill!(tmp2, NaN)
             SciMLSensitivity.vecjacobian!(dλ, y, λ, sol.prob.p, sol.t[10], S)
-            @test all(isnan, tmp2)
-            @test all(isfinite, dλ)
+            return all(isnan, tmp2), all(isfinite, dλ)
         end
+        surv_rta, finite_rta = sentinel_survives(
+            EnzymeVJP(mode = Enzyme.set_runtime_activity(Enzyme.Reverse))
+        )
+        @test surv_rta
+        @test finite_rta
+        surv_static, finite_static = sentinel_survives(EnzymeVJP())
+        @test !surv_static  # static mode keeps Duplicated(p, shadow)
+        @test finite_static
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,7 @@ run_tests(;
                 @time @safetestset "Adjoint Sensitivity" include("Core3/adjoint.jl")
                 @time @safetestset "automatic sensealg choice" include("Core3/automatic_sensealg_choice.jl")
                 @time @safetestset "GaussAdjoint ZygoteVJP In-Place" include("Core3/gauss_zygote_inplace.jl")
+                @time @safetestset "Adjoint Allocation Regression" include("Core3/allocation_regression.jl")
                 @time @safetestset "User-provided VJP" include("Core3/user_vjp.jl")
             end
         end,


### PR DESCRIPTION
**Note: please ignore this PR until reviewed by @ChrisRackauckas.**

## What

The Gauss/Quadrature adjoint ODE rhs calls `vecjacobian!` with `dgrad === nothing` on every solver stage — the parameter gradient there is not wanted (it comes from the quadrature). But the in-place EnzymeVJP branch of `_vecjacobian!` chose `Duplicated(p, shadow)` based only on the shadow buffer's existence, so Enzyme zeroed a p-sized shadow and accumulated a full parameter VJP on every stage, then discarded it.

This PR skips that discarded accumulation by demoting `p` to `Const`, **gated on `runtime_activity(mode)`**:

- Static-mode users (default `EnzymeVJP()`) keep exactly the previous `Duplicated(p, shadow)` behavior — no behavior or performance change.
- Runtime-activity modes — **including the automatically selected `EnzymeVJP(mode = set_runtime_activity(Reverse))` from `automatic_sensealg_choice`, i.e. the default Zygote-over-`solve` path** — get the demotion.

The gate is required for correctness: the first commit demoted unconditionally, and CI showed that under static activity analysis an rhs that stores p-derived array references into active computation (e.g. a Lux layer reshaping a `ComponentArray`'s weights) either raises `EnzymeRuntimeActivityError` (Core3 `default_alg_diff`, Core8 repeated adjoint) or **silently drops gradient terms** (Callbacks1 parameter-changing callback). Forcing runtime activity on instead was measured to slow small right-hand sides, so the demotion only applies when the user's mode already has runtime activity.

## Measured

32-state / 1024-parameter dense linear ODE, `GaussAdjoint`, Julia 1.10.11, Enzyme 0.13.171 (min of 10 samples):

| mode | before | after |
|---|---|---|
| `EnzymeVJP()` static | 0.58 ms | 0.58 ms (unchanged) |
| `EnzymeVJP(set_runtime_activity(Reverse))` | 0.58 ms | **0.46 ms (−21%)** |

Small-p (Lotka-Volterra): unchanged in both modes. Gradients bit-identical to a `ReverseDiffVJP` reference (relerr ≤ 5e-15) on both problems and both modes. The saving is the discarded p-VJP accumulation × ~6 stage calls/step, so it scales with `length(p)` — NN/MTK-sized parameters benefit most.

## Tests added

`test/Core3/allocation_regression.jl` (wired into the Core3 group):
1. **Per-call allocation ceiling** for the warmed `GaussIntegrand` `vec_pjac!` with EnzymeVJP (measured 64 B — all inside the `Enzyme.autodiff` entry; ceiling 128 B). Skipped under coverage.
2. **Per-step allocation slope** of full `adjoint_sensitivities` solves (T=10 vs T=100): ≤ 64 B/step for Gauss+Enzyme (measured ~24), ≤ 8 B/step for Interp+Enzyme (measured 0) — catches any accidentally introduced per-step/stage allocation. Skipped under coverage.
3. **Two-sided NaN-sentinel** (runs under coverage too): with a runtime-activity mode the parameter shadow stays untouched (`Const(p)` reached Enzyme); with the static default the shadow is written (`Duplicated` kept). The first side fails on master; the second side would fail on the unconditional demotion.

## Local validation (all against the gated commit)

- `Callbacks1/discrete_callbacks.jl`: **354/354** (this suite caught the silent gradient corruption of the unconditional version)
- `Core8/enzyme_vjp_repeated_adjoint.jl`: 3/3, `Core8/parameter_initialization.jl`: 3/3
- `Core3/default_alg_diff.jl` (auto-selection exercises the demotion): passes
- `Core3/gauss_zygote_inplace.jl`: 15/15
- New allocation regression tests: pass
- Direct gradient checks vs independent VJP on two benchmark problems: bit-identical

Pre-existing on master (not from this PR): QA (julia 1), Core4/SDE3/Core5 (julia 1.11) failures.

Background: the full adjoint performance analysis with allocation attribution is in https://github.com/ChrisRackauckas/InternalJunk/pull/61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzZhKZV2ameiUL8ouYknd