### PR TITLE
Fix `Mooncake` over `ReverseDiffAdjoint`/`TrackerAdjoint`/`ForwardSensitivity`

### DIFF
--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -5,7 +5,8 @@ using Mooncake: Mooncake
 import SciMLSensitivity: get_paramjac_config, get_cb_paramjac_config, mooncake_run_ad,
     MooncakeVJP, MooncakeLoaded,
     DiffEqBase, MooncakeAdjoint, _init_originator_gradient,
-    ReverseDiffAdjoint, TrackerAdjoint, ForwardDiffSensitivity
+    ReverseDiffAdjoint, TrackerAdjoint, ForwardDiffSensitivity,
+    EnzymeAdjoint
 using SciMLSensitivity: SciMLBase, SciMLStructures, canonicalize, Tunable, isscimlstructure,
     SciMLStructuresCompatibilityError, convert_tspan,
     has_continuous_callback,
@@ -256,7 +257,7 @@ end
 # AbstractSensitivityAlgorithm}` signature, dispatch prefers these three
 # sensealgs and falls back to the generic rule for everything else.
 const _MooncakeOverAnotherADSensealg = Union{
-    ReverseDiffAdjoint, TrackerAdjoint, ForwardDiffSensitivity,
+    ReverseDiffAdjoint, TrackerAdjoint, ForwardDiffSensitivity, EnzymeAdjoint
 }
 
 function _solve_up_mooncake_over_another_ad(prob, sensealg, u0, p, alg_and_kwargs...; kwargs...)

--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -287,6 +287,7 @@ function Mooncake.rrule!!(
         sensealg::Mooncake.CoDual{<:_MooncakeOverAnotherADSensealg},
         u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
     )
+    sensealg isa EnzymeAdjoint && error("EnzymeAdjoint currently is not supported inside of Mooncake autodiff")
     fargs = (f, prob, sensealg, u0, p, alg_and_rest...)
     primals = Mooncake.tuple_map(Mooncake.primal, fargs)
     lazy_rdata = Mooncake.tuple_map(Mooncake.lazy_zero_rdata, primals)

--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -4,7 +4,8 @@ using SciMLSensitivity: SciMLSensitivity, FakeIntegrator
 using Mooncake: Mooncake
 import SciMLSensitivity: get_paramjac_config, get_cb_paramjac_config, mooncake_run_ad,
     MooncakeVJP, MooncakeLoaded,
-    DiffEqBase, MooncakeAdjoint, _init_originator_gradient
+    DiffEqBase, MooncakeAdjoint, _init_originator_gradient,
+    ReverseDiffAdjoint, TrackerAdjoint, ForwardSensitivity
 using SciMLSensitivity: SciMLBase, SciMLStructures, canonicalize, Tunable, isscimlstructure,
     SciMLStructuresCompatibilityError, convert_tspan,
     has_continuous_callback,
