### PR TITLE
QA: ignore non-public EnzymeCore.EnzymeRules.inactive in qualified-access check

### DIFF
--- a/test/QA/aqua.jl
+++ b/test/QA/aqua.jl
@@ -73,7 +73,7 @@ run_qa(
                 # EnzymeCore
                 :Mode,
                 # EnzymeCore.EnzymeRules
-                :inactive_type,
+                :inactive_type, :inactive,
                 # FiniteDiff
                 :DerivativeCache, :GradientCache, :JacobianCache,
                 :finite_difference_derivative!, :finite_difference_gradient!,


### PR DESCRIPTION
## Summary

The QA (ExplicitImports) lane went red after #1524 (`Mark automatic_sensealg_choice inactive to Enzyme`). That PR added, in `src/enzyme_rules.jl:22`:

```julia
EnzymeRules.inactive(::typeof(automatic_sensealg_choice), args...) = nothing
```

`EnzymeCore.EnzymeRules.inactive` is a genuinely non-public name (`Base.ispublic == false`) that SciMLSensitivity must extend to define its Enzyme inactive rule. ExplicitImports' `all_qualified_accesses_are_public` check therefore flags it. This is the same situation already handled for `:inactive_type` in the same file.

## Change

Single-line, minimal: add `:inactive` to the `all_qualified_accesses_are_public` ignore tuple in `test/QA/aqua.jl`, right next to the existing `:inactive_type` under the `# EnzymeCore.EnzymeRules` grouping. No source change, no compat/floor change.

## Validation (local, Julia 1.12.6, released deps)

Ran `check_all_qualified_accesses_are_public(SciMLSensitivity)` with the QA ignore tuple:

- **Without `:inactive`** — FAILS: `inactive is not public in EnzymeCore.EnzymeRules but it was imported ... at src/enzyme_rules.jl:22:13` (confirms the red lane and that the name is genuinely non-public).
- **With `:inactive`** — PASSES.
- `check_no_stale_explicit_imports(SciMLSensitivity)` — PASSES (the ignore addition introduces no stale-imports problem).

Runic reports the file clean.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)