### PR TITLE
Fix GaussAdjoint checkpointing with non-dense Sundials solutions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.115.0"
+version = "7.115.1"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]
@@ -128,7 +128,7 @@ StaticArraysCore = "1.4.4"
 Statistics = "1.10"
 SteadyStateDiffEq = "2.10.1"
 StochasticDiffEq = "7"
-Sundials = "6.3.0"
+Sundials = "6.4.0"
 SymbolicIndexingInterface = "0.3.48"
 Test = "1.10"
 Tracker = "0.2.38"

--- a/test/Core2/sundials_adjoint.jl
+++ b/test/Core2/sundials_adjoint.jl
@@ -201,3 +201,30 @@ end
         sensealg = SundialsAdjoint(autojacvec = true)
     )
 end
+
+@testset "GaussAdjoint with CVODE_BDF" begin
+    # A `saveat` (non-dense) forward solution auto-enables Gauss checkpointing,
+    # whose dense checkpoint re-solves carry a different interpolation type
+    # (Hermite) than the original Sundials solution (linear).
+    sol_saveat = solve(
+        prob, CVODE_BDF(), abstol = 1.0e-10, reltol = 1.0e-10, saveat = ts
+    )
+    du0, dp = adjoint_sensitivities(
+        sol_saveat, CVODE_BDF(); t = ts, dgdu_discrete = dgdu,
+        sensealg = GaussAdjoint(autojacvec = ReverseDiffVJP()),
+        abstol = 1.0e-8, reltol = 1.0e-8
+    )
+    @test du0 ≈ refgrad[1:2] rtol = 1.0e-5
+    @test vec(dp) ≈ refgrad[3:end] rtol = 1.0e-5
+
+    sol_dense = solve(
+        prob, CVODE_BDF(), abstol = 1.0e-10, reltol = 1.0e-10, dense = true
+    )
+    du0d, dpd = adjoint_sensitivities(
+        sol_dense, CVODE_BDF(); t = ts, dgdu_discrete = dgdu,
+        sensealg = GaussAdjoint(autojacvec = ReverseDiffVJP()),
+        abstol = 1.0e-8, reltol = 1.0e-8
+    )
+    @test du0d ≈ refgrad[1:2] rtol = 1.0e-5
+    @test vec(dpd) ≈ refgrad[3:end] rtol = 1.0e-5
+end


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Bug

`GaussAdjoint` fails with a `MethodError` whenever the forward solution is non-dense (e.g. solved with `saveat`) and its solution type differs from a dense re-solve's — which is the case for all Sundials solvers.

```julia
using SciMLSensitivity, Sundials, ForwardDiff
f!(du,u,p,t) = (du[1]=p[1]*u[1]-p[2]*u[1]*u[2]; du[2]=-p[3]*u[2]+p[4]*u[1]*u[2]; nothing)
prob = ODEProblem(f!, [1.0,1.0], (0.0,10.0), [1.5,1.0,3.0,1.0])
ts = collect(0.0:0.5:10.0)
sol = solve(prob, CVODE_BDF(), abstol=1e-10, reltol=1e-10, saveat=ts)   # non-dense
dg(out,u,p,t,i) = (out .= 1.0)
adjoint_sensitivities(sol, CVODE_BDF(); t=ts, dgdu_discrete=dg,
    sensealg=GaussAdjoint(autojacvec=ReverseDiffVJP()))
```

On master this errors with:

```
MethodError: Cannot `convert` an object of type
  ODESolution{..., SciMLBase.HermiteInterpolation{...}, ...} to an object of type
  ODESolution{..., SciMLBase.LinearInterpolation{...}, ...}
Stacktrace:
  [1] setproperty!(x::SciMLSensitivity.GaussIntegrand{...}, f::Symbol, v::ODESolution{...})
  [2] SciMLSensitivity.ODEGaussAdjointSensitivityFunction(...) at src/gauss_adjoint.jl:72
  [3] ODEAdjointProblem(...) at src/gauss_adjoint.jl:360
  [4] _adjoint_sensitivities(...) at src/gauss_adjoint.jl:835
```

