### PR TITLE
Release LinearSolve 5 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.116.0"
+version = "7.116.1"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

- bump SciMLSensitivity from 7.116.0 to 7.116.1
- publish the LinearSolve 5 compatibility already merged in #1549

The latest registered release, 7.116.0, predates #1549 and its immutable registry metadata still rejects LinearSolve 5. That makes the current NonlinearSolve Adjoint test route unsatisfiable even though SciMLSensitivity `master` has the needed compatibility.

This is deliberately a metadata-only release PR.

## Local verification

Using this source candidate in the exact failing NonlinearSolve Adjoint route:

- Julia 1.10: 3/3, 3/3, and 1/1 assertions passed across the three targeted test sets
- Julia 1.12: 3/3, 3/3, and 1/1 assertions passed across the same test sets
- TOML parsing and `git diff --check` passed
- Runic passed on the changed file

Ignore this PR until it has been reviewed by @ChrisRackauckas.