### PR TITLE
Bump SciMLSensitivity to v7.116.2 for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.116.1"
+version = "7.116.2"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Releases unreleased changes on master, including the exact adjoint Jacobian for GaussAdjoint/QuadratureAdjoint implicit adjoints and added Accessors/Adapt imports.

Detected by comparing the `git-tree-sha1` of the latest live registered version in General against the `src` subtree on the default branch. Only the `version` field in `Project.toml` is changed. **No local test run** — CI on this PR is the check. Please ignore until reviewed by @ChrisRackauckas.