### PR TITLE
Docs: fix ensemble/solution API drift in the remaining Zygote examples

### DIFF
--- a/docs/src/examples/sde/SDE_control.md
+++ b/docs/src/examples/sde/SDE_control.md
@@ -186,9 +186,9 @@ function loss(p_nn; alg = SDE.EM(), sensealg = SMS.BacksolveAdjoint(autojacvec =
         myparameters = [myparameters.Δ, myparameters.Ωmax, myparameters.κ])
     u0 = prepare_initial(myparameters.dt, myparameters.numtraj)
 
-    function prob_func(prob, i, repeat)
+    function prob_func(prob, ctx)
         # prepare initial state and applied control pulse
-        u0tmp = deepcopy(vec(u0[:, i]))
+        u0tmp = deepcopy(vec(u0[:, ctx.sim_id]))
         W = sqrt(myparameters.dt) * randn(typeof(myparameters.dt), size(myparameters.ts)) #for 1 trajectory
         W1 = cumsum([zero(myparameters.dt); W[1:(end - 1)]], dims = 1)
         NG = DNP.NoiseGrid(myparameters.ts, W1)
@@ -218,9 +218,9 @@ function visualize(p_nn; alg = SDE.EM())
     pars = CA.ComponentArray(; p_nn,
         myparameters = [myparameters.Δ, myparameters.Ωmax, myparameters.κ])
 
-    function prob_func(prob, i, repeat)
+    function prob_func(prob, ctx)
         # prepare initial state and applied control pulse
-        u0tmp = deepcopy(vec(u0[:, i]))
+        u0tmp = deepcopy(vec(u0[:, ctx.sim_id]))
         W = sqrt(myparameters.dt) * randn(typeof(myparameters.dt), size(myparameters.ts)) #for 1 trajectory
         W1 = cumsum([zero(myparameters.dt); W[1:(end - 1)]], dims = 1)
         NG = DNP.NoiseGrid(myparameters.ts, W1)
@@ -528,9 +528,9 @@ function loss(p_nn; alg = SDE.EM(), sensealg = SMS.BacksolveAdjoint(autojacvec =
         myparameters = [myparameters.Δ, myparameters.Ωmax, myparameters.κ])
     u0 = prepare_initial(myparameters.dt, myparameters.numtraj)
 
-    function prob_func(prob, i, repeat)
+    function prob_func(prob, ctx)
         # prepare initial state and applied control pulse
-        u0tmp = deepcopy(vec(u0[:, i]))
+        u0tmp = deepcopy(vec(u0[:, ctx.sim_id]))
         W = sqrt(myparameters.dt) * randn(typeof(myparameters.dt), size(myparameters.ts)) #for 1 trajectory
         W1 = cumsum([zero(myparameters.dt); W[1:(end - 1)]], dims = 1)
         NG = DNP.NoiseGrid(myparameters.ts, W1)
@@ -566,9 +566,9 @@ function visualize(p_nn; alg = SDE.EM())
     pars = CA.ComponentArray(; p_nn,
         myparameters = [myparameters.Δ, myparameters.Ωmax, myparameters.κ])
 
-    function prob_func(prob, i, repeat)
+    function prob_func(prob, ctx)
         # prepare initial state and applied control pulse
-        u0tmp = deepcopy(vec(u0[:, i]))
+        u0tmp = deepcopy(vec(u0[:, ctx.sim_id]))
         W = sqrt(myparameters.dt) * randn(typeof(myparameters.dt), size(myparameters.ts)) #for 1 trajectory
         W1 = cumsum([zero(myparameters.dt); W[1:(end - 1)]], dims = 1)
         NG = DNP.NoiseGrid(myparameters.ts, W1)

--- a/docs/src/examples/sde/optimization_sde.md
+++ b/docs/src/examples/sde/optimization_sde.md
@@ -84,10 +84,10 @@ function cb2(st, l)
     arrsol1 = predict(st.u)
     means = Statistics.mean(arrsol1, dims = 3)[:, :]
     vars = Statistics.var(arrsol1, dims = 3)[:, :]
-    p1 = Plots.plot(sol[1].t, means', lw = 5)
-    Plots.scatter!(p1, sol[1].t, truemean')
-    p2 = Plots.plot(sol[1].t, vars', lw = 5)
-    Plots.scatter!(p2, sol[1].t, truevar')
+    p1 = Plots.plot(sol.u[1].t, means', lw = 5)
+    Plots.scatter!(p1, sol.u[1].t, truemean')
+    p2 = Plots.plot(sol.u[1].t, vars', lw = 5)
+    Plots.scatter!(p2, sol.u[1].t, truevar')
     p = Plots.plot(p1, p2, layout = (2, 1))
     display(p)
     false

--- a/docs/src/tutorials/data_parallel.md
+++ b/docs/src/tutorials/data_parallel.md
@@ -92,6 +92,7 @@ Distributed and GPU minibatching are described below.
 
 ```@example dataparallel
 import OrdinaryDiffEq as ODE
+import SciMLBase
 import Optimization as OPT
 import OptimizationOptimisers as OPO
 import SciMLSensitivity as SMS
@@ -103,8 +104,8 @@ u0 = [3.0]
 function model1(θ, ensemble)
     prob = ODE.ODEProblem((u, p, t) -> 1.01u .* p, [θ[1]], (0.0, 1.0), [θ[2]])
 
-    function prob_func(prob, i, repeat)
-        ODE.remake(prob, u0 = 0.5 .+ i / 100 .* prob.u0)
+    function prob_func(prob, ctx)
+        ODE.remake(prob, u0 = 0.5 .+ ctx.sim_id / 100 .* prob.u0)
     end
 
     ensemble_prob = ODE.EnsembleProblem(prob; prob_func)
@@ -112,8 +113,8 @@ function model1(θ, ensemble)
 end
 
 # loss function
-loss_serial(θ) = sum(abs2, 1.0 .- Array(model1(θ, ODE.EnsembleSerial())))
-loss_threaded(θ) = sum(abs2, 1.0 .- Array(model1(θ, ODE.EnsembleThreads())))
+loss_serial(θ) = sum(abs2, 1.0 .- Array(model1(θ, SciMLBase.EnsembleSerial())))
+loss_threaded(θ) = sum(abs2, 1.0 .- Array(model1(θ, SciMLBase.EnsembleThreads())))
 
 callback = function (θ, l) # callback function to observe training
     @show l
@@ -151,12 +152,13 @@ prob = ODE.ODEProblem((u, p, t) -> 1.01u .* p, [θ[1]], (0.0, 1.0), [θ[2]])
 
 In the `prob_func` we define how to build a new problem based on the
 base problem. In this case, we want to change `u0` by a constant, i.e.
-`0.5 .+ i/100 .* prob.u0` for different trajectories labelled by `i`.
+`0.5 .+ ctx.sim_id/100 .* prob.u0` for different trajectories, where
+`ctx.sim_id` is the trajectory index carried by the `EnsembleContext`.
 Thus we use the [remake function from the problem interface](https://docs.sciml.ai/DiffEqDocs/stable/basics/problem/#Modification-of-problem-types) to do so:
 
 ```@example dataparallel
-function prob_func(prob, i, repeat)
-    ODE.remake(prob, u0 = 0.5 .+ i / 100 .* prob.u0)
+function prob_func(prob, ctx)
+    ODE.remake(prob, u0 = 0.5 .+ ctx.sim_id / 100 .* prob.u0)
 end
 ```
 
@@ -168,19 +170,19 @@ ensemble_prob = ODE.EnsembleProblem(prob; prob_func)
 
 Now, to solve an ensemble problem, we need to choose an ensembling
 algorithm and choose the number of trajectories to solve. Here let's
-solve this in serial with 100 trajectories. Note that `i` will thus run
-from `1:100`.
+solve this in serial with 100 trajectories. Note that `ctx.sim_id` will
+thus run from `1:100`.
 
 ```@example dataparallel
 sim = ODE.solve(
-    ensemble_prob, ODE.Tsit5(), ODE.EnsembleSerial(), saveat = 0.1, trajectories = 100)
+    ensemble_prob, ODE.Tsit5(), SciMLBase.EnsembleSerial(), saveat = 0.1, trajectories = 100)
 ```
 
 and thus running in multithreading would be:
 
 ```@example dataparallel
 sim = ODE.solve(
-    ensemble_prob, ODE.Tsit5(), ODE.EnsembleThreads(), saveat = 0.1, trajectories = 100)
+    ensemble_prob, ODE.Tsit5(), SciMLBase.EnsembleThreads(), saveat = 0.1, trajectories = 100)
 ```
 
 This whole mechanism is differentiable, so we then put it in a training
@@ -198,7 +200,7 @@ all the same, except you utilize `EnsembleDistributed` as the ensembler:
 
 ```@example dataparallel
 sim = ODE.solve(
-    ensemble_prob, ODE.Tsit5(), ODE.EnsembleDistributed(), saveat = 0.1, trajectories = 100)
+    ensemble_prob, ODE.Tsit5(), SciMLBase.EnsembleDistributed(), saveat = 0.1, trajectories = 100)
 ```
 
 Note that for this to work, you need to ensure that your processes are
@@ -214,6 +216,7 @@ Distributed.addprocs(4)
 
 Distributed.@everywhere begin
     import OrdinaryDiffEq as ODE
+    import SciMLBase
     import Optimization as OPT
     import OptimizationOptimisers as OPO
     function f(u, p, t)
@@ -228,8 +231,8 @@ u0 = [3.0]
 function model1(θ, ensemble)
     prob = ODE.ODEProblem(f, [θ[1]], (0.0, 1.0), [θ[2]])
 
-    function prob_func(prob, i, repeat)
-        ODE.remake(prob, u0 = 0.5 .+ i / 100 .* prob.u0)
+    function prob_func(prob, ctx)
+        ODE.remake(prob, u0 = 0.5 .+ ctx.sim_id / 100 .* prob.u0)
     end
 
     ensemble_prob = ODE.EnsembleProblem(prob; prob_func)
@@ -242,7 +245,7 @@ callback = function (θ, l) # callback function to observe training
 end
 
 opt = OPO.Adam(0.1)
-loss_distributed(θ) = sum(abs2, 1.0 .- Array(model1(θ, ODE.EnsembleDistributed())))
+loss_distributed(θ) = sum(abs2, 1.0 .- Array(model1(θ, SciMLBase.EnsembleDistributed())))
 l1 = loss_distributed(θ)
 
 adtype = OPT.AutoZygote()
@@ -285,8 +288,8 @@ u0 = [3.0]
 function model1(θ, ensemble)
     prob = ODE.ODEProblem(f, [θ[1]], (0.0, 1.0), [θ[2]])
 
-    function prob_func(prob, i, repeat)
-        ODE.remake(prob, u0 = 0.5 .+ i / 100 .* prob.u0)
+    function prob_func(prob, ctx)
+        ODE.remake(prob, u0 = 0.5 .+ ctx.sim_id / 100 .* prob.u0)
     end
 
     ensemble_prob = ODE.EnsembleProblem(prob; prob_func)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft, opened by an agent.

## What

Fixes the three docs example pages that were failing in the Documentation build for reasons **unrelated to the AD backend** — the API drift that made #1560's Zygote→Enzyme conversion look like it "fixed" the pages when the real cause was these:

- **`docs/src/tutorials/data_parallel.md`**
  - `EnsembleSerial` / `EnsembleThreads` / `EnsembleDistributed` are no longer re-exported by OrdinaryDiffEq (CI: `UndefVarError: EnsembleSerial not defined in OrdinaryDiffEq`). Import `SciMLBase` and qualify them.
  - `prob_func` now takes `(prob, ctx::EnsembleContext)`; the trajectory index is `ctx.sim_id`, not the old third-arg `(prob, i, repeat)` form.
- **`docs/src/examples/sde/SDE_control.md`** — same `prob_func` signature update (4 occurrences; `u0[:, i]` → `u0[:, ctx.sim_id]`).
- **`docs/src/examples/sde/optimization_sde.md`** — indexing an `EnsembleSolution` with `sol[1]` now returns a scalar, so the callback's `sol[1].t` threw `FieldError: type Float64 has no field t` (this is the exact `@example sde` failure @wsmoses hit on #1560). Use `sol.u[1].t`.

This keeps the pages on their current `AutoZygote()` so the fix is isolated to the API drift — no backend change, per the "one thing per PR / don't stack unfixed steps" point on #1560. The Zygote→Enzyme conversion can then land as a clean follow-up on top of green pages.

## Verification (local, Julia 1.12.6, SciMLSensitivity 7.116.1)

Ran the executed blocks of both fixed pages:

- **`optimization_sde.md`**: the callback path that was throwing now resolves `sol.u[1].t` to the 101-point time axis; confirmed the old `sol[1].t` still errors with the reported `FieldError` and the new form works.
- **`data_parallel.md`**: forward ensemble solves + losses run (`loss_serial == loss_threaded == 11050.12`). With `AutoZygote()` the subsequent optimization **segfaults on Julia 1.12** (this is the known Zygote-on-1.12 ensemble segfault, #1325 — a separate, pre-existing issue, not introduced here); with `AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Reverse))` the identical page trains cleanly (objective 11050 → ~110).

So `data_parallel.md` on Zygote will still fail the docs build on 1.12 via #1325 — that page specifically needs the Enzyme conversion (#1424) to go green, which the API fix here unblocks. `optimization_sde.md` and `SDE_control.md` are fixed by the API drift alone.

## Note

`optimization_sde.md` Example 1 and `SDE_control.md` are also tracked by #1424 (EnsembleProblem tutorials still on Zygote). This PR does the API-drift prerequisite; the backend move is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