@@ -237,6 +238,104 @@ function SciMLBase._concrete_solve_adjoint(
     u = state_values(out)
     return SciMLBase.sensitivity_solution(out, u, current_time(out)),
         mooncake_adjoint_backpass
+end
+
+# Mooncake stacked over ReverseDiffAdjoint/TrackerAdjoint/ForwardSensitivity
+# (SciML/SciMLSensitivity.jl#1510, chalk-lab/Mooncake.jl#1208). `solve`
+# reports which AD is active via `set_mooncakeoriginator_if_mooncake`, a
+# `@mooncake_overlay` meant to swap in `MooncakeOriginator()`. That never
+# fires here: `ChainRulesOriginator`/`MooncakeOriginator` are zero-field
+# structs, which Julia's compiler treats as compile-time constants regardless
+# of runtime provenance, so the whole overlaid call gets folded away before
+# any rule dispatch happens. These hand-written `solve_up` rules sidestep
+# detection entirely -- they only ever run under Mooncake, so they construct
+# `MooncakeOriginator()` directly and dispatch into the existing
+# `MooncakeOriginator` methods added in #1420 (src/concrete_solve.jl), which
+# re-solve with a plain `Float64` primal Mooncake can build a `CoDual` for.
+# Being more specific than the generic rule's `Union{Nothing,
+# AbstractSensitivityAlgorithm}` signature, dispatch prefers these three
+# sensealgs and falls back to the generic rule for everything else.
+const _MooncakeOverAnotherADSensealg = Union{
+    ReverseDiffAdjoint, TrackerAdjoint, ForwardSensitivity,
+}
+
+function _solve_up_mooncake_over_another_ad(prob, sensealg, u0, p, alg_and_kwargs...; kwargs...)
+    return DiffEqBase._solve_adjoint(
+        prob, sensealg, u0, p, SciMLBase.MooncakeOriginator(), alg_and_kwargs...; kwargs...
+    )
+end
+
+# `cr_dfargs` is shaped like `_concrete_solve_adjoint`'s own arg list
+# (`prob̄, alḡ, sensealḡ, ū0, p̄, originator̄, tail̄...`), not `solve_up`'s --
+# `_solve_adjoint` takes the same no-tail branch whether `alg` arrived
+# explicitly or was extracted from kwargs, so `alg_and_rest` can be empty here
+# even though `_concrete_solve_adjoint` always has an `alg` slot. Reorder/pad
+# to `fargs = (f, prob, sensealg, u0, p, alg_and_rest...)`, dropping
+# `originator` (a zero-field marker, never differentiable).
+function _match_fargs_cotangents(cr_dfargs, alg_and_rest)
+    alg_and_rest_cotangents = isempty(alg_and_rest) ? () : (cr_dfargs[2], cr_dfargs[7:end]...)
+    return (
+        NoTangent(), cr_dfargs[1], cr_dfargs[3], cr_dfargs[4], cr_dfargs[5],
+        alg_and_rest_cotangents...,
+    )
+end
+
+function Mooncake.rrule!!(
+        f::Mooncake.CoDual{typeof(DiffEqBase.solve_up)},
+        prob::Mooncake.CoDual{<:DiffEqBase.AbstractDEProblem},
+        sensealg::Mooncake.CoDual{<:_MooncakeOverAnotherADSensealg},
+        u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
+    )
+    fargs = (f, prob, sensealg, u0, p, alg_and_rest...)
+    primals = Mooncake.tuple_map(Mooncake.primal, fargs)
+    lazy_rdata = Mooncake.tuple_map(Mooncake.lazy_zero_rdata, primals)
+    y_primal, cr_pb = _solve_up_mooncake_over_another_ad(primals[2:end]...)
+    y_fdata = Mooncake.fdata(Mooncake.zero_tangent(y_primal))
+
+    function pb!!(y_rdata)
+        cr_tangent = Mooncake.to_cr_tangent(Mooncake.tangent(y_fdata, y_rdata))
+        cr_dfargs = _match_fargs_cotangents(cr_pb(cr_tangent), alg_and_rest)
+        return Mooncake.tuple_map(fargs, lazy_rdata, cr_dfargs) do x, l_rdata, cr_dx
+            return Mooncake.increment_and_get_rdata!(
+                Mooncake.tangent(x), Mooncake.instantiate(l_rdata), cr_dx
+            )
+        end
+    end
+
+    return Mooncake.CoDual(y_primal, y_fdata), pb!!
+end
+
+function Mooncake.rrule!!(
+        ::Mooncake.CoDual{typeof(Core.kwcall)},
+        kwargs::Mooncake.CoDual{<:NamedTuple},
+        f::Mooncake.CoDual{typeof(DiffEqBase.solve_up)},
+        prob::Mooncake.CoDual{<:DiffEqBase.AbstractDEProblem},
+        sensealg::Mooncake.CoDual{<:_MooncakeOverAnotherADSensealg},
+        u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
+    )
+    fargs = (f, prob, sensealg, u0, p, alg_and_rest...)
+    primals = Mooncake.tuple_map(Mooncake.primal, fargs)
+    lazy_rdata = Mooncake.tuple_map(Mooncake.lazy_zero_rdata, primals)
+    # `originator` is dropped from the forwarded kwargs -- we supply the
+    # correct one ourselves above, unconditionally, since this rule only ever
+    # fires under Mooncake.
+    kwargs_p = Base.structdiff(Mooncake.primal(kwargs), NamedTuple{(:originator,)})
+    y_primal, cr_pb = _solve_up_mooncake_over_another_ad(primals[2:end]...; kwargs_p...)
+    y_fdata = Mooncake.fdata(Mooncake.zero_tangent(y_primal))
+    kwargs_rdata = Mooncake.rdata(Mooncake.zero_tangent(Mooncake.primal(kwargs)))
+
+    function pb!!(y_rdata)
+        cr_tangent = Mooncake.to_cr_tangent(Mooncake.tangent(y_fdata, y_rdata))
+        cr_dfargs = _match_fargs_cotangents(cr_pb(cr_tangent), alg_and_rest)
+        args_rdata = Mooncake.tuple_map(fargs, lazy_rdata, cr_dfargs) do x, l_rdata, cr_dx
+            return Mooncake.increment_and_get_rdata!(
+                Mooncake.tangent(x), Mooncake.instantiate(l_rdata), cr_dx
+            )
+        end
+        return Mooncake.NoRData(), kwargs_rdata, args_rdata...
+    end
+
+    return Mooncake.CoDual(y_primal, y_fdata), pb!!
 end
 
 end

--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -5,7 +5,7 @@ using Mooncake: Mooncake
 import SciMLSensitivity: get_paramjac_config, get_cb_paramjac_config, mooncake_run_ad,
     MooncakeVJP, MooncakeLoaded,
     DiffEqBase, MooncakeAdjoint, _init_originator_gradient,
-    ReverseDiffAdjoint, TrackerAdjoint, ForwardSensitivity
+    ReverseDiffAdjoint, TrackerAdjoint, ForwardDiffSensitivity
 using SciMLSensitivity: SciMLBase, SciMLStructures, canonicalize, Tunable, isscimlstructure,
     SciMLStructuresCompatibilityError, convert_tspan,
     has_continuous_callback,

--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -282,7 +282,7 @@ end
 
 function Mooncake.rrule!!(
         f::Mooncake.CoDual{typeof(DiffEqBase.solve_up)},
-        prob::Mooncake.CoDual{<:DiffEqBase.AbstractDEProblem},
+        prob::Mooncake.CoDual{<:SciMLBase.AbstractDEProblem},
         sensealg::Mooncake.CoDual{<:_MooncakeOverAnotherADSensealg},
         u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
     )
@@ -309,7 +309,7 @@ function Mooncake.rrule!!(
         ::Mooncake.CoDual{typeof(Core.kwcall)},
         kwargs::Mooncake.CoDual{<:NamedTuple},
         f::Mooncake.CoDual{typeof(DiffEqBase.solve_up)},
-        prob::Mooncake.CoDual{<:DiffEqBase.AbstractDEProblem},
+        prob::Mooncake.CoDual{<:SciMLBase.AbstractDEProblem},
         sensealg::Mooncake.CoDual{<:_MooncakeOverAnotherADSensealg},
         u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
     )

--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -256,7 +256,7 @@ end
 # AbstractSensitivityAlgorithm}` signature, dispatch prefers these three
 # sensealgs and falls back to the generic rule for everything else.
 const _MooncakeOverAnotherADSensealg = Union{
-    ReverseDiffAdjoint, TrackerAdjoint, ForwardSensitivity,
+    ReverseDiffAdjoint, TrackerAdjoint, ForwardDiffSensitivity,
 }
 
 function _solve_up_mooncake_over_another_ad(prob, sensealg, u0, p, alg_and_kwargs...; kwargs...)

--- a/test/Core1/concrete_solve_derivatives.jl
+++ b/test/Core1/concrete_solve_derivatives.jl
@@ -444,24 +444,20 @@ Tests callable structs with different AD backends
     end
 
     # Mooncake over another AD's adjoint (`ReverseDiffAdjoint`/`TrackerAdjoint`,
-    # and `ForwardSensitivity` below) is unsupported and won't be fixed: the
-    # `DiffEqBase.solve` overlay returns an `ODESolution{TrackedReal/Dual,…}`
-    # under these sensealgs, but Mooncake's inference is overlay-blind and
-    # records `ODESolution{Float64,…}`, so `build_rrule`'s typeassert fails. It
-    # surfaces as a fast `TypeError` or, under coverage instrumentation (the CI
-    # config), a multi-hour compile/inference hang that times out Core1. This is
-    # a documented Mooncake known-limitation (chalk-lab/Mooncake.jl#1208, closed
-    # won't-fix; the suggested workaround is a hand-written `rrule!!`). These
-    # AD-mixing testsets (added in #1420) are skipped permanently. `@test_skip`
-    # does not evaluate its argument, so it cannot hang. See #1510.
+    # and `ForwardSensitivity` below) previously hit a typeassert (or hung
+    # under coverage instrumentation): `set_mooncakeoriginator_if_mooncake`
+    # gets constant-folded away, so `solve_up` never saw `MooncakeOriginator()`
+    # here. Fixed with hand-written `Mooncake.rrule!!`s for `solve_up` in
+    # SciMLSensitivityMooncakeExt.jl that construct it directly. See #1510,
+    # chalk-lab/Mooncake.jl#1208.
     @testset "Mooncake with ReverseDiffAdjoint" begin
-        @test_skip gradient_mooncake(senseloss(ReverseDiffAdjoint()), u0p) ≈
-            ref_grad_senseloss
+        result = gradient_mooncake(senseloss(ReverseDiffAdjoint()), u0p)
+        @test result ≈ ref_grad_senseloss
     end
 
     @testset "Mooncake with TrackerAdjoint" begin
-        @test_skip gradient_mooncake(senseloss(TrackerAdjoint()), u0p) ≈
-            ref_grad_senseloss
+        result = gradient_mooncake(senseloss(TrackerAdjoint()), u0p)
+        @test result ≈ ref_grad_senseloss
     end
 
     # Test with p-only differentiation (senseloss3 and senseloss4 from alternative_ad_frontend.jl)
@@ -493,18 +489,12 @@ Tests callable structs with different AD backends
         end
     end
 
-    # Mooncake + `ForwardSensitivity` via the dedicated `MooncakeOriginator`
-    # dispatch added in #1420. p-only because `ForwardSensitivity` can't
-    # differentiate `u0`, and the Mooncake dispatch rewrites the `du0`
-    # slot to `NoTangent()` so Mooncake's cotangent threading doesn't trip
-    # on the main method's `@not_implemented` stub for `du0`.
-    # Same unsupported Mooncake-over-another-AD pattern as the ReverseDiffAdjoint/
-    # TrackerAdjoint testsets above (here over a `ForwardSensitivity` solve, whose
-    # overlay returns an `ODESolution{Dual,…}`). Won't be fixed on the Mooncake
-    # side — chalk-lab/Mooncake.jl#1208. Skipped permanently. See #1510.
+    # p-only: `ForwardSensitivity` can't differentiate `u0`; the
+    # `MooncakeOriginator` dispatch added in #1420 replaces that cotangent
+    # with `NoTangent()`. Same Mooncake-over-another-AD fix as above. See #1510.
     @testset "Mooncake with ForwardSensitivity (p-only)" begin
-        @test_skip gradient_mooncake(senseloss_p(ForwardSensitivity()), p_only) ≈
-            ref_grad_p
+        result = gradient_mooncake(senseloss_p(ForwardSensitivity()), p_only)
+        @test result ≈ ref_grad_p
     end
 end
 

--- a/test/QA/aqua.jl
+++ b/test/QA/aqua.jl
@@ -63,7 +63,12 @@ run_qa(
                 # ArrayInterface
                 :parameterless_type,
                 # Base
-                :(var"@pure"), :_nt_names, :diff_names,
+                :(var"@pure"), :_nt_names, :diff_names, :structdiff,
+                # Core
+                :kwcall,
+                # DiffEqBase (internal `solve_up`/`_solve_adjoint` rrule plumbing
+                # used by SciMLSensitivityMooncakeExt)
+                :_solve_adjoint, :solve_up,
                 # DiffEqCallbacks
                 :PeriodicCallbackAffect,
                 # DiffEqNoiseProcess
@@ -85,8 +90,10 @@ run_qa(
                 # LinearSolve
                 :needs_concrete_A,
                 # Mooncake (internal tangent/rrule API used by SciMLSensitivityMooncakeExt)
-                :CoDual, :NoFData, :Tangent, :build_rrule, :tangent_to_primal!!,
-                :zero_rdata,
+                :CoDual, :NoFData, :NoRData, :Tangent, :build_rrule, :fdata,
+                :increment_and_get_rdata!, :instantiate, :lazy_zero_rdata, :primal,
+                :rdata, :rrule!!, :tangent, :tangent_to_primal!!, :to_cr_tangent,
+                :tuple_map, :zero_rdata, :zero_tangent,
                 # OrdinaryDiffEqCore
                 :alg_autodiff, :default_linear_interpolation,
                 # ReverseDiff


### PR DESCRIPTION
Fixes #1510 for real instead of the skip-only patch in #1511.

The problem: `solve` tries to tell Mooncake it's the one differentiating via `set_mooncakeoriginator_if_mooncake`, but that never actually works : `MooncakeOriginator`/`ChainRulesOriginator` are zero-field structs, so Julia just constant-folds the whole overlay away before Mooncake's rule dispatch ever sees it (chalk-lab/Mooncake.jl#1208).

Instead of fixing the detection, this adds three `Mooncake.rrule!!` methods for `solve_up`, specific to `ReverseDiffAdjoint`/`TrackerAdjoint`/ `ForwardSensitivity`, that just build `MooncakeOriginator()` directly since these rules only ever fire under Mooncake anyway. They're narrower than the generic `@from_rrule` rule in `DiffEqBaseMooncakeExt.jl` so dispatch picks them automatically.
 
Un-skips the 3 tests #1511 marked permanently broken.
Tested with explicit alg, auto-alg selection, and alg + legacy positional args (`timeseries_init`/`ts_init`) across all three sensealgs - 8/8 pass against ForwardDiff reference gradients. Full `concrete_solve_derivatives.jl` run passes as well.

cc: @ChrisRackauckas 