### PR TITLE
Add DAEProblem support to SundialsAdjoint via the SUNDIALS IDAS C adjoint interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.115.0"
+version = "7.116.0"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]

--- a/ext/SciMLSensitivitySundialsExt.jl
+++ b/ext/SciMLSensitivitySundialsExt.jl
@@ -885,6 +885,16 @@ function _adjoint_sensitivities(
     ncheck = Ref{Cint}(0)
     which = Ref{Cint}(0)
 
+    # The forward/backward linear solvers and matrices are raw SUNDIALS pointers
+    # that IDAS uses for the whole integration; they carry no finalizer, so they
+    # must stay bound (pre-declared here, assigned inside the `try`) and be freed
+    # explicitly in the `finally` after `IDAFree` (via `empty!(mem)`) and before
+    # `SUNContext_Free`, otherwise they leak. `:GMRES` returns a `nothing` matrix.
+    local LSf = nothing
+    local Af = nothing
+    local LSB = nothing
+    local AB = nothing
+
     GC.@preserve data ufwd_nv dufwd_nv yret_nv ypret_nv yinterp_nv ypinterp_nv λ_nv λp_nv qB_nv id_nv begin
         try
             # Forward pass with checkpointing. The provided `(u0, du0)` are
@@ -1099,6 +1109,10 @@ function _adjoint_sensitivities(
             has_p && (dp .+= qB)
         finally
             empty!(mem)
+            LSf === nothing || Sundials.SUNLinSolFree(LSf)
+            LSB === nothing || Sundials.SUNLinSolFree(LSB)
+            Af === nothing || Sundials.SUNMatDestroy(Af)
+            AB === nothing || Sundials.SUNMatDestroy(AB)
             Sundials.SUNContext_Free(ctx)
         end
     end

--- a/ext/SciMLSensitivitySundialsExt.jl
+++ b/ext/SciMLSensitivitySundialsExt.jl
@@ -4,12 +4,12 @@ using SciMLSensitivity: SciMLSensitivity, SciMLBase, SciMLLogging,
     SundialsAdjoint, QuadratureAdjoint, GaussAdjoint,
     ODEQuadratureAdjointSensitivityFunction, GaussIntegrand,
     vecjacobian!, vec_pjac!, accumulate_cost!, inplace_vjp,
-    ReverseDiffVJP, mutable_zeros,
+    ReverseDiffVJP, mutable_zeros, compile_tape, ReverseDiff,
     canonicalize, Tunable, isscimlstructure, unwrapped_f
 import SciMLSensitivity: _adjoint_sensitivities
-using SciMLBase: ODEProblem, isinplace
+using SciMLBase: ODEProblem, DAEProblem, isinplace
 using Sundials: Sundials, N_Vector, NVector, realtype
-using LinearAlgebra: I, UniformScaling
+using LinearAlgebra: I, UniformScaling, pinv, norm, mul!
 
 _cvodes_lmm(::Sundials.CVODE_BDF) = Sundials.CV_BDF
 _cvodes_lmm(::Sundials.CVODE_Adams) = Sundials.CV_ADAMS
@@ -189,7 +189,10 @@ function _adjoint_sensitivities(
 
     prob = sol.prob
     prob isa ODEProblem ||
-        error("SundialsAdjoint only supports `ODEProblem`s.")
+        error(
+        "SundialsAdjoint with `CVODE_BDF`/`CVODE_Adams` only supports `ODEProblem`s. " *
+            "For a `DAEProblem`, use `IDA()` as the solver instead."
+    )
     isinplace(prob) ||
         error("SundialsAdjoint currently only supports in-place (mutating) `ODEProblem`s.")
     mm = prob.f.mass_matrix
@@ -483,6 +486,624 @@ function _adjoint_sensitivities(
 
     du0 = copy(λ)
     return du0, has_p ? dp' : nothing
+end
+
+# ===== IDAS adjoint for fully implicit DAEProblems =====
+#
+# Backward problem in residual form (Cao–Li–Petzold; IDAS user guide):
+#
+#     resB = (∂F/∂du)ᵀ ypB − (∂F/∂u)ᵀ yB
+#
+# which is the adjoint DAE  d/dt[(∂F/∂du)ᵀ λ] − (∂F/∂u)ᵀ λ = 0  under the
+# assumption that ∂F/∂du is CONSTANT (F linear in `du` with state- and
+# time-independent coefficients), so the d/dt(∂F/∂du)ᵀ λ term vanishes.
+# The parameter gradient is the backward quadrature  qB' = (∂F/∂p)ᵀ λ  with
+# qB(tf) = 0, giving  dG/dp = qB(t0) = −∫ λᵀ (∂F/∂p) dt, and the gradient
+# with respect to the initial state is  (∂F/∂du)ᵀ λ |_{t0}  (plus any cost
+# jump exactly at t0). These conventions reproduce the analytic gradients of
+# the SUNDIALS `idas` adjoint examples.
+
+function _check_idas_flag(flag, fname)
+    return flag >= Sundials.IDA_SUCCESS ||
+        error("SundialsAdjoint: $fname failed with error code = $flag")
+end
+
+_idas_linear_solver(::Sundials.SundialsDAEAlgorithm{LS}) where {LS} = LS
+
+function _idas_set_solvers(ls_setter, alg, unv, n, ctx)
+    linear_solver = _idas_linear_solver(alg)
+    if linear_solver == :Dense
+        A = Sundials.SUNDenseMatrix(n, n, ctx)
+        LS = Sundials.SUNLinSol_Dense(unv, A, ctx)
+        _check_idas_flag(ls_setter(LS, A), "IDASetLinearSolver")
+        return LS, A
+    elseif linear_solver == :Band
+        A = Sundials.SUNBandMatrix(n, alg.jac_upper, alg.jac_lower, ctx)
+        LS = Sundials.SUNLinSol_Band(unv, A, ctx)
+        _check_idas_flag(ls_setter(LS, A), "IDASetLinearSolver")
+        return LS, A
+    elseif linear_solver == :GMRES
+        krylov_dim = alg.krylov_dim == 0 ? 5 : alg.krylov_dim
+        LS = Sundials.SUNLinSol_SPGMR(unv, Cint(Sundials.PREC_NONE), Cint(krylov_dim), ctx)
+        # A typed null pointer is required for dispatch to reach the ccall method.
+        nullmat = Sundials.SUNMatrix(C_NULL)
+        _check_idas_flag(ls_setter(LS, nullmat), "IDASetLinearSolver")
+        return LS, nothing
+    else
+        error(
+            "SundialsAdjoint with `IDA` currently supports the `:Dense`, `:Band`, and " *
+                "`:GMRES` linear solvers, got `$(linear_solver)`."
+        )
+    end
+end
+
+# Records a ReverseDiff tape of the DAE residual over `(du, u[, p], t)`.
+function _idas_dae_tape(f, p, has_p, repack, du, u, tunables, t)
+    _du = collect(Float64, du)
+    _u = collect(Float64, u)
+    if has_p
+        return ReverseDiff.GradientTape(
+            (_du, _u, collect(Float64, tunables), [t])
+        ) do du_, u_, p_, t_
+            res = similar(u_, size(u_))
+            res .= false
+            f(res, du_, u_, repack(p_), first(t_))
+            return vec(res)
+        end
+    else
+        return ReverseDiff.GradientTape((_du, _u, [t])) do du_, u_, t_
+            res = similar(u_, size(u_))
+            res .= false
+            f(res, du_, u_, p, first(t_))
+            return vec(res)
+        end
+    end
+end
+
+# User data passed through the IDAS C callbacks via `IDASetUserData(B)`. With
+# `compile = true` the recorded `tape` is reused (which freezes control flow,
+# the standard `ReverseDiffVJP(true)` restriction); otherwise a fresh tape is
+# recorded at every evaluation point, matching the `vecjacobian!` convention.
+mutable struct IDASAdjointUserData{ND, F, P, RP, TU, T}
+    const f::F
+    const p::P
+    const repack::RP
+    const tunables::TU
+    const has_p::Bool
+    const sz::NTuple{ND, Int}
+    const n::Int
+    const tape::T
+    const dλ::Vector{Float64}
+    const ddu::Vector{Float64}
+    const tscratch::Vector{Float64}
+end
+
+# Computes vector-Jacobian products of the DAE residual at the forward point
+# `(yp, y, t)`: seeds `yB` to get `(∂F/∂u)ᵀ yB` into `data.dλ` (and, when
+# `dgrad !== nothing`, `(∂F/∂p)ᵀ yB` into `dgrad`), and seeds `ypB` to get
+# `(∂F/∂du)ᵀ ypB` into `data.ddu`. Both seeds share one tape forward pass;
+# ReverseDiff clears instruction-output derivatives during the reverse pass,
+# so only the input hooks need unseeding between the two reverse passes.
+function _idas_res_vjps!(data::IDASAdjointUserData, y, yp, t, yB, ypB, dgrad)
+    tape = data.tape === nothing ?
+        _idas_dae_tape(
+            data.f, data.p, data.has_p, data.repack, yp, y,
+            data.tunables, t
+        ) : data.tape
+    if data.has_p
+        tdu, tu, tp, tt = ReverseDiff.input_hook(tape)
+    else
+        tdu, tu, tt = ReverseDiff.input_hook(tape)
+        tp = nothing
+    end
+    output = ReverseDiff.output_hook(tape)
+    ReverseDiff.unseed!(tdu)
+    ReverseDiff.unseed!(tu)
+    tp === nothing || ReverseDiff.unseed!(tp)
+    ReverseDiff.unseed!(tt)
+    ReverseDiff.value!(tdu, yp)
+    ReverseDiff.value!(tu, y)
+    tp === nothing || ReverseDiff.value!(tp, data.tunables)
+    data.tscratch[1] = t
+    ReverseDiff.value!(tt, data.tscratch)
+    ReverseDiff.forward_pass!(tape)
+    if yB !== nothing
+        ReverseDiff.increment_deriv!(output, yB)
+        ReverseDiff.reverse_pass!(tape)
+        copyto!(vec(data.dλ), ReverseDiff.deriv(tu))
+        dgrad === nothing || copyto!(vec(dgrad), ReverseDiff.deriv(tp))
+        if ypB !== nothing
+            ReverseDiff.unseed!(tdu)
+            ReverseDiff.unseed!(tu)
+            tp === nothing || ReverseDiff.unseed!(tp)
+            ReverseDiff.unseed!(tt)
+        end
+    end
+    if ypB !== nothing
+        ReverseDiff.increment_deriv!(output, ypB)
+        ReverseDiff.reverse_pass!(tape)
+        copyto!(vec(data.ddu), ReverseDiff.deriv(tdu))
+    end
+    return nothing
+end
+
+function _idas_forward_res(
+        t::realtype, yy_nv::N_Vector, yp_nv::N_Vector, rr_nv::N_Vector,
+        data::IDASAdjointUserData{ND}
+    ) where {ND}
+    y = unsafe_wrap(Array{Float64, ND}, Sundials.N_VGetArrayPointer_Serial(yy_nv), data.sz)
+    dy = unsafe_wrap(Array{Float64, ND}, Sundials.N_VGetArrayPointer_Serial(yp_nv), data.sz)
+    res = unsafe_wrap(
+        Array{Float64, ND}, Sundials.N_VGetArrayPointer_Serial(rr_nv),
+        data.sz
+    )
+    data.f(res, dy, y, data.p, t)
+    return Sundials.IDA_SUCCESS
+end
+
+function _idas_adjoint_res(
+        t::realtype, yy_nv::N_Vector, yp_nv::N_Vector, yyB_nv::N_Vector,
+        ypB_nv::N_Vector, rrB_nv::N_Vector, data::IDASAdjointUserData{ND}
+    ) where {ND}
+    y = unsafe_wrap(Array{Float64, ND}, Sundials.N_VGetArrayPointer_Serial(yy_nv), data.sz)
+    dy = unsafe_wrap(Array{Float64, ND}, Sundials.N_VGetArrayPointer_Serial(yp_nv), data.sz)
+    λ = unsafe_wrap(Vector{Float64}, Sundials.N_VGetArrayPointer_Serial(yyB_nv), data.n)
+    λp = unsafe_wrap(Vector{Float64}, Sundials.N_VGetArrayPointer_Serial(ypB_nv), data.n)
+    out = unsafe_wrap(Vector{Float64}, Sundials.N_VGetArrayPointer_Serial(rrB_nv), data.n)
+    _idas_res_vjps!(data, y, dy, t, λ, λp, nothing)
+    @. out = data.ddu - data.dλ
+    return Sundials.IDA_SUCCESS
+end
+
+function _idas_quad_rhs(
+        t::realtype, yy_nv::N_Vector, yp_nv::N_Vector, yyB_nv::N_Vector,
+        ypB_nv::N_Vector, qBdot_nv::N_Vector, data::IDASAdjointUserData{ND}
+    ) where {ND}
+    y = unsafe_wrap(Array{Float64, ND}, Sundials.N_VGetArrayPointer_Serial(yy_nv), data.sz)
+    dy = unsafe_wrap(Array{Float64, ND}, Sundials.N_VGetArrayPointer_Serial(yp_nv), data.sz)
+    λ = unsafe_wrap(Vector{Float64}, Sundials.N_VGetArrayPointer_Serial(yyB_nv), data.n)
+    out = unsafe_wrap(
+        Vector{Float64}, Sundials.N_VGetArrayPointer_Serial(qBdot_nv),
+        length(data.tunables)
+    )
+    _idas_res_vjps!(data, y, dy, t, λ, nothing, out)
+    return Sundials.IDA_SUCCESS
+end
+
+function _idas_forward_cfunction(::T) where {T <: IDASAdjointUserData}
+    return @cfunction(
+        _idas_forward_res, Cint,
+        (realtype, N_Vector, N_Vector, N_Vector, Ref{T})
+    )
+end
+
+function _idas_adjoint_cfunction(::T) where {T <: IDASAdjointUserData}
+    return @cfunction(
+        _idas_adjoint_res, Cint,
+        (realtype, N_Vector, N_Vector, N_Vector, N_Vector, N_Vector, Ref{T})
+    )
+end
+
+function _idas_quad_cfunction(::T) where {T <: IDASAdjointUserData}
+    return @cfunction(
+        _idas_quad_rhs, Cint,
+        (realtype, N_Vector, N_Vector, N_Vector, N_Vector, N_Vector, Ref{T})
+    )
+end
+
+# Solves `(∂F/∂du)ᵀ Δλ = gu` for the adjoint jump at a discrete cost time and
+# errors when `gu` is not in the range of `(∂F/∂du)ᵀ`, i.e. when the cost
+# depends on algebraic variables — that case needs a constraint-transfer term
+# this implementation does not provide, so failing loudly beats a silently
+# wrong gradient.
+function _idas_cost_jump(Mtpinv, Mt, gu, t)
+    Δλ = Mtpinv * gu
+    resid = Mt * Δλ .- gu
+    if norm(resid) > max(1.0e-10, 1.0e-8 * norm(gu))
+        error(
+            "SundialsAdjoint with `IDA` does not support discrete cost gradients " *
+                "(`dgdu_discrete`) with nonzero components for algebraic variables " *
+                "(detected at t = $t). Formulate the cost in terms of the " *
+                "differential variables of the DAE."
+        )
+    end
+    return Δλ
+end
+
+function _adjoint_sensitivities(
+        sol, sensealg::SundialsAdjoint{CS, AD, FDT},
+        alg::Sundials.IDA;
+        t = nothing,
+        dgdu_discrete = nothing,
+        dgdp_discrete = nothing,
+        dgdu_continuous = nothing,
+        dgdp_continuous = nothing,
+        g = nothing, no_start = false,
+        abstol = 1.0e-6, reltol = 1.0e-3,
+        maxiters = Int(1.0e5),
+        verbose = SciMLLogging.Standard(),
+        kwargs...
+    ) where {CS, AD, FDT}
+    prob = sol.prob
+    prob isa DAEProblem ||
+        error(
+        "SundialsAdjoint with `IDA` only supports `DAEProblem`s. For an " *
+            "`ODEProblem`, use `CVODE_BDF()` or `CVODE_Adams()` as the solver instead."
+    )
+    isinplace(prob) ||
+        error("SundialsAdjoint currently only supports in-place (mutating) `DAEProblem`s.")
+    u0 = prob.u0
+    du0 = prob.du0
+    eltype(u0) === Float64 && eltype(prob.tspan) === Float64 ||
+        error("SundialsAdjoint requires `Float64` state and time (a SUNDIALS restriction).")
+    t0, tf = prob.tspan
+    t0 < tf || error("SundialsAdjoint requires a forward time span with `tspan[1] < tspan[2]`.")
+    diffvars = prob.differential_vars
+    diffvars === nothing &&
+        error(
+        "SundialsAdjoint with `IDA` requires the `DAEProblem` to specify " *
+            "`differential_vars` (needed for consistent initialization of the " *
+            "backward problem via `IDACalcICB`)."
+    )
+
+    if dgdu_continuous !== nothing || dgdp_continuous !== nothing || g !== nothing
+        error(
+            "SundialsAdjoint with `IDA` currently only supports discrete cost " *
+                "functionals (`t` with `dgdu_discrete`). Continuous cost functionals " *
+                "(`g`/`dgdu_continuous`/`dgdp_continuous`) are not yet implemented " *
+                "for `DAEProblem`s."
+        )
+    end
+    t !== nothing && dgdu_discrete !== nothing ||
+        error(
+        "SundialsAdjoint with `IDA` requires a discrete cost functional: pass " *
+            "the cost times `t` together with `dgdu_discrete`."
+    )
+
+    ts = collect(Float64, t)
+    issorted(ts) || error("SundialsAdjoint requires the cost times `t` to be sorted in ascending order.")
+    if !isempty(ts) && !(first(ts) >= t0 && last(ts) <= tf)
+        error("SundialsAdjoint requires all cost times `t` to lie within the problem `tspan`.")
+    end
+
+    p = prob.p
+    has_p = !(p === nothing || p isa SciMLBase.NullParameters)
+    if has_p
+        if isscimlstructure(p) && !(p isa AbstractArray)
+            tunables, repack, _ = canonicalize(Tunable(), p)
+        elseif p isa AbstractArray
+            tunables, repack = p, identity
+        else
+            error(
+                "SundialsAdjoint requires the parameters to be an `AbstractArray` or a " *
+                    "SciMLStructures-compatible struct, got `$(typeof(p))`."
+            )
+        end
+    else
+        tunables, repack = Float64[], identity
+    end
+
+    # `adjoint_sensitivities` resolves `autojacvec === nothing` via
+    # `inplace_vjp`, which returns `ReverseDiffVJP()` for DAEProblems; the
+    # `nothing` branch here only triggers on direct `_adjoint_sensitivities`
+    # calls.
+    vjp = sensealg.autojacvec === nothing ? ReverseDiffVJP() : sensealg.autojacvec
+    vjp isa ReverseDiffVJP ||
+        error(
+        "SundialsAdjoint with `IDA` currently only supports " *
+            "`autojacvec = ReverseDiffVJP()` for the DAE residual vector-Jacobian " *
+            "products, got `$(typeof(vjp))`."
+    )
+
+    n = length(u0)
+    np = length(tunables)
+    f = unwrapped_f(prob.f)
+    tape = compile_tape(vjp) ?
+        ReverseDiff.compile(_idas_dae_tape(f, p, has_p, repack, du0, u0, tunables, t0)) :
+        nothing
+    data = IDASAdjointUserData(
+        f, p, repack, has_p ? mutable_zeros(tunables) : Float64[], has_p,
+        size(u0), n, tape, zeros(n), zeros(n), [t0]
+    )
+    has_p && copyto!(data.tunables, tunables)
+    fwd_cfun = _idas_forward_cfunction(data)
+    adj_cfun = _idas_adjoint_cfunction(data)
+    quad_cfun = has_p ? _idas_quad_cfunction(data) : nothing
+
+    u0v = collect(Float64, vec(u0))
+    du0v = collect(Float64, vec(du0))
+
+    # `Mt = (∂F/∂du)ᵀ`, constant by assumption; used to transfer discrete cost
+    # jumps onto the adjoint variables and for the `du0` boundary term.
+    Mt = zeros(n, n)
+    eseed = zeros(n)
+    for i in 1:n
+        eseed[i] = 1.0
+        _idas_res_vjps!(data, u0v, du0v, t0, nothing, eseed, nothing)
+        Mt[:, i] .= data.ddu
+        eseed[i] = 0.0
+    end
+    Mtpinv = pinv(Mt)
+
+    # Best-effort screen for the constant-∂F/∂du assumption: compare the vjp at
+    # a second, perturbed point. Skipped if the residual cannot be evaluated
+    # there (e.g. domain errors).
+    let w = [1.0 + i / n for i in 1:n]
+        try
+            _idas_res_vjps!(
+                data, u0v .+ 0.5, du0v .+ 1.0, (t0 + tf) / 2, nothing, w,
+                nothing
+            )
+            if !isapprox(data.ddu, Mt * w; rtol = 1.0e-6, atol = 1.0e-10)
+                error(
+                    "SundialsAdjoint with `IDA` requires the DAE residual " *
+                        "`F(du, u, p, t)` to have a constant Jacobian `∂F/∂du` (i.e. " *
+                        "F linear in `du` with state- and time-independent " *
+                        "coefficients); a state/time-dependent `∂F/∂du` was detected."
+                )
+            end
+        catch err
+            err isa ErrorException && startswith(err.msg, "SundialsAdjoint") && rethrow()
+        end
+    end
+
+    interp = sensealg.interp === :hermite ? Sundials.IDA_HERMITE : Sundials.IDA_POLYNOMIAL
+
+    ctx_ref = Ref{Sundials.SUNContext}(C_NULL)
+    Sundials.SUNContext_Create(
+        C_NULL,
+        Base.unsafe_convert(Ptr{Sundials.SUNContext}, ctx_ref)
+    )
+    ctx = ctx_ref[]
+    mem = Sundials.Handle(Sundials.IDACreate(ctx))
+
+    ufwd = copy(u0v)
+    dufwd = copy(du0v)
+    ufwd_nv = NVector(ufwd, ctx)
+    dufwd_nv = NVector(dufwd, ctx)
+    yret = similar(ufwd)
+    ypret = similar(dufwd)
+    yret_nv = NVector(yret, ctx)
+    ypret_nv = NVector(ypret, ctx)
+    yinterp = similar(ufwd)
+    ypinterp = similar(dufwd)
+    yinterp_nv = NVector(yinterp, ctx)
+    ypinterp_nv = NVector(ypinterp, ctx)
+    λ = zeros(n)
+    λp = zeros(n)
+    λ_nv = NVector(λ, ctx)
+    λp_nv = NVector(λp, ctx)
+    qB = zeros(np)
+    qB_nv = has_p ? NVector(qB, ctx) : nothing
+    id = Float64.(collect(diffvars))
+    id_nv = NVector(id, ctx)
+    gu = zeros(n)
+    gp = dgdp_discrete === nothing ? nothing : zeros(np)
+    dp = has_p ? zeros(np) : nothing
+    du0_grad = zeros(n)
+    tret = [t0]
+    ncheck = Ref{Cint}(0)
+    which = Ref{Cint}(0)
+
+    GC.@preserve data ufwd_nv dufwd_nv yret_nv ypret_nv yinterp_nv ypinterp_nv λ_nv λp_nv qB_nv id_nv begin
+        try
+            # Forward pass with checkpointing. The provided `(u0, du0)` are
+            # assumed consistent (as for the forward `IDA` solve).
+            _check_idas_flag(
+                Sundials.IDAInit(mem, fwd_cfun, t0, ufwd_nv, dufwd_nv),
+                "IDAInit"
+            )
+            _check_idas_flag(Sundials.IDASetUserData(mem, data), "IDASetUserData")
+            _check_idas_flag(
+                Sundials.IDASStolerances(mem, reltol, abstol),
+                "IDASStolerances"
+            )
+            _check_idas_flag(
+                Sundials.IDASetMaxNumSteps(mem, maxiters),
+                "IDASetMaxNumSteps"
+            )
+            _check_idas_flag(Sundials.IDASetId(mem, id_nv), "IDASetId")
+            LSf, Af = _idas_set_solvers(
+                (LS, A) -> Sundials.IDASetLinearSolver(mem, LS, A),
+                alg, ufwd_nv, n, ctx
+            )
+            _check_idas_flag(
+                Sundials.IDAAdjInit(mem, sensealg.steps, interp),
+                "IDAAdjInit"
+            )
+            _check_idas_flag(
+                Sundials.IDASolveF(
+                    mem, tf, tret, yret_nv, ypret_nv, Sundials.IDA_NORMAL,
+                    ncheck
+                ),
+                "IDASolveF"
+            )
+
+            # Backward (adjoint) problem. λ(tf) collects the cost jumps at tf,
+            # transferred through `(∂F/∂du)ᵀ Δλ = gu`.
+            cur_time = length(ts)
+            if cur_time >= 1 && ts[cur_time] == tf
+                y_f = sol(tf)
+                while cur_time >= 1 && ts[cur_time] == tf
+                    if !(no_start && cur_time == 1)
+                        fill!(gu, false)
+                        dgdu_discrete(gu, y_f, p, tf, cur_time)
+                        λ .+= _idas_cost_jump(Mtpinv, Mt, gu, tf)
+                        if dgdp_discrete !== nothing
+                            fill!(gp, false)
+                            dgdp_discrete(gp, y_f, p, tf, cur_time)
+                            dp .+= gp
+                        end
+                    end
+                    cur_time -= 1
+                end
+            end
+
+            _check_idas_flag(Sundials.IDACreateB(mem, which), "IDACreateB")
+            fill!(λp, false)
+            _check_idas_flag(
+                Sundials.IDAInitB(mem, which[], adj_cfun, tf, λ_nv, λp_nv),
+                "IDAInitB"
+            )
+            _check_idas_flag(
+                Sundials.IDASetUserDataB(mem, which[], data),
+                "IDASetUserDataB"
+            )
+            _check_idas_flag(
+                Sundials.IDASStolerancesB(mem, which[], reltol, abstol),
+                "IDASStolerancesB"
+            )
+            _check_idas_flag(
+                Sundials.IDASetMaxNumStepsB(mem, which[], maxiters),
+                "IDASetMaxNumStepsB"
+            )
+            _check_idas_flag(Sundials.IDASetIdB(mem, which[], id_nv), "IDASetIdB")
+            LSB, AB = _idas_set_solvers(
+                (LS, A) -> Sundials.IDASetLinearSolverB(mem, which[], LS, A),
+                alg, λ_nv, n, ctx
+            )
+            if has_p
+                _check_idas_flag(
+                    Sundials.IDAQuadInitB(mem, which[], quad_cfun, qB_nv),
+                    "IDAQuadInitB"
+                )
+                _check_idas_flag(
+                    Sundials.IDAQuadSStolerancesB(mem, which[], reltol, abstol),
+                    "IDAQuadSStolerancesB"
+                )
+                _check_idas_flag(
+                    Sundials.IDASetQuadErrConB(
+                        mem, which[],
+                        sensealg.quad_error_control ? 1 : 0
+                    ),
+                    "IDASetQuadErrConB"
+                )
+            end
+
+            # Consistent backward initial conditions: the algebraic components
+            # of λ and the differential components of λ' are computed by IDAS
+            # from the differential λ set above (IDACalcICB takes the forward
+            # solution at tf as input).
+            next_stop = cur_time >= 1 && ts[cur_time] > t0 && ts[cur_time] < tf ?
+                ts[cur_time] : t0
+            _check_idas_flag(
+                Sundials.IDACalcICB(mem, which[], next_stop, yret_nv, ypret_nv),
+                "IDACalcICB"
+            )
+
+            # Integrate backward, stopping at every discrete cost time to add
+            # the jump and reinitialize the backward problem.
+            tcur = tf
+            while cur_time >= 1
+                s = ts[cur_time]
+                if s < tcur && s > t0
+                    _check_idas_flag(
+                        Sundials.IDASolveB(mem, s, Sundials.IDA_NORMAL),
+                        "IDASolveB"
+                    )
+                    _check_idas_flag(
+                        Sundials.IDAGetB(mem, which[], tret, λ_nv, λp_nv),
+                        "IDAGetB"
+                    )
+                    if has_p
+                        _check_idas_flag(
+                            Sundials.IDAGetQuadB(mem, convert(Cint, which[]), tret, qB_nv),
+                            "IDAGetQuadB"
+                        )
+                    end
+                    tcur = s
+                    y_s = sol(s)
+                    while cur_time >= 1 && ts[cur_time] == s
+                        if !(no_start && cur_time == 1)
+                            fill!(gu, false)
+                            dgdu_discrete(gu, y_s, p, s, cur_time)
+                            λ .+= _idas_cost_jump(Mtpinv, Mt, gu, s)
+                            if dgdp_discrete !== nothing
+                                fill!(gp, false)
+                                dgdp_discrete(gp, y_s, p, s, cur_time)
+                                dp .+= gp
+                            end
+                        end
+                        cur_time -= 1
+                    end
+                    _check_idas_flag(
+                        Sundials.IDAReInitB(mem, which[], s, λ_nv, λp_nv),
+                        "IDAReInitB"
+                    )
+                    if has_p
+                        _check_idas_flag(
+                            Sundials.IDAQuadReInitB(mem, convert(Cint, which[]), qB_nv),
+                            "IDAQuadReInitB"
+                        )
+                    end
+                    next_stop = cur_time >= 1 && ts[cur_time] > t0 && ts[cur_time] < s ?
+                        ts[cur_time] : t0
+                    _check_idas_flag(
+                        Sundials.IDAGetAdjY(mem, s, yinterp_nv, ypinterp_nv),
+                        "IDAGetAdjY"
+                    )
+                    _check_idas_flag(
+                        Sundials.IDACalcICB(
+                            mem, which[], next_stop, yinterp_nv,
+                            ypinterp_nv
+                        ),
+                        "IDACalcICB"
+                    )
+                else
+                    break
+                end
+            end
+
+            # Final leg down to t0.
+            if tcur > t0
+                _check_idas_flag(
+                    Sundials.IDASolveB(mem, t0, Sundials.IDA_NORMAL),
+                    "IDASolveB"
+                )
+                _check_idas_flag(
+                    Sundials.IDAGetB(mem, which[], tret, λ_nv, λp_nv),
+                    "IDAGetB"
+                )
+                if has_p
+                    _check_idas_flag(
+                        Sundials.IDAGetQuadB(mem, convert(Cint, which[]), tret, qB_nv),
+                        "IDAGetQuadB"
+                    )
+                end
+            end
+
+            # Gradient w.r.t. the initial state: the adjoint boundary term
+            # `(∂F/∂du)ᵀ λ(t0)`, plus any cost jump exactly at t0 (which enters
+            # `dG/du0` directly, not through the transform).
+            mul!(du0_grad, Mt, λ)
+            while cur_time >= 1
+                s = ts[cur_time]
+                s == t0 ||
+                    error("SundialsAdjoint: internal error, unprocessed cost time $(s).")
+                if !(no_start && cur_time == 1)
+                    y_s = sol(s)
+                    fill!(gu, false)
+                    dgdu_discrete(gu, y_s, p, s, cur_time)
+                    # Range check only; jumps at t0 are added to `du0_grad` as-is.
+                    _idas_cost_jump(Mtpinv, Mt, gu, s)
+                    du0_grad .+= gu
+                    if dgdp_discrete !== nothing
+                        fill!(gp, false)
+                        dgdp_discrete(gp, y_s, p, s, cur_time)
+                        dp .+= gp
+                    end
+                end
+                cur_time -= 1
+            end
+
+            has_p && (dp .+= qB)
+        finally
+            empty!(mem)
+            Sundials.SUNContext_Free(ctx)
+        end
+    end
+
+    return du0_grad, has_p ? dp' : nothing
 end
 
 end

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -37,6 +37,10 @@ function _enzyme_vjp_probe(f, repack, out, u, _p, t)
 end
 
 function inplace_vjp(prob, u0, p, verbose, repack)
+    # The probes below call `f(du, u, p, t)` and thus cannot handle DAE
+    # residuals `f(res, du, u, p, t)`; the DAE residual vjp machinery
+    # (the SundialsAdjoint/IDA path) is ReverseDiff-tape based.
+    prob isa SciMLBase.AbstractDAEProblem && return ReverseDiffVJP()
     du = zero(u0)
     # Get verbosity for sensitivity VJP choice warnings
     _verbose = _get_sensitivity_vjp_verbose(verbose)
@@ -523,6 +527,7 @@ end
 function SciMLBase._concrete_solve_adjoint(
         prob::Union{
             SciMLBase.AbstractODEProblem,
+            SciMLBase.AbstractDAEProblem,
             SciMLBase.AbstractSDEProblem,
             SciMLBase.AbstractRODEProblem,
         },
@@ -542,6 +547,23 @@ function SciMLBase._concrete_solve_adjoint(
         initializealg_default = SciMLBase.OverrideInit(; abstol = 1.0e-6, reltol = 1.0e-3),
         kwargs...
     )
+    if prob isa SciMLBase.AbstractDAEProblem && !(sensealg isa SundialsAdjoint)
+        error(
+            "Continuous adjoint sensitivities for `DAEProblem`s are only supported " *
+                "via `SundialsAdjoint` with the `IDA()` solver (requires `using Sundials`). " *
+                "For other solvers, use a discrete-sensitivity method such as " *
+                "`ForwardDiffSensitivity` or `ReverseDiffAdjoint`."
+        )
+    end
+    # `SciMLBase.sensitivity_solution` has no `DAESolution` method, so build the
+    # subset solution directly for DAEs.
+    _sensitivity_solution(sol, u, ts) =
+        sol isa SciMLBase.AbstractDAESolution ?
+        SciMLBase.build_solution(
+            sol.prob, sol.alg, ts isa Vector ? ts : collect(ts), u;
+            retcode = sol.retcode, stats = sol.stats
+        ) :
+        SciMLBase.sensitivity_solution(sol, u, ts)
     if !supports_functor_params(sensealg) &&
             !(p isa Union{Nothing, SciMLBase.NullParameters, AbstractArray}) &&
             !isscimlstructure(p) ||
@@ -715,7 +737,7 @@ function SciMLBase._concrete_solve_adjoint(
         # Saving behavior unchanged
         ts = current_time(sol)
         only_end = length(ts) == 1 && ts[1] == _prob.tspan[2]
-        out = SciMLBase.sensitivity_solution(sol, state_values(sol), ts)
+        out = _sensitivity_solution(sol, state_values(sol), ts)
     elseif saveat isa Number
         if _prob.tspan[2] > _prob.tspan[1]
             ts = _prob.tspan[1]:convert(typeof(_prob.tspan[2]), abs(saveat)):_prob.tspan[2]
@@ -732,10 +754,10 @@ function SciMLBase._concrete_solve_adjoint(
         end
 
         out = if save_idxs === nothing
-            out = SciMLBase.sensitivity_solution(sol, state_values(_out), ts)
+            out = _sensitivity_solution(sol, state_values(_out), ts)
         else
             _outf = getu(_out, save_idxs)
-            out = SciMLBase.sensitivity_solution(sol, _outf(_out), ts)
+            out = _sensitivity_solution(sol, _outf(_out), ts)
         end
         only_end = length(ts) == 1 && ts[1] == _prob.tspan[2]
     elseif isempty(saveat)
@@ -748,7 +770,7 @@ function SciMLBase._concrete_solve_adjoint(
         _u = sol.u[sol_idxs]
         u = save_idxs === nothing ? _u : [x[save_idxs] for x in _u]
         ts = current_time(sol, sol_idxs)
-        out = SciMLBase.sensitivity_solution(sol, u, ts)
+        out = _sensitivity_solution(sol, u, ts)
     else
         _saveat = saveat isa Array ? sort(saveat) : saveat # for minibatching
         if cb === nothing
@@ -762,10 +784,10 @@ function SciMLBase._concrete_solve_adjoint(
         end
 
         out = if save_idxs === nothing
-            out = SciMLBase.sensitivity_solution(sol, state_values(_out), ts)
+            out = _sensitivity_solution(sol, state_values(_out), ts)
         else
             _outf = getu(_out, save_idxs)
-            out = SciMLBase.sensitivity_solution(sol, _outf(_out), ts)
+            out = _sensitivity_solution(sol, _outf(_out), ts)
         end
         only_end = length(ts) == 1 && ts[1] == _prob.tspan[2]
     end

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -727,17 +727,20 @@ SundialsAdjoint{CS, AD, FDT, VJP} <: AbstractAdjointSensitivityAlgorithm{CS, AD,
 ```
 
 An implementation of adjoint sensitivity analysis which uses the SUNDIALS CVODES
-C adjoint interface (`CVodeAdjInit`/`CVodeF`/`CVodeB`). The forward pass is
-re-integrated by CVODES with checkpointing, the backward (adjoint) pass is
-integrated by CVODES with its checkpoint-based interpolation of the forward
-solution, and the parameter gradient is accumulated by the CVODES backward
-quadrature integration. Vector-Jacobian products inside the backward pass are
-computed with the standard SciMLSensitivity `autojacvec` machinery.
+and IDAS C adjoint interfaces (`CVodeAdjInit`/`CVodeF`/`CVodeB` for
+`ODEProblem`s, `IDAAdjInit`/`IDASolveF`/`IDASolveB` for `DAEProblem`s). The
+forward pass is re-integrated by SUNDIALS with checkpointing, the backward
+(adjoint) pass is integrated by SUNDIALS with its checkpoint-based interpolation
+of the forward solution, and the parameter gradient is accumulated by the
+SUNDIALS backward quadrature integration. Vector-Jacobian products inside the
+backward pass are computed with the standard SciMLSensitivity `autojacvec`
+machinery (`ReverseDiffVJP` only for `DAEProblem`s).
 
-This method requires `using Sundials` and a Sundials.jl CVODES-compatible
-solver, i.e. `CVODE_BDF` or `CVODE_Adams`, both for the forward `solve` and as
-the `alg` argument of `adjoint_sensitivities`. Using any other solver throws an
-error.
+This method requires `using Sundials` and a Sundials.jl adjoint-compatible
+solver — `CVODE_BDF` or `CVODE_Adams` for `ODEProblem`s and `IDA` for
+`DAEProblem`s — both for the forward `solve` and as the `alg` argument of
+`adjoint_sensitivities`. Using any other solver (or mismatching problem and
+solver types) throws an error.
 
 ## Constructor
 
@@ -784,13 +787,33 @@ SundialsAdjoint(; chunk_size = 0, autodiff = true,
 
 ## SciMLProblem Support
 
-This `sensealg` only supports in-place `ODEProblem`s without callbacks (events).
-Discrete cost functionals (`t` with `dgdu_discrete`, which is what reverse-mode
-AD of `solve` uses) and continuous cost functionals (`dgdu_continuous`/
-`dgdp_continuous` or a scalar `g(u, p, t)`) are supported, including both at
-once; the continuous contributions are integrated by CVODES itself as part of
-the backward pass. The state and time types must be `Float64` (a SUNDIALS
-requirement), and mass matrices are not supported.
+This `sensealg` supports in-place `ODEProblem`s and in-place fully implicit
+`DAEProblem`s, both without callbacks (events). The state and time types must
+be `Float64` (a SUNDIALS requirement).
+
+For `ODEProblem`s (with `CVODE_BDF`/`CVODE_Adams`): discrete cost functionals
+(`t` with `dgdu_discrete`, which is what reverse-mode AD of `solve` uses) and
+continuous cost functionals (`dgdu_continuous`/`dgdp_continuous` or a scalar
+`g(u, p, t)`) are supported, including both at once; the continuous
+contributions are integrated by CVODES itself as part of the backward pass.
+Mass matrices are not supported (a CVODES restriction) — write the system as a
+`DAEProblem` instead.
+
+For `DAEProblem`s (with `IDA`): the residual `F(du, u, p, t)` **must be linear
+in `du` with a constant (state- and time-independent) Jacobian `∂F/∂du`**, i.e.
+`F = M du - h(u, p, t)` with a constant mass matrix `M` — this covers
+mass-matrix-style and semi-explicit index-1 DAEs written implicitly. The
+backward residual omits the `d/dt (∂F/∂du)ᵀ λ` term, which only vanishes under
+this assumption (a best-effort runtime check errors when a state/time-dependent
+`∂F/∂du` is detected). Additional current restrictions: only discrete cost
+functionals (`t` with `dgdu_discrete`/`dgdp_discrete`) are supported, the cost
+gradient must have zero components with respect to algebraic variables,
+`differential_vars` must be specified (used for consistent initialization of
+the backward problem via `IDACalcICB`), and only `autojacvec = ReverseDiffVJP()`
+is available. The returned `du0` is the adjoint boundary term
+`(∂F/∂du)ᵀ λ |_{t0}`, i.e. the gradient with respect to the differential
+components of `u0` (algebraic components of `u0` are determined by consistency,
+and their entries are zero for semi-explicit systems).
 
 ## References
 
@@ -801,6 +824,10 @@ Software (TOMS), 31, pp:363–396 (2005)
 
 Serban, R. and Hindmarsh, A. C., CVODES: The Sensitivity-Enabled ODE Solver in
 SUNDIALS, Proceedings of IDETC/CIE (2005)
+
+Cao, Y. and Li, S. and Petzold, L. and Serban, R., Adjoint Sensitivity Analysis
+for Differential-Algebraic Equations: The Adjoint DAE System and Its Numerical
+Solution, SIAM Journal on Scientific Computing, 24, pp:1076-1089 (2003)
 """
 struct SundialsAdjoint{CS, AD, FDT, VJP} <:
     AbstractAdjointSensitivityAlgorithm{CS, AD, FDT}

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -525,21 +525,22 @@ function _adjoint_sensitivities(
     return du0, dp
 end
 
-# The actual implementation lives in the SciMLSensitivitySundialsExt package
-# extension, which adds a more specific method for CVODES-compatible `alg`s.
+# The actual implementations live in the SciMLSensitivitySundialsExt package
+# extension, which adds more specific methods for CVODES/IDAS-compatible `alg`s.
 function _adjoint_sensitivities(sol, sensealg::SundialsAdjoint, alg; kwargs...)
     error(
         """
-        `SundialsAdjoint` uses the SUNDIALS CVODES C adjoint interface and therefore
-        requires a Sundials.jl CVODES-compatible solver. Got `alg = $(nameof(typeof(alg)))`.
+        `SundialsAdjoint` uses the SUNDIALS CVODES/IDAS C adjoint interfaces and
+        therefore requires a Sundials.jl compatible solver. Got `alg = $(nameof(typeof(alg)))`.
 
         To use `SundialsAdjoint`:
 
           1. Load Sundials.jl with `using Sundials` (this activates the
              SciMLSensitivitySundialsExt extension), and
-          2. use `CVODE_BDF()` or `CVODE_Adams()` as the solver, e.g.
+          2. use `CVODE_BDF()` or `CVODE_Adams()` as the solver for `ODEProblem`s,
+             or `IDA()` for `DAEProblem`s, e.g.
              `solve(prob, CVODE_BDF(); sensealg = SundialsAdjoint())` or
-             `adjoint_sensitivities(sol, CVODE_BDF(); sensealg = SundialsAdjoint(), ...)`.
+             `adjoint_sensitivities(sol, IDA(); sensealg = SundialsAdjoint(), ...)`.
 
         For non-Sundials solvers, use a native adjoint method such as `GaussAdjoint`
         or `InterpolatingAdjoint` instead.

--- a/test/Core2/sundials_adjoint.jl
+++ b/test/Core2/sundials_adjoint.jl
@@ -187,7 +187,7 @@ end
         e
     end
     @test err isa ErrorException
-    @test occursin("CVODES-compatible solver", err.msg)
+    @test occursin("CVODES/IDAS", err.msg)
     @test occursin("CVODE_BDF", err.msg)
 
     sol = solve(prob, CVODE_BDF(), abstol = 1.0e-10, reltol = 1.0e-10, saveat = ts)

--- a/test/Core2/sundials_idas_adjoint.jl
+++ b/test/Core2/sundials_idas_adjoint.jl
@@ -1,0 +1,260 @@
+using SciMLSensitivity, Sundials, OrdinaryDiffEq, ForwardDiff, Zygote, Test
+using SciMLBase, LinearAlgebra
+
+# Index-1 DAE with known analytic gradient (the Sundials.jl IDAS adjoint test
+# problem): F1 = y1' + a*y1, F2 = y2 - y1, y1(0) = y2(0) = 1, so
+# y1(t) = y2(t) = exp(-a*t). For G = y1(tf): dG/dy1(0) = exp(-a*tf) and
+# dG/da = -tf*exp(-a*tf).
+@testset "analytic index-1 DAE" begin
+    function lin_dae!(res, du, u, p, t)
+        res[1] = du[1] + p[1] * u[1]
+        res[2] = u[2] - u[1]
+        return nothing
+    end
+    a = 0.3
+    tf = 2.0
+    prob = DAEProblem(
+        lin_dae!, [-a, -a], [1.0, 1.0], (0.0, tf), [a];
+        differential_vars = [true, false]
+    )
+    sol = solve(prob, IDA(); abstol = 1.0e-10, reltol = 1.0e-10, saveat = [tf])
+    @test sol.u[end][1] ≈ exp(-a * tf) rtol = 1.0e-7
+
+    dgdu(out, u, p, t, i) = (out .= 0.0; out[1] = 1.0)
+    du0, dp = adjoint_sensitivities(
+        sol, IDA(); t = [tf], dgdu_discrete = dgdu,
+        sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP()),
+        abstol = 1.0e-10, reltol = 1.0e-10
+    )
+    @test du0[1] ≈ exp(-a * tf) rtol = 1.0e-6
+    @test du0[2] == 0.0
+    @test dp[1] ≈ -tf * exp(-a * tf) rtol = 1.0e-6
+end
+
+function rober_dae!(res, du, u, p, t)
+    y1, y2, y3 = u
+    k1, k2, k3 = p
+    res[1] = du[1] + k1 * y1 - k3 * y2 * y3
+    res[2] = du[2] - k1 * y1 + k2 * y2^2 + k3 * y2 * y3
+    res[3] = y1 + y2 + y3 - 1
+    return nothing
+end
+
+p = [0.04, 3.0e7, 1.0e4]
+u0 = [1.0, 0.0, 0.0]
+du0 = [-0.04, 0.04, 0.0]
+tspan = (0.0, 100.0)
+ts = [10.0, 50.0, 100.0]
+daeprob = DAEProblem(
+    rober_dae!, du0, u0, tspan, p; differential_vars = [true, true, false]
+)
+sol = solve(daeprob, IDA(); abstol = 1.0e-10, reltol = 1.0e-10, saveat = ts)
+
+# G = sum over ts of (u1 + u2). Cost only on the differential variables; the
+# gradient w.r.t. (u1(0), u2(0)) is taken along the constraint manifold
+# u3 = 1 - u1 - u2, matching what the DAE solution operator differentiates.
+dgdu(out, u, p, t, i) = (out .= 0.0; out[1] = 1.0; out[2] = 1.0)
+
+# ForwardDiff reference through the equivalent mass-matrix ODE formulation.
+function rober_mm!(du, u, p, t)
+    y1, y2, y3 = u
+    k1, k2, k3 = p
+    du[1] = -k1 * y1 + k3 * y2 * y3
+    du[2] = k1 * y1 - k2 * y2^2 - k3 * y2 * y3
+    du[3] = y1 + y2 + y3 - 1
+    return nothing
+end
+fmm = ODEFunction(rober_mm!, mass_matrix = Diagonal([1.0, 1.0, 0.0]))
+function G(θ)
+    _u0 = [θ[1], θ[2], 1 - θ[1] - θ[2]]
+    _prob = ODEProblem(fmm, _u0, tspan, θ[3:5])
+    _sol = solve(_prob, Rodas5P(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = ts)
+    return sum(u[1] + u[2] for u in _sol.u)
+end
+refgrad = ForwardDiff.gradient(G, [u0[1]; u0[2]; p])
+
+@testset "Robertson DAE vs ForwardDiff" begin
+    @testset "vjp = $(vjp)" for vjp in (ReverseDiffVJP(), ReverseDiffVJP(true))
+        du0g, dp = adjoint_sensitivities(
+            sol, IDA(); t = ts, dgdu_discrete = dgdu,
+            sensealg = SundialsAdjoint(autojacvec = vjp),
+            abstol = 1.0e-10, reltol = 1.0e-10
+        )
+        @test du0g[1:2] ≈ refgrad[1:2] rtol = 1.0e-4
+        @test du0g[3] == 0.0
+        @test vec(dp) ≈ refgrad[3:5] rtol = 1.0e-5
+    end
+
+    @testset "default autojacvec" begin
+        du0g, dp = adjoint_sensitivities(
+            sol, IDA(); t = ts, dgdu_discrete = dgdu,
+            sensealg = SundialsAdjoint(),
+            abstol = 1.0e-10, reltol = 1.0e-10
+        )
+        @test du0g[1:2] ≈ refgrad[1:2] rtol = 1.0e-4
+        @test vec(dp) ≈ refgrad[3:5] rtol = 1.0e-5
+    end
+
+    @testset "dgdp_discrete" begin
+        # G2 = G + sum over ts of k1, so dG2/dk1 = dG/dk1 + length(ts).
+        dgdp(out, u, p, t, i) = (out .= 0.0; out[1] = 1.0)
+        du0g, dp = adjoint_sensitivities(
+            sol, IDA(); t = ts, dgdu_discrete = dgdu, dgdp_discrete = dgdp,
+            sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP()),
+            abstol = 1.0e-10, reltol = 1.0e-10
+        )
+        @test dp[1] ≈ refgrad[3] + length(ts) rtol = 1.0e-5
+        @test vec(dp)[2:3] ≈ refgrad[4:5] rtol = 1.0e-5
+    end
+
+    @testset "endpoint only" begin
+        du0g, dp = adjoint_sensitivities(
+            sol, IDA(); t = [tspan[2]], dgdu_discrete = dgdu,
+            sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP()),
+            abstol = 1.0e-10, reltol = 1.0e-10
+        )
+        function Gend(θ)
+            _u0 = [θ[1], θ[2], 1 - θ[1] - θ[2]]
+            _prob = ODEProblem(fmm, _u0, tspan, θ[3:5])
+            _sol = solve(
+                _prob, Rodas5P(), abstol = 1.0e-12, reltol = 1.0e-12,
+                save_everystep = false
+            )
+            return _sol.u[end][1] + _sol.u[end][2]
+        end
+        refend = ForwardDiff.gradient(Gend, [u0[1]; u0[2]; p])
+        @test du0g[1:2] ≈ refend[1:2] rtol = 1.0e-4
+        @test vec(dp) ≈ refend[3:5] rtol = 1.0e-5
+    end
+end
+
+@testset "reverse-mode AD of solve" begin
+    function loss(p)
+        _sol = solve(
+            daeprob, IDA(); p = p, saveat = ts,
+            abstol = 1.0e-10, reltol = 1.0e-10,
+            sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP())
+        )
+        A = Array(_sol)
+        return sum(A[1, :]) + sum(A[2, :])
+    end
+    dp_zygote = Zygote.gradient(loss, p)[1]
+    @test dp_zygote ≈ refgrad[3:5] rtol = 1.0e-5
+
+    function loss_u0(u0)
+        _sol = solve(
+            daeprob, IDA(); u0 = u0, saveat = ts,
+            abstol = 1.0e-10, reltol = 1.0e-10,
+            sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP())
+        )
+        A = Array(_sol)
+        return sum(A[1, :]) + sum(A[2, :])
+    end
+    du0_zygote = Zygote.gradient(loss_u0, u0)[1]
+    @test du0_zygote[1:2] ≈ refgrad[1:2] rtol = 1.0e-4
+    @test du0_zygote[3] == 0.0
+end
+
+@testset "informative errors" begin
+    # DAEProblem with a CVODES solver
+    err = try
+        adjoint_sensitivities(
+            sol, CVODE_BDF(); t = ts, dgdu_discrete = dgdu,
+            sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP())
+        )
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("IDA", err.msg)
+
+    # ODEProblem with IDA
+    odeprob = ODEProblem((du, u, p, t) -> (du .= -u), [1.0], (0.0, 1.0))
+    odesol = solve(odeprob, CVODE_BDF(); abstol = 1.0e-8, reltol = 1.0e-8, saveat = [1.0])
+    err = try
+        adjoint_sensitivities(
+            odesol, IDA(); t = [1.0],
+            dgdu_discrete = (out, u, p, t, i) -> (out .= 1.0),
+            sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP())
+        )
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("CVODE_BDF", err.msg)
+
+    # unsupported autojacvec
+    @test_throws ErrorException adjoint_sensitivities(
+        sol, IDA(); t = ts, dgdu_discrete = dgdu,
+        sensealg = SundialsAdjoint(autojacvec = EnzymeVJP())
+    )
+
+    # unsorted cost times
+    @test_throws ErrorException adjoint_sensitivities(
+        sol, IDA(); t = reverse(ts), dgdu_discrete = dgdu,
+        sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP())
+    )
+
+    # continuous cost functionals are not implemented for DAEs
+    @test_throws ErrorException adjoint_sensitivities(
+        sol, IDA(); g = (u, p, t) -> sum(u),
+        sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP())
+    )
+
+    # cost gradient touching an algebraic variable
+    dgdu_alg(out, u, p, t, i) = (out .= 0.0; out[3] = 1.0)
+    err = try
+        adjoint_sensitivities(
+            sol, IDA(); t = ts, dgdu_discrete = dgdu_alg,
+            sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP())
+        )
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("algebraic", err.msg)
+
+    # state-dependent ∂F/∂du is caught by the runtime screen
+    function nonlin_du!(res, du, u, p, t)
+        res[1] = u[1] * du[1] + p[1] * u[1]
+        res[2] = u[2] - u[1]
+        return nothing
+    end
+    nlprob = DAEProblem(
+        nonlin_du!, [-0.3, -0.3], [1.0, 1.0], (0.0, 2.0), [0.3];
+        differential_vars = [true, false]
+    )
+    nlsol = solve(nlprob, IDA(); abstol = 1.0e-8, reltol = 1.0e-8, saveat = [2.0])
+    err = try
+        adjoint_sensitivities(
+            nlsol, IDA(); t = [2.0],
+            dgdu_discrete = (out, u, p, t, i) -> (out .= 0.0; out[1] = 1.0),
+            sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP())
+        )
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("constant Jacobian", err.msg)
+
+    # missing differential_vars
+    nodiffvars = DAEProblem(rober_dae!, du0, u0, tspan, p)
+    nodiffsol = SciMLBase.build_solution(
+        nodiffvars, IDA(), sol.t, sol.u; retcode = sol.retcode
+    )
+    err = try
+        adjoint_sensitivities(
+            nodiffsol, IDA(); t = ts, dgdu_discrete = dgdu,
+            sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP())
+        )
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("differential_vars", err.msg)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ run_tests(;
                 @time @safetestset "Enzyme VJP Inactive" include("Core2/enzyme_vjp_inactive.jl")
                 @time @safetestset "Enzyme VJP View ComponentArray" include("Core2/enzyme_view_componentarray.jl")
                 @time @safetestset "Sundials CVODES Adjoint" include("Core2/sundials_adjoint.jl")
+                @time @safetestset "Sundials IDAS DAE Adjoint" include("Core2/sundials_idas_adjoint.jl")
             end
         end,
         "Core3" => function ()


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

Follow-up to #1539: extends `SundialsAdjoint` to fully implicit `DAEProblem`s using the SUNDIALS **IDAS** C adjoint interface (`IDAAdjInit`/`IDASolveF`/`IDACreateB`/`IDAInitB`/`IDACalcICB`/`IDAQuadInitB`/`IDASolveB`), mirroring the CVODES structure merged there. Uses the IDAS adjoint wrappers already present in the registered Sundials.jl v6.2.3 (validated end-to-end by SciML/Sundials.jl#546), so no Sundials.jl release is needed.

## Design

New method `_adjoint_sensitivities(sol, ::SundialsAdjoint, ::Sundials.IDA)` in `ext/SciMLSensitivitySundialsExt.jl` for in-place Float64 `DAEProblem`s `F(du, u, p, t) = 0` with discrete cost functionals.

**Adjoint formulation** (Cao–Li–Petzold / IDAS user guide), backward problem in residual form:

```
resB = (∂F/∂du)ᵀ ypB − (∂F/∂u)ᵀ yB
```

with backward quadrature `qB' = (∂F/∂p)ᵀ λ`, `qB(tf) = 0`, so `dG/dp = qB(t0) = −∫ λᵀ (∂F/∂p) dt`, and `du0 = (∂F/∂du)ᵀ λ |_{t0}` (the gradient w.r.t. the differential components of `u0`; algebraic entries are zero for semi-explicit systems). The sign conventions were pinned against the analytic gradients of the low-level Sundials.jl IDAS adjoint test (`test/idas_adjoint.jl` from SciML/Sundials.jl#546) and then validated numerically against ForwardDiff (below).

**Key assumption (documented prominently in the docstring):** the residual must be **linear in `du` with a constant `∂F/∂du`** (i.e. `F = M du − h(u, p, t)` with a constant mass matrix), so the `d/dt (∂F/∂du)ᵀ λ` term of the adjoint DAE vanishes. This covers mass-matrix-style and semi-explicit index-1 DAEs written implicitly — the overwhelmingly common case. A best-effort runtime screen compares the `(∂F/∂du)ᵀ v` vjp at two different `(du, u, t)` points and errors when a state/time-dependent `∂F/∂du` is detected, so du-nonlinear residuals fail loudly instead of returning silently wrong gradients.

**Cost jumps and consistent backward initialization:** `(∂F/∂du)ᵀ` is formed once as a constant matrix `Mt` (n vjps, valid by the constancy assumption). Discrete cost jumps are transferred onto the adjoint by solving `(∂F/∂du)ᵀ Δλ = gu` via `pinv(Mt)`, with a residual check that errors informatively when the cost gradient has components w.r.t. algebraic variables (that case needs an index-1 constraint-transfer term not implemented here — erroring beats a silently wrong gradient; `gu` on algebraic components is not in the range of `(∂F/∂du)ᵀ`). After `IDAInitB` and after each interior-stop `IDAReInitB`, `IDACalcICB` (enabled by `IDASetIdB` from `differential_vars`) computes the consistent algebraic λ components and differential λ′ components; the forward `(y, y′)` that `IDACalcICB` needs at interior stops comes from `IDAGetAdjY`. `differential_vars` is therefore required (informative error otherwise). Empirically `IDACalcICB` converged immediately on all test problems, including with the zero `λ′` guess.

**VJPs:** the existing `vecjacobian!`/`vec_pjac!` caches are ODE-`f(du,u,p,t)`-shaped, so the extension builds ReverseDiff `GradientTape`s over `(du, u, p, t)` directly: one tape forward pass per callback evaluation with two reverse passes (seed `yB` → `(∂F/∂u)ᵀ` and `(∂F/∂p)ᵀ` pulls; seed `ypB` → `(∂F/∂du)ᵀ` pull). `ReverseDiffVJP(true)` caches a compiled tape; the uncompiled default re-records at each evaluation point (same convention as `vecjacobian!`). Only `ReverseDiffVJP` is supported for DAEs in this first version; other `autojacvec` choices error informatively. `inplace_vjp` now returns `ReverseDiffVJP()` early for `AbstractDAEProblem` (its probes are 4-arg-ODE-shaped and previously all failed through to `false` with noisy warnings).

**Reverse-AD of `solve`:** the ODE/SDE/RODE `_concrete_solve_adjoint` method in `src/concrete_solve.jl` is widened to `AbstractDAEProblem`, guarded so that non-`SundialsAdjoint` continuous adjoints on DAEs get an informative error (previously a `MethodError`). `SciMLBase.sensitivity_solution` has no `DAESolution` method, so a local `_sensitivity_solution` helper builds the subset solution via `SciMLBase.build_solution` for DAE solutions and delegates unchanged for everything else. Zygote-over-`solve` works for both `p` and `u0`.

## Supported / deferred

Supported (DAE path): discrete costs (`t` + `dgdu_discrete`/`dgdp_discrete`), `no_start`, jump loop with `IDAReInitB` + `IDAQuadReInitB` + `IDACalcICB`, `:Dense`/`:Band`/`:GMRES` linear solvers, `:hermite`/`:polynomial` checkpoint interpolation, `steps`, `quad_error_control`, `abstol`/`reltol`/`maxiters`, reverse-mode AD of `solve` (Zygote tested).

Deferred with informative errors (possible follow-ups):

- continuous cost functionals (`g`/`dgdu_continuous`/`dgdp_continuous`) for DAEs;
- cost gradients w.r.t. algebraic variables (needs the index-1 constraint-transfer term);
- vjp choices other than `ReverseDiffVJP` (an Enzyme path would need a DAE-residual vjp cache);
- du-nonlinear residuals (needs the `d/dt (∂F/∂du)ᵀ λ` term).

## Validation (all run locally, Julia 1.10)

Analytic index-1 DAE (`F1 = y1' + a y1`, `F2 = y2 − y1`, `G = y1(tf)`): `du0 = exp(-a tf)` and `dp = -tf exp(-a tf)` matched to ~1e-9 absolute; the algebraic `du0` component is exactly 0.

Robertson DAE (index-1, stiff, `ts = [10, 50, 100]`, `G = Σ_ts (u1+u2)`) vs `ForwardDiff.gradient` through the equivalent mass-matrix ODE formulation (`Rodas5P`, 1e-12 tolerances), forward solve `solve(daeprob, IDA(); saveat = ts, abstol = 1e-10, reltol = 1e-10)`:

```
du0 rel err:       [5.9e-9, 1.8e-5]   (2nd component magnitude ~2.8e-5)
dp  rel err:       [1.8e-9, 5.2e-9, 5.2e-9]
Zygote dp rel err: [1.8e-9, 5.2e-9, 5.2e-9]
```

Local test-suite runs:

```
Sundials IDAS DAE Adjoint | 32 pass   (new test/Core2/sundials_idas_adjoint.jl)
Sundials CVODES Adjoint   | 28 pass   (existing suite re-run)
Literal Adjoint           |  1 pass   (ODE-path regression check for the
                                       concrete_solve.jl changes)
```

## Notes for review

- One existing-test change: the `occursin("CVODES-compatible solver", …)` assertion in `test/Core2/sundials_adjoint.jl` was updated to `occursin("CVODES/IDAS", …)` because the `SundialsAdjoint` fallback error message now mentions both interfaces.
- Version bumped 7.115.0 → 7.116.0 (new public capability, minor bump).
- `SundialsAdjoint` docstring updated (overview + SciMLProblem Support) with DAE support, the linear-in-`du` assumption, `du0` semantics, and the Cao–Li–Petzold reference; the docs `@docs` entry already exists.
- A `sensitivity_solution(::DAESolution, u, t)` method in SciMLBase would let us drop the local `_sensitivity_solution` helper; can be done upstream as a follow-up.
- While re-running the existing CVODES suite locally, one run (out of five) segfaulted in `N_VScale` inside `libsundials_core` during the `adjoint_sensitivities interface` testset — a code path this PR does not touch. This looks like an intermittent GC-rooting issue in the #1539 CVODES extension code (prime suspect: SUNDIALS solver objects/handles held only in dead locals outside the `GC.@preserve` block); it is being investigated separately and any fix will come as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrfZy7xBqQLgTqok5zGAdY
