### PR TITLE
Select the DeepEquilibriumNetworks Core group

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         package:
           - {user: SciML, repo: DiffEqFlux.jl, group: All}
-          - {user: SciML, repo: DeepEquilibriumNetworks.jl, group: CPU}
+          - {user: SciML, repo: DeepEquilibriumNetworks.jl, group: Core}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       owner: "${{ matrix.package.user }}"


### PR DESCRIPTION
## Summary

- replace the undeclared `DeepEquilibriumNetworks/CPU` selector with its declared `Core` group
- preserve the existing downstream target and shared-workflow setup

The prior selector did not map to a real test group, so the job could not provide the intended integration coverage.

## Local verification

- exact workflow-shaped Julia 1.12.6 `DeepEquilibriumNetworks/Core` run with SciMLSensitivity developed — exited 0; 1,538/1,538 tests passed in 31m11s
- `actionlint .github/workflows/Downstream.yml` — passed
- `julia +1.12 -m Runic --check .` — passed
- `git diff --check` — passed

A pre-existing repository-wide Actionlint custom-runner-label warning is being investigated separately; the changed workflow itself validates cleanly.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.