### PR TITLE
Provide exact adjoint Jacobian for GaussAdjoint/QuadratureAdjoint implicit adjoint solves (~2-3.5x on stiff Brusselator adjoints)

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -815,6 +815,79 @@ function getprob(S::SensitivityFunction)
 end
 inplace_sensitivity(S::SensitivityFunction) = isinplace(getprob(S))
 
+"""
+    build_adjoint_jac(sol, sensealg, alg, f, tspan)
+
+Construct a `jac(J_adj, λ, p, t)` for the adjoint ODE of the state-only adjoint
+methods (`GaussAdjoint`, `QuadratureAdjoint`, whose adjoint state is just `λ`).
+The adjoint rhs `-(∂f/∂u)ᵀλ` is linear in `λ`, so its Jacobian is exactly
+`-(∂f/∂u)ᵀ` evaluated at the interpolated forward solution — independent of `λ`.
+
+When the user supplies an analytical `jac` (with a `jac_prototype`), evaluate it
+at `y(t)` and negate-transpose. Otherwise, for dense in-place ODEs solved by a
+ForwardDiff-based implicit method, fall back to differentiating the *forward*
+rhs (ForwardDiff/FiniteDiff per `sensealg`'s `autodiff` setting) and
+negate-transposing. Without this, the implicit adjoint solver differentiates the
+vjp-based adjoint rhs itself, which costs a full vjp (plus a forward-solution
+interpolation) per Jacobian column — and with `ReverseDiffVJP` re-records the
+tape with `Dual` numbers on every Jacobian evaluation.
+
+Returns `nothing` when no cheap exact Jacobian can be built; the adjoint solver
+then falls back to its own AD/FD of the adjoint rhs.
+"""
+function build_adjoint_jac(sol, sensealg, alg, f, tspan)
+    jac_prototype = sol.prob.f.jac_prototype
+    u0 = state_values(sol.prob)
+    if SciMLBase.has_jac(sol.prob.f) && jac_prototype !== nothing
+        _fwd_jac_cache = copy(jac_prototype)
+        _fwd_jac_fn = sol.prob.f.jac
+        _fwd_sol = sol
+        if jac_prototype isa SparseArrays.AbstractSparseMatrixCSC
+            return function (J_adj, _λ, _p, _t)
+                _y = _fwd_sol(_t, continuity = :right)
+                _fwd_jac_fn(_fwd_jac_cache, _y, _p, _t)
+                SparseArrays.ftranspose!(J_adj, _fwd_jac_cache, -)
+                return nothing
+            end
+        else
+            return function (J_adj, _λ, _p, _t)
+                _y = _fwd_sol(_t, continuity = :right)
+                _fwd_jac_fn(_fwd_jac_cache, _y, _p, _t)
+                transpose!(J_adj, _fwd_jac_cache)
+                lmul!(-1, J_adj)
+                return nothing
+            end
+        end
+    elseif jac_prototype === nothing && alg !== nothing &&
+            SciMLBase.forwarddiffs_model(alg) &&
+            SciMLBase.isinplace(sol.prob) && u0 isa AbstractArray &&
+            ArrayInterface.ismutable(u0) && eltype(u0) <: AbstractFloat
+        # `forwarddiffs_model(alg)` implies the adjoint solver would push `Dual`
+        # numbers through the vjp-based adjoint rhs anyway, so requiring the
+        # forward rhs to be ForwardDiff-compatible here does not narrow support.
+        _fwd_sol = sol
+        _f = unwrapped_f(f)
+        numindvar = length(u0)
+        _J_cache = similar(u0, numindvar, numindvar)
+        _J_cache .= false
+        _uf = SciMLBase.UJacobianWrapper(_f, tspan[2], parameter_values(sol.prob))
+        _jac_config = build_jac_config(sensealg, _uf, u0)
+        _y_cache = similar(u0)
+        _fx_cache = similar(u0)
+        return function (J_adj, _λ, _p, _t)
+            _fwd_sol(_y_cache, _t, continuity = :right)
+            _uf.t = _t
+            _uf.p = _p
+            jacobian!(_J_cache, _uf, _y_cache, _fx_cache, sensealg, _jac_config)
+            transpose!(J_adj, _J_cache)
+            lmul!(-1, J_adj)
+            return nothing
+        end
+    else
+        return nothing
+    end
+end
+
 struct ReverseLossCallback{
         λType, timeType, yType, RefType, FMType, AlgType, dg1Type,
         dg2Type,

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -376,36 +376,18 @@ end
     )
 
     jac_prototype = sol.prob.f.jac_prototype
