### PR TITLE
Configure Actionlint for V100 runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - gpu-v100


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- declare the legitimate gpu-v100 self-hosted runner label in Actionlint configuration
- keep the GPU workflow and its runner selection unchanged

## Root cause

Repository-wide Actionlint rejected GPU.yml lines 43 and 63 because custom self-hosted labels must be declared locally. The label itself is valid: GPU workflow run 29181902759 assigned both GPU jobs to runners with labels self-hosted and gpu-v100, and the GPU Tests job completed successfully.

A focused Actionlint diagnostic bisect identifies 3ba6b8c45dd66afac5e4b001475bdab6ebfe02b4 as the first commit using gpu-v100. The later 5b3a1f0c commit moved GPU tests to the same legitimate V100 pool.

## Validation

- actionlint -color
- actionlint -color .github/workflows/GPU.yml
- Julia Runic --check over the repository
- git diff --check

All commands exited successfully locally on clean current master.