### PR TITLE
Hoist unwrapped_f out of the Gauss/Quadrature vec_pjac! inner loop

### DIFF
--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -1,6 +1,6 @@
 mutable struct GaussIntegrand{
         pType, uType, lType, rateType, S, PF, PJC, PJT, DGP,
-        G, SAlg <: AbstractGAdjoint, tType, rType,
+        G, SAlg <: AbstractGAdjoint, tType, rType, UF,
     }
     sol::S
     p::pType
@@ -15,6 +15,10 @@ mutable struct GaussIntegrand{
     dgdp::G
     tunables::tType
     repack::rType
+    # `unwrapped_f(sol.prob.f)` hoisted to construction: digging the function
+    # out of a FunctionWrappersWrapper is dynamic and would otherwise dominate
+    # every `vec_pjac!` call.
+    unwrappedf::UF
 end
 
 struct ODEGaussAdjointSensitivityFunction{
@@ -616,7 +620,7 @@ function GaussIntegrand(sol, sensealg, checkpoints, dgdp = nothing)
 
     return GaussIntegrand(
         cpsol, p, y, λ, pf, f_cache, pJ, paramjac_config,
-        sensealg, dgdp_cache, dgdp, tunables, repack
+        sensealg, dgdp_cache, dgdp, tunables, repack, unwrappedf
     )
 end
 
@@ -629,7 +633,7 @@ end
 function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
     (; pJ, pf, p, f_cache, dgdp_cache, paramjac_config, sensealg, sol, tunables, repack) = S
     _odef = sol.prob.f
-    f = unwrapped_f(_odef)
+    f = S.unwrappedf
     isautojacvec = get_jacvec(sensealg)
 
     # Priority: vjp_p > paramjac > autojacvec dispatch.

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -215,7 +215,7 @@ end
 
 struct AdjointSensitivityIntegrand{
         pType, uType, lType, rateType, S, AS, PF, PJC, PJT, DGP,
-        G, tType, rType,
+        G, tType, rType, UF,
     }
     sol::S
     adj_sol::AS
@@ -231,6 +231,10 @@ struct AdjointSensitivityIntegrand{
     dgdp::G
     tunables::tType
     repack::rType
+    # `unwrapped_f(sol.prob.f)` hoisted to construction: digging the function
+    # out of a FunctionWrappersWrapper is dynamic and would otherwise dominate
+    # every `vec_pjac!` call.
+    unwrappedf::UF
 end
 
 function AdjointSensitivityIntegrand(sol, adj_sol, sensealg, dgdp = nothing)
@@ -323,7 +327,7 @@ function AdjointSensitivityIntegrand(sol, adj_sol, sensealg, dgdp = nothing)
     end
     return AdjointSensitivityIntegrand(
         sol, adj_sol, p, y, λ, pf, f_cache, pJ, paramjac_config,
-        sensealg, dgdp_cache, dgdp, tunables, repack
+        sensealg, dgdp_cache, dgdp, tunables, repack, unwrappedf
     )
 end
 
@@ -341,7 +345,7 @@ _enzyme_vecpjac_dot(f, repack, y, tunables, t, λ) = dot(vec(f(y, repack(tunable
 function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
     (; pJ, pf, p, f_cache, dgdp_cache, paramjac_config, sensealg, sol, adj_sol, tunables, repack) = S
     _odef = sol.prob.f
-    f = unwrapped_f(_odef)
+    f = S.unwrappedf
 
     # Priority: vjp_p > paramjac > autojacvec dispatch.
     if SciMLBase.has_vjp_p(_odef)
@@ -635,7 +639,7 @@ end
 function update_p_integrand(integrand::AdjointSensitivityIntegrand, p)
     (;
         sol, adj_sol, y, λ, pf, f_cache, pJ, paramjac_config,
-        sensealg, dgdp_cache, dgdp,
+        sensealg, dgdp_cache, dgdp, unwrappedf,
     ) = integrand
     _use_full_p = hasproperty(sensealg, :diff_tunables) &&
         sensealg.diff_tunables isa Val{false} &&
@@ -649,7 +653,7 @@ function update_p_integrand(integrand::AdjointSensitivityIntegrand, p)
     end
     return AdjointSensitivityIntegrand(
         sol, adj_sol, p, y, λ, pf, f_cache, pJ, paramjac_config,
-        sensealg, dgdp_cache, dgdp, tunables, repack
+        sensealg, dgdp_cache, dgdp, tunables, repack, unwrappedf
     )
 end
 

--- a/test/Core3/allocation_regression.jl
+++ b/test/Core3/allocation_regression.jl
@@ -56,9 +56,9 @@ end
             SciMLSensitivity.vec_pjac!(out, λ, y, t, S)
             SciMLSensitivity.vec_pjac!(out, λ, y, t, S)
             a = minimum(@allocated(SciMLSensitivity.vec_pjac!(out, λ, y, t, S)) for _ in 1:5)
-            # measured 64 B (3 small allocs inside Enzyme.autodiff) on
-            # Julia 1.10 / Enzyme 0.13; the ceiling leaves 2x headroom.
-            @test a <= 128
+            # the warmed vec_pjac! inner loop is allocation-free: the Enzyme
+            # call itself is 0 B and `unwrapped_f` is hoisted to construction.
+            @test a == 0
         end
     end
 
@@ -67,9 +67,10 @@ end
             @info "coverage active — skipping adjoint allocation slope"
         else
             # slope = (allocs(T=100) - allocs(T=10)) / (fwd-steps difference).
-            # Measured: Gauss+Enzyme ~24 B/step, Interp+Enzyme 0 B/step.
+            # Both inner loops are allocation-free; the ceiling only leaves
+            # room for measurement noise.
             for (name, sa, ceiling) in [
-                    ("Gauss+EnzymeVJP", GaussAdjoint(autojacvec = EnzymeVJP()), 64.0),
+                    ("Gauss+EnzymeVJP", GaussAdjoint(autojacvec = EnzymeVJP()), 8.0),
                     ("Interp+EnzymeVJP", InterpolatingAdjoint(autojacvec = EnzymeVJP()), 8.0),
                 ]
                 a10, n10 = adjoint_allocs(10.0, sa)


### PR DESCRIPTION
**Note: please ignore this PR until reviewed by @ChrisRackauckas.**

Was stacked on #1527; now rebased onto master after its merge — single-commit diff.

## What

`unwrapped_f` on a `FunctionWrappersWrapper`-carrying `ODEFunction` (i.e. any `AutoSpecialize` problem — the default) is dynamic: **64 B and ~1.3 µs per call**. `vec_pjac!` called it on every evaluation, which was **96% of the runtime** of the GaussAdjoint integrand (3 Gauss nodes per accepted adjoint step) and likewise for every quadgk node in QuadratureAdjoint. The integrand constructors already compute `unwrapped_f` once — this PR stores it in the `GaussIntegrand`/`AdjointSensitivityIntegrand` structs and uses the cached value in `vec_pjac!`.

## Measured (Julia 1.10.11, Enzyme 0.13.171, min of 10 samples)

| metric | before | after |
|---|---|---|
| `vec_pjac!` per call (LV, EnzymeVJP) | 64 B / 1436 ns | **0 B / 35 ns (41×)** |
| GaussAdjoint full adjoint, LV 2×4 | 0.58 ms | **0.27 ms (2.1×)** |
| GaussAdjoint, 32×1024 + RTA EnzymeVJP (with #1527) | 0.46 ms | **0.38 ms** |
| GaussAdjoint+EnzymeVJP allocation slope | ~24 B/step | **0.0 B/step** |

With this, the GaussAdjoint+EnzymeVJP inner loop is **completely allocation-free** (identical total allocations at T=10 and T=100 — pure setup cost), matching InterpolatingAdjoint. The only adjoint with per-step allocations left is QuadratureAdjoint (~660 B/step from out-of-place quadgk nodes) — planned follow-up using `quadgk!` + `segbuf`.

## Tests

Tightens the allocation regression tests from #1527 to the new floor: `vec_pjac!` per-call ceiling 128 → **0 B**, Gauss slope ceiling 64 → 8 B/step (same as Interp).

## Local validation

- Gradients bit-identical to a `ReverseDiffVJP` reference for both GaussAdjoint (both Enzyme modes) and QuadratureAdjoint (relerr ≤ 5.4e-15)
- `Callbacks1/discrete_callbacks.jl`: **354/354** (covers the `update_p_integrand` reconstruction path that also changed)
- Allocation regression tests with the tightened ceilings: pass

Background: full analysis in https://github.com/ChrisRackauckas/InternalJunk/pull/61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzZhKZV2ameiUL8ouYknd