-    adjoint_jac_prototype = !sense.discrete || jac_prototype === nothing ? nothing :
+    # The adjoint state is just λ, so the transposed forward prototype is the
+    # adjoint rhs sparsity for continuous costs too (the dgdu forcing term is
+    # λ-independent).
+    adjoint_jac_prototype = jac_prototype === nothing ? nothing :
         copy(jac_prototype')
 
-    # When the user provides an analytical Jacobian for the forward problem,
-    # construct an adjoint Jacobian that evaluates -(df/du)^T at the
-    # interpolated forward solution. This avoids finite-difference Jacobian
-    # computation in the adjoint solver.
-    adjoint_jac = if SciMLBase.has_jac(sol.prob.f) && jac_prototype !== nothing
-        _fwd_jac_cache = copy(jac_prototype)
-        _fwd_jac_fn = sol.prob.f.jac
-        _fwd_sol = sol
-        if jac_prototype isa SparseArrays.AbstractSparseMatrixCSC
-            function (J_adj, _λ, _p, _t)
-                _y = _fwd_sol(_t, continuity = :right)
-                _fwd_jac_fn(_fwd_jac_cache, _y, _p, _t)
-                SparseArrays.ftranspose!(J_adj, _fwd_jac_cache, -)
-                return nothing
-            end
-        else
-            function (J_adj, _λ, _p, _t)
-                _y = _fwd_sol(_t, continuity = :right)
-                _fwd_jac_fn(_fwd_jac_cache, _y, _p, _t)
-                transpose!(J_adj, _fwd_jac_cache)
-                lmul!(-1, J_adj)
-                return nothing
-            end
-        end
-    else
-        nothing
-    end
+    # The adjoint rhs is linear in λ, so its Jacobian is exactly -(df/du)^T at
+    # the interpolated forward solution: evaluate it from the user's analytical
+    # Jacobian when given, or by ForwardDiff/FiniteDiff of the forward rhs.
+    # This avoids differentiating the vjp-based adjoint rhs in the implicit
+    # adjoint solver.
+    adjoint_jac = build_adjoint_jac(sol, sensealg, alg, f, tspan)
 
     original_mm = sol.prob.f.mass_matrix
     if original_mm === I || original_mm === (I, I)

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -160,36 +160,18 @@ end
     )
 
     jac_prototype = sol.prob.f.jac_prototype
