### PR TITLE
Document exported API coverage

### DIFF
--- a/docs/src/manual/differential_equation_sensitivities.md
+++ b/docs/src/manual/differential_equation_sensitivities.md
@@ -204,6 +204,7 @@ ForwardSensitivity
 ForwardDiffSensitivity
 BacksolveAdjoint
 GaussAdjoint
+GaussKronrodAdjoint
 InterpolatingAdjoint
 QuadratureAdjoint
 ReverseDiffAdjoint
@@ -211,10 +212,12 @@ TrackerAdjoint
 ZygoteAdjoint
 EnzymeAdjoint
 MooncakeAdjoint
+ForwardDiffOverAdjoint
 ForwardLSS
 AdjointLSS
 NILSS
 NILSAS
+SensitivityAlg
 ```
 
 ## Vector-Jacobian Product (VJP) Choices
@@ -225,6 +228,21 @@ EnzymeVJP
 TrackerVJP
 ReverseDiffVJP
 SciMLSensitivity.MooncakeVJP
+ReactantVJP
+ReactantVJPConfig
+ReactantDualTag
+supports_functor_params
+```
+
+## Shadowing Problem Interfaces
+
+```@docs
+ForwardLSSProblem
+AdjointLSSProblem
+NILSSProblem
+NILSASProblem
+shadow_forward
+shadow_adjoint
 ```
 
 ## More Details on Sensitivity Algorithm Choices

--- a/docs/src/manual/direct_adjoint_sensitivities.md
+++ b/docs/src/manual/direct_adjoint_sensitivities.md
@@ -4,6 +4,12 @@
 
 ```@docs
 adjoint_sensitivities
+ODEAdjointProblem
+SDEAdjointProblem
+RODEAdjointProblem
+AdjointSensitivityIntegrand
+SensitivityFunction
+StochasticTransformedFunction
 ```
 
 ## Second Order Adjoint Sensitivities

--- a/docs/src/manual/direct_forward_sensitivity.md
+++ b/docs/src/manual/direct_forward_sensitivity.md
@@ -2,5 +2,7 @@
 
 ```@docs
 ODEForwardSensitivityProblem
+ODELocalSensitivityProblem
+ODEForwardSensitivityFunction
 extract_local_sensitivities
 ```

--- a/docs/src/manual/nonlinear_solve_sensitivities.md
+++ b/docs/src/manual/nonlinear_solve_sensitivities.md
@@ -2,4 +2,5 @@
 
 ```@docs
 SteadyStateAdjoint
+UnconstrainedOptimizationAdjoint
 ```

--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -64,8 +64,93 @@ using Random: Random, rand!
 using SparseArrays: SparseArrays
 using Statistics: Statistics, mean
 
+"""
+    SensitivityFunction
+
+Abstract supertype for the internal right-hand-side functions used by
+SciMLSensitivity adjoint and callback sensitivity problems.
+
+Concrete subtypes carry the forward solution, cost-function derivatives,
+algorithm choice, and derivative caches needed by the generated sensitivity
+`ODEProblem`, `SDEProblem`, or `RODEProblem`. This is developer API for
+SciMLSensitivity and SciML solver integrations; users normally select a
+`sensealg` through `solve` or construct one of the documented sensitivity
+problem wrappers instead.
+"""
 abstract type SensitivityFunction end
+
+"""
+    TransformedFunction
+
+Abstract supertype for transformed differential-equation functions used inside
+SciMLSensitivity.
+
+Concrete subtypes adapt a user-supplied model into the drift or sensitivity
+form required by a sensitivity algorithm. This is developer API for
+SciMLSensitivity internals and extensions; it is not a user-facing modeling
+interface.
+"""
 abstract type TransformedFunction end