## Root cause

`ischeckpointing(GaussAdjoint, sol)` auto-enables checkpointing for non-dense forward solutions. The Gauss checkpointing machinery then re-solves checkpoint intervals with `dense = true` and reassigns the result to `GaussIntegrand`'s `sol` field (in `ODEGaussAdjointSensitivityFunction`, `split_states`, and `Gaussupdate_checkpoint_sol!`). But `mutable struct GaussIntegrand{..., S, ...}` had `sol::S` concretely typed to the *original* solution's type. For Sundials, a `saveat` solution carries `SciMLBase.LinearInterpolation` while a dense re-solve carries `SciMLBase.HermiteInterpolation`, so the implicit `convert` in `setproperty!` throws. For OrdinaryDiffEq solvers both are `InterpolationData`, which is why the bug was masked there.

## Fix

Of the options considered:

- *Construct `GaussIntegrand` with the checkpoint-solution type from the start*: not workable without restructuring — the integrand is built in `_adjoint_sensitivities` (the integrating callback needs it) before the checkpoint intervals/tolerances are resolved inside `ODEAdjointProblem`, and the dense re-solve's type can't be known without doing the solve.
- *Store the checkpoint solution only in `GaussCheckpointSolution`*: doesn't help — the integrand has no reference to that struct, and `GaussCheckpointSolution.cpsol` is itself concretely typed (fine there, since all its re-solves have one consistent dense type; the type mismatch is only against the *original* solution).
- **Loosen the field (chosen)**: `sol::Any`, with the hot paths kept inferred.

To keep `vec_pjac!` (the per-quadrature-node VJP, also reused by the CVODES `SundialsAdjoint` extension) fully inferred, `sol.prob.f` is hoisted into a new concretely-typed `odefunc` field at construction — it is invariant across checkpoint re-solves, which `remake` the same problem — mirroring how `unwrappedf` was already hoisted. After this, `vec_pjac!` never reads `sol`; the only dynamic call left is the once-per-node interpolation `sol(y, t)` in the integrand functor, which is negligible next to the VJP itself.

## Performance check (Lotka-Volterra, Tsit5, ReverseDiffVJP, 7 runs each, two sessions)

| case | master min/median | fix min/median | master alloc | fix alloc |
|---|---|---|---|---|
| dense | 27.2 / 32.1 ms; 28.1 / 38.1 ms | 28.2 / 29.1 ms; 28.0 / 35.3 ms | 15,674,704 B | 15,709,792 B |
| checkpointing | 39.8 / 40.1 ms; 39.5 / 41.2 ms | 40.6 / 41.2 ms; 40.0 / 40.6 ms | 24,863,248 B | 24,873,664 B |

Timings are within run-to-run noise; allocations +0.2% (dense) / +0.04% (checkpointing).

## Tests

New regression testset `"GaussAdjoint with CVODE_BDF"` in `test/Core2/sundials_adjoint.jl`: GaussAdjoint + CVODE_BDF with a `saveat` (non-dense, auto-checkpointing) forward solution and with a `dense = true` forward solution, both `du0` and `dp` validated against a ForwardDiff/Vern9 reference at `rtol = 1e-5`.

Local runs (Julia 1.10.11):

```
Test Summary:    | Pass  Total     Time
sundials_adjoint |   32     32  2m14.7s

Test Summary:                           | Pass  Total  Time
Gauss adjoint regression vs ForwardDiff |   11     11  0.7s
  (replicates the GaussAdjoint/GaussKronrodAdjoint blocks of test/Core3/adjoint.jl:
   default/ReverseDiffVJP(true)/EnzymeVJP/autojacvec=false, checkpointing=true,
   GaussKronrod checkpointing, in-place and OOP)

Test Summary:        | Pass  Total     Time
gauss_zygote_inplace |   15     15  2m29.6s
```

The repro above now returns gradients matching `ForwardDiff.gradient` to `rtol = 1e-5` for both `du0` and `dp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrfZy7xBqQLgTqok5zGAdY