-    adjoint_jac_prototype = !sense.discrete || jac_prototype === nothing ? nothing :
+    # The adjoint state is just λ, so the transposed forward prototype is the
+    # adjoint rhs sparsity for continuous costs too (the dgdu forcing term is
+    # λ-independent).
+    adjoint_jac_prototype = jac_prototype === nothing ? nothing :
         copy(jac_prototype')
 
-    # When the user provides an analytical Jacobian for the forward problem,
-    # construct an adjoint Jacobian that evaluates -(df/du)^T at the
-    # interpolated forward solution. This avoids finite-difference Jacobian
-    # computation in the adjoint solver.
-    adjoint_jac = if SciMLBase.has_jac(sol.prob.f) && jac_prototype !== nothing
-        _fwd_jac_cache = copy(jac_prototype)
-        _fwd_jac_fn = sol.prob.f.jac
-        _fwd_sol = sol
-        if jac_prototype isa SparseArrays.AbstractSparseMatrixCSC
-            function (J_adj, _λ, _p, _t)
-                _y = _fwd_sol(_t, continuity = :right)
-                _fwd_jac_fn(_fwd_jac_cache, _y, _p, _t)
-                SparseArrays.ftranspose!(J_adj, _fwd_jac_cache, -)
-                return nothing
-            end
-        else
-            function (J_adj, _λ, _p, _t)
-                _y = _fwd_sol(_t, continuity = :right)
-                _fwd_jac_fn(_fwd_jac_cache, _y, _p, _t)
-                transpose!(J_adj, _fwd_jac_cache)
-                lmul!(-1, J_adj)
-                return nothing
-            end
-        end
-    else
-        nothing
-    end
+    # The adjoint rhs is linear in λ, so its Jacobian is exactly -(df/du)^T at
+    # the interpolated forward solution: evaluate it from the user's analytical
+    # Jacobian when given, or by ForwardDiff/FiniteDiff of the forward rhs.
+    # This avoids differentiating the vjp-based adjoint rhs in the implicit
+    # adjoint solver.
+    adjoint_jac = build_adjoint_jac(sol, sensealg, alg, f, tspan)
 
     original_mm = sol.prob.f.mass_matrix
     if original_mm === I || original_mm === (I, I)

--- a/test/Core3/user_vjp.jl
+++ b/test/Core3/user_vjp.jl
@@ -229,3 +229,92 @@ end
         @test jac_calls[] > 0
     end
 end
+
+@testset "AD fallback adjoint Jacobian (no user jac)" begin
+    f_plain = ODEFunction(lotka_volterra!)
+    prob = ODEProblem(f_plain, u0, tspan, p)
+    sol = solve(prob, Rodas5P(); solver_kwargs...)
+
+    # Unit test: the fallback builds -(df/du)^T at the interpolated forward state
+    for sensealg in (GaussAdjoint(), GaussAdjoint(autodiff = false))
+        jacfn = SciMLSensitivity.build_adjoint_jac(
+            sol, sensealg, Rodas5P(), sol.prob.f, reverse(tspan)
+        )
+        @test jacfn !== nothing
+        J_adj = zeros(2, 2)
+        jacfn(J_adj, nothing, p, 4.2)
+        J_ref = zeros(2, 2)
+        lv_jac!(J_ref, sol(4.2), p, 4.2)
+        @test isapprox(J_adj, -J_ref', rtol = 1.0e-6)
+    end
+
+    # No fallback for explicit adjoint solvers (Jacobian never used) or
+    # finite-difference implicit solvers (rhs may not be Dual-safe there).
+    @test SciMLSensitivity.build_adjoint_jac(
+        sol, GaussAdjoint(), Tsit5(), sol.prob.f, reverse(tspan)
+    ) === nothing
+    @test SciMLSensitivity.build_adjoint_jac(
+        sol, GaussAdjoint(), Rodas5P(autodiff = AutoFiniteDiff()), sol.prob.f,
+        reverse(tspan)
+    ) === nothing
+
+    # End-to-end: gradients with an implicit adjoint solver match ForwardDiff
+    ts_disc = collect(0.5:0.5:10.0)
+    dgdu_disc = (out, u, p, t, i) -> (out .= 1)
+    function loss_fd(p)
+        _sol = solve(
+            remake(prob, p = p), Rodas5P(); saveat = ts_disc, solver_kwargs...
+        )
+        return sum(sum(u) for u in _sol.u)
+    end
+    grad_ref = ForwardDiff.gradient(loss_fd, p)
+    @testset "$name / Rodas5P" for (name, sensealg) in [
+            ("GaussAdjoint(EnzymeVJP)", GaussAdjoint(autojacvec = EnzymeVJP())),
+            ("GaussAdjoint(ReverseDiffVJP)", GaussAdjoint(autojacvec = ReverseDiffVJP())),
+            (
+                "QuadratureAdjoint(EnzymeVJP)",
+                QuadratureAdjoint(
+                    autojacvec = EnzymeVJP(), abstol = 1.0e-10, reltol = 1.0e-10
+                ),
+            ),
+        ]
+        du0, dp = adjoint_sensitivities(
+            sol, Rodas5P(); t = ts_disc, dgdu_discrete = dgdu_disc,
+            sensealg = sensealg, abstol = 1.0e-8, reltol = 1.0e-8
+        )
+        @test isapprox(vec(dp), grad_ref, rtol = 1.0e-4)
+    end
+end
+
+@testset "Sparse user jac + continuous cost (regression: ftranspose! into dense)" begin
+    # Before the adjoint_jac_prototype fix, the sparse-jac closure was passed to
+    # the adjoint solver without its sparse prototype for continuous costs, so
+    # `ftranspose!` hit a dense destination and threw a MethodError. The sparse
+    # setup must run and agree with the dense-prototype setup.
+    jp_dense = zeros(2, 2)
+    lv_jac!(jp_dense, u0, p, 0.0)
+    dgdu_cont = (out, u, p, t) -> (out .= 1)
+    results = map((sparse(jp_dense), copy(jp_dense))) do jp
+        f = ODEFunction(lotka_volterra!; jac = lv_jac!, jac_prototype = jp)
+        prob = ODEProblem(f, u0, tspan, p)
+        sol = solve(prob, Rodas5P(); solver_kwargs...)
+        map(
+            (
+                GaussAdjoint(autojacvec = ReverseDiffVJP()),
+                QuadratureAdjoint(
+                    autojacvec = ReverseDiffVJP(), abstol = 1.0e-10, reltol = 1.0e-10
+                ),
+            )
+        ) do sa
+            du0, dp = adjoint_sensitivities(
+                sol, Rodas5P(); dgdu_continuous = dgdu_cont,
+                sensealg = sa, abstol = 1.0e-8, reltol = 1.0e-8
+            )
+            vec(dp)
+        end
+    end
+    dp_sparse, dp_dense = results
+    for (dps, dpd) in zip(dp_sparse, dp_dense)
+        @test isapprox(dps, dpd, rtol = 1.0e-6)
+    end
+end


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

Investigating GaussAdjoint performance on the 2D Brusselator (N=16, 512 states) showed that for **stiff adjoint solves without a user-provided analytical Jacobian**, the implicit adjoint solver differentiates the vjp-based adjoint rhs itself to get its Jacobian. That costs a full vjp (plus a forward-solution interpolation) per Jacobian column — and with `ReverseDiffVJP` it re-records the tape with `Dual` numbers on **every** Jacobian evaluation.

But the adjoint rhs of the state-only adjoints (`GaussAdjoint`, `QuadratureAdjoint`) is linear in `λ`: its Jacobian is exactly `-(df/du)^T` evaluated at the interpolated forward solution, independent of `λ`. #1378 already passed the user's analytical `jac` through to the adjoint solver; this PR extends that to the no-user-jac case by differentiating the **forward** rhs directly (ForwardDiff/FiniteDiff per the sensealg's `autodiff` setting) and negate-transposing.

The shared closure construction now lives in `build_adjoint_jac` (adjoint_common.jl), used by both `GaussAdjoint` and `QuadratureAdjoint`.

**Gating for the AD fallback** (conservative):
- no user `jac`, no `jac_prototype` (dense only; a sparse prototype without user jac keeps the existing colored-AD-of-adjoint-rhs path)
- `SciMLBase.forwarddiffs_model(alg)` — the adjoint solver would push `Dual`s through the vjp rhs anyway, so requiring a ForwardDiff-compatible forward rhs does not narrow support; explicit solvers (no Jacobian use) and finite-difference implicit solvers keep current behavior
- in-place ODE, mutable `AbstractFloat` state

## Also fixes a latent bug

With a **sparse user `jac_prototype` and a continuous cost**, the sparse `ftranspose!` adjoint-jac closure was passed to the adjoint solver *without* its sparse prototype (`adjoint_jac_prototype` was gated on `sense.discrete`), so the adjoint solver allocated a dense `J` and `ftranspose!` threw:

```
MethodError: no method matching ftranspose!(::Matrix{Float64}, ::SparseMatrixCSC{Float64, Int64}, ::typeof(-))
```

The adjoint state is just `λ` for these methods, so the transposed prototype is correct for continuous costs too; the gate is removed.

## Benchmarks

2D Brusselator, N=16 (512 states), KenCarp47 forward + adjoint, tol 1e-6, discrete sum cost at 23 time points, `adjoint_sensitivities`. Forward solve: 0.45 s.

| sensealg | master | this PR | speedup |
|---|---|---|---|
| `GaussAdjoint(EnzymeVJP)` | 0.97–1.17 s, 8.05M allocs, 703 MiB | 0.45–0.50 s, 6.5k allocs, 8.8 MiB | **~2.2×** |
| `GaussAdjoint(ReverseDiffVJP(true))` | 5.2–6.9 s, 2.4 GiB | 1.5–1.7 s, 14.7 MiB | **~3.5×** |
| `QuadratureAdjoint(EnzymeVJP)` | 0.98–1.88 s, 705 MiB | 0.64 s, 10.6 MiB | **~1.7×** |

The adjoint solve now costs about the same as the forward solve. Gradients are identical to master (verified digit-for-digit on the benchmark, and against ForwardDiff references in the new tests).

Explicit-solver adjoints are unaffected (profiled: ~88% of time is inside Enzyme vjp calls, which this PR does not touch).

## Tests

Added to `test/Core3/user_vjp.jl`:
- unit test that the fallback Jacobian matches `-(df/du)^T` analytically (both `autodiff=true` and `autodiff=false`)
- gating tests (no fallback for `Tsit5`, no fallback for `Rodas5P(autodiff=AutoFiniteDiff())`)
- end-to-end `adjoint_sensitivities` gradients vs ForwardDiff with `Rodas5P` adjoint solves for `GaussAdjoint(EnzymeVJP)`, `GaussAdjoint(ReverseDiffVJP)`, `QuadratureAdjoint(EnzymeVJP)`
- regression test for the sparse-jac + continuous-cost `ftranspose!` bug (sparse vs dense prototype must agree)

Ran locally: `test/Core3/user_vjp.jl` (all 34 pass), plus full `GROUP=Core1`, `GROUP=Core2` (stiff adjoints), and `GROUP=Core3` package test groups — all pass.

## Process notes

Investigation: cloned repo, benchmarked GaussAdjoint vs Interpolating/Quadrature on Brusselator with ROCK4 (explicit) and KenCarp47 (stiff), profiled both vjp backends, identified the AD-of-vjp-rhs Jacobian as the dominant stiff-path cost (8M allocations, 703 MiB per gradient), implemented the exact-Jacobian fallback, and A/B benchmarked master vs branch in separate environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