+
+"""
+    ODEAdjointProblem(sol, sensealg, alg, t=nothing,
+        dgdu_discrete=nothing, dgdp_discrete=nothing,
+        dgdu_continuous=nothing, dgdp_continuous=nothing, g=nothing; kwargs...)
+
+Construct the reverse-time `ODEProblem` used by continuous adjoint sensitivity
+algorithms.
+
+## Arguments
+
+  - `sol`: forward solution whose problem, trajectory, and parameters define the
+    adjoint system.
+  - `sensealg`: adjoint sensitivity algorithm, such as `BacksolveAdjoint`,
+    `InterpolatingAdjoint`, `QuadratureAdjoint`, or `GaussAdjoint`.
+  - `alg`: differential-equation solver algorithm used for the adjoint solve.
+  - `t`: saved time points for discrete costs. Use `nothing` for a continuous
+    cost.
+  - `dgdu_discrete`, `dgdp_discrete`: derivatives of a discrete cost at the
+    saved points.
+  - `dgdu_continuous`, `dgdp_continuous`: derivatives of a continuous cost
+    integrand.
+  - `g`: optional scalar cost function used when derivative callbacks are not
+    supplied.
+
+## Returns
+
+An `ODEProblem` whose state contains adjoint variables and parameter-gradient
+accumulators. Some internal methods can also return callback bookkeeping when
+requested by SciMLSensitivity internals.
+"""
+function ODEAdjointProblem end
+
+"""
+    SDEAdjointProblem(sol, sensealg, alg, t=nothing,
+        dgdu_discrete=nothing, dgdp_discrete=nothing,
+        dgdu_continuous=nothing, dgdp_continuous=nothing, g=nothing; kwargs...)
+
+Construct the reverse-time `SDEProblem` used by continuous adjoint sensitivity
+algorithms for stochastic differential equations.
+
+The arguments mirror `ODEAdjointProblem`. For Ito problems the drift is
+internally transformed to the adjoint-compatible form; Stratonovich problems use
+the original drift interpretation.
+"""
+function SDEAdjointProblem end
+
+"""
+    RODEAdjointProblem(sol, sensealg, alg, t=nothing,
+        dgdu_discrete=nothing, dgdp_discrete=nothing,
+        dgdu_continuous=nothing, dgdp_continuous=nothing, g=nothing; kwargs...)
+
+Construct the reverse-time `RODEProblem` used by continuous adjoint sensitivity
+algorithms for random ordinary differential equations.
+
+The arguments mirror `ODEAdjointProblem`. The returned problem reuses the
+forward solution noise process in reverse order and augments the state with
+adjoint and parameter-gradient variables.
+"""
+function RODEAdjointProblem end
 
 include("utils.jl")
 include("parameters_handling.jl")

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -573,8 +573,33 @@ end
 # Dispatched on inside extension.
 struct MooncakeLoaded end
 struct ReactantLoaded end
+"""
+    ReactantDualTag
+
+Tag type used by the Reactant extension to distinguish dual-number compilation
+paths from floating-point compilation paths.
+
+This is developer API for `SciMLSensitivityReactantExt` and related extension
+code.
+"""
 struct ReactantDualTag end
 
+"""
+    ReactantVJPConfig
+
+Compiled-kernel cache used by `ReactantVJP`.
+
+## Fields
+
+  - `float_kernel`, `dual_kernel`: Reactant-compiled kernels for ordinary and
+    dual-number execution.
+  - `float_caches`, `dual_caches`: buffers reused by the corresponding kernels.
+  - `is_nullparams`: whether the differentiated problem has null parameters.
+  - `chunk_size`: ForwardDiff chunk size used when dual execution is required.
+
+This is developer API for the Reactant extension; users normally configure it
+through `ReactantVJP`.
+"""
 struct ReactantVJPConfig{FK, DK, FC, DC}
     float_kernel::FK
     dual_kernel::DK

--- a/src/forward_sensitivity.jl
+++ b/src/forward_sensitivity.jl
@@ -1,11 +1,27 @@
 """
 ODEForwardSensitivityFunction{iip,F,A,Tt,OJ,J,JP,S,PJ,TW,TWt,UF,PF,JC,PJC,Alg,fc,JM,pJM,MM,CV} <: AbstractODEFunction{iip}
 
-ODEForwardSensitivityFunction is an internal to the ODEForwardSensitivityProblem which extends the AbstractODEFunction
-to be used in an ODEProblem, but defines the tools requires for calculating the extra differential equations associated
-with the derivative terms.
+Developer-facing `AbstractODEFunction` used by `ODEForwardSensitivityProblem`
+to append local forward sensitivity equations to an ODE.
 
-ODEForwardSensitivityFunction is not intended to be part of the public API.
+## Fields
+
+The fields store the primal ODE function, Jacobian and parameter-Jacobian
+definitions or AD caches, sensitivity algorithm choice, dimensions, temporary
+Jacobian buffers, mass matrix, and sparsity/coloring metadata.
+
+## Usage
+
+Users normally construct an `ODEForwardSensitivityProblem` instead of this type
+directly:
+
+```julia
+prob = ODEForwardSensitivityProblem(f, u0, tspan, p;
+    sensealg = ForwardSensitivity())
+```
+
+This type is exported for compatibility and extension code that needs to inspect
+or rebuild the generated `ODEFunction`.
 """
 struct ODEForwardSensitivityFunction{
         iip, F, A, Tt, OJ, J, JP, S, PJ, TW, TWt, UF, PF, JC,
@@ -211,6 +227,11 @@ end
     args...;
     kwargs...
 )
