### PR TITLE
Downgrade: keep Sundials weakdep unpromoted (no_promote) to fix resolve KeyError

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -23,4 +23,12 @@ jobs:
     with:
       julia-version: "${{ matrix.julia-version }}"
       group: "${{ matrix.group }}"
+      # Sundials (a weakdep behind SciMLSensitivitySundialsExt) cannot be
+      # --min-resolved by Resolver.jl in the merged floor-resolve: promoting it
+      # to a hard dep throws `KeyError: key UUID(c3572dad-…) not found`
+      # (Resolve.jl:118), the same class of failure as Mooncake. Keep it a
+      # weakdep during downgrade resolution (Mooncake is the reusable
+      # workflow's default; overriding no_promote replaces that default, so it
+      # must be re-listed here).
+      no_promote: "Mooncake,Sundials"
     secrets: "inherit"


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Problem

The `Downgrade` workflow (job "Downgrade Tests - Core1", Julia lts) fails on `master` at the dependency-**resolve** stage, introduced by #1539 (merge commit `1ebcdead`), which added `Sundials` as a `[weakdeps]` entry behind the new `SciMLSensitivitySundialsExt`.

The SciML reusable downgrade workflow promotes every weakdep extension into the merged project's `[deps]` for a joint `--min` floor-resolve. Resolver.jl (StefanKarpinski/Resolver.jl) cannot `--min`-resolve `Sundials`:

```
[ Info: Promoting Sundials from weakdep to dependency in merged project
ERROR: LoadError: KeyError: key UUID("c3572dad-4567-51f8-b174-8c6c989267f4") not found   # c3572dad = Sundials
    @ Resolver .../src/Resolve.jl:118
ERROR: LoadError: failed process: Process(`julia ... resolve.jl ... --min=@deps --julia=1.10`) ProcessExited(1)
```

This is the same failure class already handled for `Mooncake`, which is kept as a weakdep via the reusable workflow's `no_promote` input (Resolver.jl issue StefanKarpinski/Resolver.jl#24).

## Fix

Add `Sundials` to `no_promote` so it stays a weakdep during downgrade resolution instead of being floor-resolved. Overriding `no_promote` **replaces** the reusable workflow's `"Mooncake"` default, so Mooncake is re-listed: `no_promote: "Mooncake,Sundials"`.

Note: `skip` is not the right lever here — in the current action (`julia-actions/julia-downgrade-compat@v2`) the `skip`/`ignore_pkgs` list is only consumed by the `forcedeps` floor-check and is not passed to the actual `resolve.jl` invocation, so it does not remove Sundials from the failing merged-project resolve. `no_promote` keeps the weakdep out of the merged `[deps]` entirely, which is what avoids the KeyError.

## Local verification

Ran the action's `downgrade.jl` against `master`'s `Project.toml` with Julia 1.10 (matching the lts leg):

- `no_promote="Mooncake"` → reproduces `KeyError: key UUID("c3572dad-…") not found` at `Resolve.jl:118` (exit 1).
- `no_promote="Mooncake,Sundials"` → `[ Info: Not promoting Sundials into merged [deps] (listed in no_promote)` then `Successfully resolved minimal versions` (exit 0).

## Scope

This fixes the resolve-stage regression from #1539 only. The Downgrade job also had a separate, pre-existing failure before #1539 (a `too many parameters for type` precompile error in ModelingToolkit / OrdinaryDiffEqBDF on the lts downgrade), which is unrelated to Sundials and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrfZy7xBqQLgTqok5zGAdY