### PR TITLE
Fix premature GC of CVODES solver objects in SundialsAdjoint (segfault)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.115.0"
+version = "7.115.1"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]

--- a/ext/SciMLSensitivitySundialsExt.jl
+++ b/ext/SciMLSensitivitySundialsExt.jl
@@ -298,6 +298,18 @@ function _adjoint_sensitivities(
     ncheck = Ref{Cint}(0)
     which = Ref{Cint}(0)
 
+    # The solver objects created inside the `try` must stay referenced until the
+    # `finally` cleanup: `NonLinSolHandle` carries a finalizer that frees the
+    # SUNDIALS nonlinear solver, so letting the binding go dead mid-integration
+    # lets GC free memory CVODES is still using (segfault); the linear solver and
+    # matrix have no finalizers and would leak without the explicit frees.
+    local nlsf = nothing
+    local LSf = nothing
+    local Af = nothing
+    local nlsB = nothing
+    local LSB = nothing
+    local AB = nothing
+
     GC.@preserve data ufwd_nv yret_nv λ_nv qB_nv begin
         try
             # Forward pass with checkpointing.
@@ -477,6 +489,12 @@ function _adjoint_sensitivities(
             has_p && (dp .+= qB)
         finally
             empty!(mem)
+            nlsf === nothing || empty!(nlsf)
+            nlsB === nothing || empty!(nlsB)
+            LSf === nothing || Sundials.SUNLinSolFree(LSf)
+            LSB === nothing || Sundials.SUNLinSolFree(LSB)
+            Af === nothing || Sundials.SUNMatDestroy(Af)
+            AB === nothing || Sundials.SUNMatDestroy(AB)
             Sundials.SUNContext_Free(ctx)
         end
     end

--- a/test/Core2/sundials_adjoint.jl
+++ b/test/Core2/sundials_adjoint.jl
@@ -91,6 +91,27 @@ dgdu(out, u, p, t, i) = (out .= 1.0)
     end
 end
 
+@testset "solver objects survive GC during integration" begin
+    # The FixedPoint nonlinear solver handle used for `method = :Functional`
+    # must stay rooted for the whole CVodeF/CVodeB integration; GC pressure in
+    # the RHS segfaulted when it was collectable (its finalizer frees the
+    # SUNDIALS object). GC in every RHS call makes that deterministic.
+    function lotka_gc!(du, u, p, t)
+        GC.gc(false)
+        lotka!(du, u, p, t)
+        return nothing
+    end
+    prob_gc = ODEProblem(lotka_gc!, u0, tspan, p)
+    sol_gc = solve(prob_gc, CVODE_Adams(), abstol = 1.0e-8, reltol = 1.0e-8, saveat = ts)
+    du0, dp = adjoint_sensitivities(
+        sol_gc, CVODE_Adams(); t = ts, dgdu_discrete = dgdu,
+        sensealg = SundialsAdjoint(autojacvec = ReverseDiffVJP()),
+        abstol = 1.0e-8, reltol = 1.0e-8
+    )
+    @test du0 ≈ refgrad[1:2] rtol = 1.0e-4
+    @test vec(dp) ≈ refgrad[3:end] rtol = 1.0e-4
+end
+
 @testset "continuous cost functionals" begin
     sol = solve(prob, CVODE_BDF(), abstol = 1.0e-10, reltol = 1.0e-10)
 


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

Fixes a GC-timing segfault in the `SundialsAdjoint` CVODES extension merged in #1539. The nonlinear solver handle (`method = :Functional`, i.e. the `CVODE_Adams()` default), the linear solver, and the matrix were assigned to locals that are never read after attachment, so Julia's liveness-based GC could collect them mid-integration. `NonLinSolHandle` carries a finalizer that frees the SUNDIALS object, producing a use-after-free inside `CVodeF`/`CVodeB` (crash in `N_VScale`). The linear solver and matrix have no finalizers, so they leaked instead.

Reproduced deterministically on master by forcing `GC.gc(false)` in the RHS of a Lotka-Volterra adjoint with `CVODE_Adams()`: segfault in `libsundials_core` `N_VScale` during the backward solve. Found while building the IDAS `DAEProblem` adjoint follow-up.

## Fix

Pre-declare the six solver-object locals before the `try` and release them explicitly in the `finally` (after `CVodeFree`, before `SUNContext_Free`): `empty!` on the nonlinear solver handles, `SUNLinSolFree`/`SUNMatDestroy` on the linear solvers/matrices. The `finally` references keep everything rooted for the full integration and fix the leak at the same time.

## Local validation (Julia 1.10, local Sundials.jl dev'd)

- The GC-pressure repro segfaults on unmodified master and passes with this fix (gradient matches the ForwardDiff reference).
- Added a regression testset to `test/Core2/sundials_adjoint.jl` (`GC.gc(false)` in every RHS call on the `CVODE_Adams` `:Functional` path, gradients checked at rtol 1e-4); a regression segfaults CI rather than merely failing, which is the point.
- Full `test/Core2/sundials_adjoint.jl`: 30/30 pass.

Patch bump 7.115.0 → 7.115.1. Note #1541 also bumps to 7.115.1 — whichever merges second needs a trivial rebase of the version line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrfZy7xBqQLgTqok5zGAdY