+@doc """
+    ODELocalSensitivityProblem(args...; kwargs...)
+
+Deprecated alias for `ODEForwardSensitivityProblem`.
+""" ODELocalSensitivityProblem
 
 struct ODEForwardSensitivityProblem{iip, A}
     sensealg::A

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -115,6 +115,30 @@ function LSSSensitivityFunction(
     )
 end
 
+"""
+    ForwardLSSProblem(sol, sensealg::ForwardLSS; kwargs...)
+
+Problem wrapper for forward least-squares shadowing sensitivities of chaotic
+ODE trajectories.
+
+## Arguments
+
+  - `sol`: reference solution whose saved time points define the shadowing
+    discretization.
+  - `sensealg`: `ForwardLSS` algorithm choice.
+
+## Keyword Arguments
+
+  - `t`: saved times for discrete cost derivatives.
+  - `dgdu_discrete`, `dgdp_discrete`: derivatives of a discrete cost.
+  - `dgdu_continuous`, `dgdp_continuous`: derivatives of a continuous cost.
+  - `g`: scalar observable used by time-dilation regularization.
+
+## Returns
+
+A `ForwardLSSProblem` containing the discretized reference trajectory, Schur
+factorization, work arrays, and derivative caches consumed by `shadow_forward`.
+"""
 struct ForwardLSSProblem{
         A, C, solType, dtType, umidType, dudtType, SType, Ftype, bType,
         ηType, wType, vType, windowType,
@@ -358,6 +382,17 @@ function b!(b, prob::ForwardLSSProblem)
     return nothing
 end
 
+"""
+    shadow_forward(prob::ForwardLSSProblem; sensealg=prob.sensealg)
+    shadow_forward(prob::NILSSProblem, alg; sensealg=prob.sensealg)
+
+Compute forward shadowing sensitivities.
+
+For `ForwardLSSProblem`, this solves the least-squares shadowing linear system
+on the already discretized trajectory and returns the parameter derivative of
+the averaged objective. For `NILSSProblem`, `alg` is the ODE solver used on each
+segment of the NILSS forward sensitivity problem.
+"""
 function shadow_forward(prob::ForwardLSSProblem; sensealg = prob.sensealg)
     return shadow_forward(prob, sensealg, sensealg.LSSregularizer)
 end
@@ -514,6 +549,16 @@ function lss_accumulate_cost!(u, p, t, sensealg::ForwardLSS, diffcache, idx)
 
     return nothing
 end
+"""
+    AdjointLSSProblem(sol, sensealg::AdjointLSS; kwargs...)
+
+Problem wrapper for adjoint least-squares shadowing sensitivities of chaotic ODE
+trajectories.
+
+The arguments and cost-derivative keywords match `ForwardLSSProblem`. The
+constructed problem stores the adjoint LSS Schur factorization and work arrays
+used by `shadow_adjoint`.
+"""
 struct AdjointLSSProblem{
         A, C, solType, dtType, umidType, dudtType, SType, FType, hType,
         bType, wType,
@@ -668,6 +713,17 @@ function wBcorrect!(S, sol, g, Nt, sense, sensealg)
     return nothing
 end
 
+"""
+    shadow_adjoint(prob::AdjointLSSProblem; sensealg=prob.sensealg)
+    shadow_adjoint(prob::NILSASProblem, alg; sensealg=prob.sensealg, kwargs...)
+
+Compute adjoint shadowing sensitivities.
+
+For `AdjointLSSProblem`, this solves the adjoint least-squares shadowing system
+and returns derivatives of the averaged objective with respect to parameters.
+For `NILSASProblem`, `alg` is the differential-equation solver used on each
+reverse segment.
+"""
 function shadow_adjoint(prob::AdjointLSSProblem; sensealg = prob.sensealg)
     return shadow_adjoint(prob, sensealg, sensealg.LSSregularizer)
 end

--- a/src/nilsas.jl
+++ b/src/nilsas.jl
@@ -40,6 +40,31 @@ function QuadratureCache(u0, M, nseg, numparams)
     )
 end
 
+"""
+    NILSASProblem(sol, sensealg::NILSAS, alg; kwargs...)
+
+Problem wrapper for non-intrusive least-squares adjoint shadowing
+sensitivities.
+
+## Arguments
+
+  - `sol`: forward solution of the ODE problem.
+  - `sensealg`: `NILSAS` algorithm choice.
+  - `alg`: solver algorithm used for the segmented adjoint solves.
+
+## Keyword Arguments
+
+  - `dgdu_continuous`, `dgdp_continuous`: derivatives of the continuous
+    objective.
+  - `g`: scalar observable; required by `NILSAS`.
+
+`NILSAS` currently rejects discrete cost functions.
+
+## Returns
+
+A `NILSASProblem` containing the adjoint segment problem, terminal conditions,
+quadrature cache, and work arrays consumed by `shadow_adjoint`.
+"""
 struct NILSASProblem{A, NILSS, Aprob, Qcache, solType, z0Type, tType, G, T, DG1, DG2}
     sensealg::A
     nilss::NILSS # diffcache

--- a/src/nilss.jl
+++ b/src/nilss.jl
@@ -71,6 +71,31 @@ function NILSSSensitivityFunction(
     )
 end
 
+"""
+    NILSSProblem(prob, sensealg::NILSS; kwargs...)
+
+Problem wrapper for non-intrusive least-squares shadowing forward
+sensitivities.
+
+## Arguments
+
+  - `prob`: ODE problem defining the chaotic trajectory.
+  - `sensealg`: `NILSS` algorithm choice.
+
+## Keyword Arguments
+
+  - `t`: discrete saved-time grid. When supplied, it must align with the NILSS
+    segment save spacing.
+  - `dgdu_discrete`, `dgdp_discrete`: derivatives of a discrete objective.
+  - `dgdu_continuous`, `dgdp_continuous`: derivatives of a continuous objective.
+  - `g`: scalar observable; required by `NILSS`.
+
+## Returns
+
+A `NILSSProblem` containing the segmented forward sensitivity problem,
+orthonormalization buffers, quadrature weights, and work arrays consumed by
+`shadow_forward`.
+"""
 struct NILSSProblem{
         A, CacheType, FSprob, probType, u0Type, vstar0Type, w0Type,
         TType, dtType, gType, yType, vstarType,

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -213,6 +213,25 @@ end
     end
 end
 
+"""
+    AdjointSensitivityIntegrand(sol, adj_sol, sensealg, dgdp=nothing)
+
+Callable quadrature integrand for parameter-gradient accumulation in
+`QuadratureAdjoint` and related continuous adjoint paths.
+
+## Arguments
+
+  - `sol`: forward solution.
+  - `adj_sol`: reverse adjoint solution.
+  - `sensealg`: quadrature-style adjoint algorithm.
+  - `dgdp`: optional continuous cost derivative with respect to parameters.
+
+## Returns
+
+A callable object. Calling `integrand(out, t)` writes the row vector
+``lambda(t)' * df/ dp + dg / dp`` into `out`, and calling `integrand(t)`
+allocates and returns that value.
+"""
 struct AdjointSensitivityIntegrand{
         pType, uType, lType, rateType, S, AS, PF, PJC, PJT, DGP,
         G, tType, rType, UF,

--- a/src/sde_tools.jl
+++ b/src/sde_tools.jl
@@ -1,4 +1,25 @@
 # for Ito / Stratonovich conversion
+"""
+    StochasticTransformedFunction(sol, f, g, corfunc_analytical=nothing)
+
+Drift-function wrapper used when constructing stochastic adjoint problems.
+
+For Ito SDEs, the wrapper subtracts the noise-induced correction from the drift
+so continuous adjoint equations can be formed in the required interpretation.
+For Stratonovich problems this transformation is not needed.
+
+## Arguments
+
+  - `sol`: forward stochastic solution.
+  - `f`: drift function.
+  - `g`: diffusion function.
+  - `corfunc_analytical`: optional analytical correction function.
+
+## Returns
+
+A callable `StochasticTransformedFunction` with both in-place and out-of-place
+methods matching the original drift function style.
+"""
 struct StochasticTransformedFunction{
         pType, fType <: AbstractDiffEqFunction,
         gType, noiseType, cfType,

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -1,3 +1,13 @@
+"""
+    SensitivityAlg(args...; kwargs...)
+
+Deprecated sensitivity-algorithm selector.
+
+SciMLSensitivity now uses explicit sensitivity algorithm types such as
+`ForwardSensitivity`, `GaussAdjoint`, `InterpolatingAdjoint`, and
+`SteadyStateAdjoint`. Calling `SensitivityAlg` emits an error message directing
+users to the current sensitivity documentation.
+"""
 function SensitivityAlg(args...; kwargs...)
     return @error("The SensitivityAlg choice mechanism was completely overhauled. Please consult the local sensitivity documentation for more information")
 end

--- a/test/QA/public_api_docs.jl
+++ b/test/QA/public_api_docs.jl
@@ -1,0 +1,59 @@
+using SciMLSensitivity
+using Test
+
+function exported_names(mod)
+    return Set(
+        filter!(
+            name -> name != nameof(mod),
+            collect(names(mod; all = false, imported = false))
+        )
+    )
+end
+
+function documented_names(root)
+    docs = Set{Symbol}()
+    for (dir, _, files) in walkdir(joinpath(root, "docs", "src"))
+        for file in files
+            endswith(file, ".md") || continue
+            in_docs_block = false
+            for raw_line in eachline(joinpath(dir, file))
+                line = strip(raw_line)
+                if startswith(line, "```@docs")
+                    in_docs_block = true
+                    continue
+                elseif in_docs_block && startswith(line, "```")
+                    in_docs_block = false
+                    continue
+                end
+                in_docs_block || continue
+                isempty(line) && continue
+                startswith(line, "#") && continue
+
+                name = first(split(line))
+                name = replace(name, "SciMLSensitivity." => "")
+                push!(docs, Symbol(name))
+            end
+        end
+    end
+    return docs
+end
+
+function has_docstring(mod, name)
+    object = getfield(mod, name)
+    doc = sprint(show, MIME"text/plain"(), Docs.doc(object))
+    return !contains(doc, "No documentation found")
+end
+
+root = normpath(joinpath(@__DIR__, "..", ".."))
+exports = exported_names(SciMLSensitivity)
+rendered_docs = documented_names(root)
+
+@testset "exported API has docstrings" begin
+    missing_docstrings = sort!(collect(filter(name -> !has_docstring(SciMLSensitivity, name), exports)))
+    @test isempty(missing_docstrings)
+end
+
+@testset "exported API is rendered in docs" begin
+    missing_rendered_docs = sort!(collect(setdiff(exports, rendered_docs)))
+    @test isempty(missing_rendered_docs)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -157,7 +157,10 @@ run_tests(;
         ),
     ),
     qa = function ()
-        return @time @safetestset "Quality Assurance" include("QA/aqua.jl")
+        return @testset "Quality Assurance" begin
+            @time @safetestset "Aqua" include("QA/aqua.jl")
+            @time @safetestset "Public API docs" include("QA/public_api_docs.jl")
+        end
     end,
     all = [
         "Core1", "Core2", "Core3", "Core4", "Core5", "Core6", "Core7", "Core8",


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Add docstrings for exported/public API names that were missing source documentation.
- Add missing exported API entries to the rendered manual pages.
- Add QA coverage that checks every exported name has a docstring and appears in a docs `@docs` block.

## Validation
- `Runic.main(... --check ...)` on touched source/test files passed.
- `include("test/QA/public_api_docs.jl")` passed: exported API has docstrings 1/1, exported API is rendered in docs 1/1.
- Direct Aqua QA run passed earlier: `Quality Assurance | 17 | 17`.
- Full docs build was attempted with `timeout 3600 env JULIA_NUM_THREADS=1 julia +release --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'`. It logged unrelated executable-example failures in `docs/src/examples/neural_ode/simplechains.md` and `docs/src/examples/ode/second_order_neural.md` before reaching the one-hour timeout.