### PR TITLE
Revert failing second-order docs conversions

### DIFF
--- a/docs/src/examples/ode/second_order_adjoints.md
+++ b/docs/src/examples/ode/second_order_adjoints.md
@@ -24,7 +24,7 @@ import OrdinaryDiffEq as ODE
 import Plots
 import Random
 import OptimizationOptimJL as OOJ
-import Enzyme
+import Mooncake
 
 u0 = Float32[2.0; 0.0]
 datasize = 30
@@ -85,7 +85,7 @@ callback = function (state, l; doplot = false)
     return l < 0.01
 end
 
-adtype1 = OPT.AutoEnzyme()
+adtype1 = OPT.AutoMooncake(; config = Mooncake.Config(; friendly_tangents = true))
 optf1 = OPT.OptimizationFunction((x, p) -> loss_neuralode(x), adtype1)
 optprob1 = OPT.OptimizationProblem(optf1, ps)
 pstart = OPT.solve(optprob1, OPO.Adam(0.01); callback, maxiters = 100).u

--- a/docs/src/examples/ode/second_order_neural.md
+++ b/docs/src/examples/ode/second_order_neural.md
@@ -29,7 +29,7 @@ import OptimizationOptimisers as OPO
 import RecursiveArrayTools
 import Random
 import ComponentArrays as CA
-import Enzyme
+import Mooncake
 
 u0 = Float32[0.0; 2.0]
 du0 = Float32[0.0; 0.0]
@@ -62,7 +62,7 @@ callback = function (state, l)
     l < 0.01
 end
 
-adtype = OPT.AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Reverse))
+adtype = OPT.AutoMooncake(; config = Mooncake.Config(; friendly_tangents = true))
 optf = OPT.OptimizationFunction((x, p) -> loss_n_ode(x), adtype)
 optprob = OPT.OptimizationProblem(optf, ps)
 


### PR DESCRIPTION
This PR stacks on top of #1490 and reverts the two second-order docs conversions that currently fail locally, so #1490 can keep the passing conversions separate from follow-up failures.

Ignore this PR until reviewed by @ChrisRackauckas.

Changes:
- Revert `docs/src/examples/ode/second_order_adjoints.md` from Enzyme back to Mooncake.
- Revert `docs/src/examples/ode/second_order_neural.md` from Enzyme back to Mooncake.

Isolated follow-up issues opened:
- #1532: `second_order_adjoints.md` Enzyme conversion fails with `EnzymeRuntimeActivityError`.
- #1533: `second_order_neural.md` exits 139 during Documenter example execution.
- #1534: unrelated `simplechains.md` docs example fails with Enzyme illegal type analysis.

Local verification on Julia 1.12.6:

```sh
timeout 3600 env JULIA_DEPOT_PATH="$PWD/.julia_depot" /home/crackauc/.juliaup/bin/julia +1.12.6 --project -e 'using Pkg; Pkg.activate("docs"); push!(LOAD_PATH, pwd()); using Documenter, SciMLSensitivity; ENV["GKSwstype"]="100"; using Plots; makedocs(; root="docs", sitename="target", modules=[SciMLSensitivity], clean=true, doctest=false, linkcheck=false, warnonly=[:missing_docs], pages=["target" => "examples/ode/second_order_adjoints.md"])'
```

Result: exited 139 after reverting, so this is not a docs-green claim. The revert removes the PR-introduced Enzyme runtime-activity failure, but the original/Mooncake page still appears to have a separate crash.

Also ran `git diff --check`, which passed.