### PR TITLE
Add EnzymeVJP dispatch for _jacNoise! (non-diagonal noise SDE adjoints)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.116.2"
+version = "7.116.3"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -445,6 +445,45 @@ function adjointdiffcache(
                     end
                 end
             end
+        elseif autojacvec isa EnzymeVJP
+            # Cache the reusable buffers so `_jacNoise!(::EnzymeVJP)` allocates
+            # nothing per reverse-solver step (mirrors the drift `_vecjacobian!`).
+            jac_noise_config = nothing
+            noise_rate_prototype = prob.noise_rate_prototype
+            _diag = SciMLBase.is_diagonal_noise(prob)
+            # Output-shaped buffers (state-shaped for diagonal noise, matrix-shaped
+            # for non-diagonal), plus the state-shaped primal/shadow.
+            _du_out = _diag ? zero(y) : zero(noise_rate_prototype)
+            _du_seed = _diag ? zero(y) : zero(noise_rate_prototype)
+            _u_buf = zero(y)
+            _du_u = zero(y)
+            _pf = get_pf(autojacvec; _f = unwrappedf, isinplace, isRODE)
+            _func_shadow = Enzyme.make_zero(_pf)
+            # Dense parameter-gradient shadow (used directly for plain-array and
+            # view-backed `p`).
+            _dp_dense = zero(_p)
+            # #1470-safe parameter shadow: for a SciMLStructures (non-array) `p` the
+            # shadow must be a fully disjoint `make_zero(p)` (NOT
+            # `repack(zero(tunables))`, which aliases `p`'s non-tunable arrays);
+            # re-zeroing a cached aliasing shadow would corrupt the user's `p`.
+            _needs_shadow = !(p isa SciMLBase.NullParameters) &&
+                isscimlstructure(p) && !(p isa AbstractArray)
+            _shadow_p = if _needs_shadow
+                Enzyme.make_zero(p)
+            elseif !(p isa SciMLBase.NullParameters) && p isa AbstractArray &&
+                    typeof(tunables) !== typeof(zero(tunables))
+                # view-backed tunables (e.g. ComponentArray with SubArray data):
+                # pre-allocate a dense primal buffer to match the dense shadow type.
+                EnzymeViewPrimalBuffer(copy(tunables))
+            else
+                nothing
+            end
+            paramjac_noise_config = (
+                du_out = _du_out, du_seed = _du_seed,
+                u_buf = _u_buf, du_u = _du_u,
+                func_shadow = _func_shadow, dp_dense = _dp_dense,
+                shadow_p = _shadow_p,
+            )
         elseif autojacvec isa Bool
             if isinplace
                 if SciMLBase.is_diagonal_noise(prob)

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -1736,43 +1736,63 @@ function _jacNoise!(
 
     _p_scimlstruct = false
     if want_pgrad
-        (; tunables, repack) = S.diffcache
         _p_scimlstruct = isscimlstructure(p) && !(p isa AbstractArray)
     end
+
+    # Buffers pre-allocated once in the diffcache (see the EnzymeVJP branch in
+    # `adjointdiffcache`), reused and re-zeroed per reverse-solver step × column.
+    cfg = S.diffcache.paramjac_noise_config
+    du_out = cfg.du_out
+    du_seed = cfg.du_seed
+    u_buf = cfg.u_buf
+    du_u = cfg.du_u
+    func_shadow = cfg.func_shadow
+    dp_dense = cfg.dp_dense
+    cached_shadow = cfg.shadow_p
 
     func = SciMLBase.Void(f)
 
     for i in 1:m
-        # Primal output buffer (zeroed) and its cotangent seed. Enzyme consumes the
-        # seed shadow during the reverse pass, so both are freshly allocated per
-        # column. Seeding column `i` with `λ` computes the vjp of the `i`-th Wiener
-        # column of the noise term; for diagonal noise a single scalar `λ[i]` at
-        # component `i` computes the vjp of the `i`-th diagonal noise component.
-        du_out = diag ? zero(y) : zero(noise_rate_prototype)
-        du_seed = diag ? zero(y) : zero(noise_rate_prototype)
+        # Zero the reused output buffer and its cotangent seed, then seed column
+        # `i` with `λ`: computes the vjp of the `i`-th Wiener column of the noise
+        # term. For diagonal noise a single scalar `λ[i]` at component `i`
+        # computes the vjp of the `i`-th diagonal noise component.
+        Enzyme.remake_zero!(du_out)
+        Enzyme.remake_zero!(du_seed)
         if diag
             du_seed[i] = λ[i]
         else
             @views du_seed[:, i] .= λ
         end
 
-        u_buf = Base.copy(y)
-        du_u = zero(y)
+        vec(u_buf) .= vec(y)
+        Enzyme.remake_zero!(du_u)
 
-        local dp_shadow
+        _shadow_p = nothing
         dup_p = if want_pgrad
-            if _p_scimlstruct
-                dp_shadow = repack(zero(tunables))
+            if cached_shadow isa EnzymeViewPrimalBuffer
+                # view-backed p: dense primal buffer + dense shadow, both re-zeroed.
+                copyto!(cached_shadow.buf, p)
+                Enzyme.remake_zero!(dp_dense)
+                _shadow_p = dp_dense
+                Enzyme.Duplicated(cached_shadow.buf, dp_dense)
+            elseif cached_shadow !== nothing
+                # SciMLStructures p: disjoint `make_zero(p)` shadow (see #1470).
+                Enzyme.remake_zero!(cached_shadow)
+                _shadow_p = cached_shadow
+                Enzyme.Duplicated(p, cached_shadow)
             else
-                dp_shadow = zero(p)
+                # plain-array p: the dense shadow buffer is the gradient.
+                Enzyme.remake_zero!(dp_dense)
+                _shadow_p = dp_dense
+                Enzyme.Duplicated(p, dp_dense)
             end
-            Enzyme.Duplicated(p, dp_shadow)
         else
             Enzyme.Const(p)
         end
 
+        Enzyme.remake_zero!(func_shadow)
         if inplace
-            func_shadow = Enzyme.make_zero(func)
             Enzyme.autodiff(
                 enzyme_mode, Enzyme.Duplicated(func, func_shadow), Enzyme.Const,
                 Enzyme.Duplicated(du_out, du_seed),
@@ -1780,10 +1800,9 @@ function _jacNoise!(
                 dup_p, Enzyme.Const(t)
             )
         else
-            f_shadow = Enzyme.make_zero(f)
             Enzyme.autodiff(
                 enzyme_mode, Enzyme.Const(gclosure1), Enzyme.Const,
-                Enzyme.Duplicated(f, f_shadow),
+                Enzyme.Duplicated(f, func_shadow),
                 Enzyme.Duplicated(du_out, du_seed),
                 Enzyme.Duplicated(u_buf, du_u),
                 dup_p, Enzyme.Const(t)
@@ -1793,10 +1812,10 @@ function _jacNoise!(
         dλ !== nothing && (dλ[:, i] .= vec(du_u))
         if want_pgrad && !isempty(dgrad)
             if _p_scimlstruct
-                grad_tunables, _, _ = canonicalize(Tunable(), dp_shadow)
+                grad_tunables, _, _ = canonicalize(Tunable(), _shadow_p)
                 dgrad[:, i] .= vec(grad_tunables)
             else
-                dgrad[:, i] .= vec(dp_shadow)
+                dgrad[:, i] .= vec(_shadow_p)
             end
         end
         if dy !== nothing

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -1716,6 +1716,100 @@ function _jacNoise!(
     return
 end
 
+function _jacNoise!(
+        λ, y, p, t, S::TS, isnoise::EnzymeVJP, dgrad, dλ,
+        dy
+    ) where {TS <: SensitivityFunction}
+    prob = getprob(S)
+    f = unwrapped_f(S.f)
+    enzyme_mode = isnoise.mode
+    inplace = inplace_sensitivity(S)
+
+    noise_rate_prototype = prob.noise_rate_prototype
+    diag = SciMLBase.is_diagonal_noise(prob)
+    # number of Wiener processes / noise columns
+    m = noise_rate_prototype === nothing ? length(y) : size(noise_rate_prototype, 2)
+
+    # The Gauss/Quadrature-style adjoint rhs may call with `dgrad === nothing`; in
+    # that case skip the parameter-gradient accumulation entirely (Const `p`).
+    want_pgrad = dgrad !== nothing && !(p === nothing || p isa SciMLBase.NullParameters)
+
+    _p_scimlstruct = false
+    if want_pgrad
+        (; tunables, repack) = S.diffcache
+        _p_scimlstruct = isscimlstructure(p) && !(p isa AbstractArray)
+    end
+
+    func = SciMLBase.Void(f)
+
+    for i in 1:m
+        # Primal output buffer (zeroed) and its cotangent seed. Enzyme consumes the
+        # seed shadow during the reverse pass, so both are freshly allocated per
+        # column. Seeding column `i` with `λ` computes the vjp of the `i`-th Wiener
+        # column of the noise term; for diagonal noise a single scalar `λ[i]` at
+        # component `i` computes the vjp of the `i`-th diagonal noise component.
+        du_out = diag ? zero(y) : zero(noise_rate_prototype)
+        du_seed = diag ? zero(y) : zero(noise_rate_prototype)
+        if diag
+            du_seed[i] = λ[i]
+        else
+            @views du_seed[:, i] .= λ
+        end
+
+        u_buf = Base.copy(y)
+        du_u = zero(y)
+
+        local dp_shadow
+        dup_p = if want_pgrad
+            if _p_scimlstruct
+                dp_shadow = repack(zero(tunables))
+            else
+                dp_shadow = zero(p)
+            end
+            Enzyme.Duplicated(p, dp_shadow)
+        else
+            Enzyme.Const(p)
+        end
+
+        if inplace
+            func_shadow = Enzyme.make_zero(func)
+            Enzyme.autodiff(
+                enzyme_mode, Enzyme.Duplicated(func, func_shadow), Enzyme.Const,
+                Enzyme.Duplicated(du_out, du_seed),
+                Enzyme.Duplicated(u_buf, du_u),
+                dup_p, Enzyme.Const(t)
+            )
+        else
+            f_shadow = Enzyme.make_zero(f)
+            Enzyme.autodiff(
+                enzyme_mode, Enzyme.Const(gclosure1), Enzyme.Const,
+                Enzyme.Duplicated(f, f_shadow),
+                Enzyme.Duplicated(du_out, du_seed),
+                Enzyme.Duplicated(u_buf, du_u),
+                dup_p, Enzyme.Const(t)
+            )
+        end
+
+        dλ !== nothing && (dλ[:, i] .= vec(du_u))
+        if want_pgrad && !isempty(dgrad)
+            if _p_scimlstruct
+                grad_tunables, _, _ = canonicalize(Tunable(), dp_shadow)
+                dgrad[:, i] .= vec(grad_tunables)
+            else
+                dgrad[:, i] .= vec(dp_shadow)
+            end
+        end
+        if dy !== nothing
+            if diag
+                dy[i] = du_out[i]
+            else
+                @views dy[:, i] .= vec(du_out[:, i])
+            end
+        end
+    end
+    return
+end
+
 function accumulate_cost!(
         dλ, y, p, t, S::TS,
         dgrad = nothing

--- a/test/SDE2/sde_nondiag_stratonovich.jl
+++ b/test/SDE2/sde_nondiag_stratonovich.jl
@@ -120,6 +120,19 @@ end
         soloop, EulerHeun(), t = Array(t),
         dgdu_discrete = dg!,
         dt = dtnd, adaptive = false,
+        sensealg = BacksolveAdjoint(autojacvec = EnzymeVJP())
+    )
+
+    @test isapprox(res_sde_u0a, res_sde_u0, rtol = 1.0e-6)
+    @test isapprox(res_sde_pa, res_sde_p, rtol = 1.0e-6)
+
+    @info res_sde_pa
+
+    res_sde_u0a,
+        res_sde_pa = adjoint_sensitivities(
+        soloop, EulerHeun(), t = Array(t),
+        dgdu_discrete = dg!,
+        dt = dtnd, adaptive = false,
         sensealg = BacksolveAdjoint(autojacvec = false)
     )
 
@@ -147,6 +160,19 @@ end
         dgdu_discrete = dg!,
         dt = dtnd, adaptive = false,
         sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+    )
+
+    @test isapprox(res_sde_u0a, res_sde_u0, rtol = 1.0e-5)
+    @test isapprox(res_sde_pa, res_sde_p, rtol = 1.0e-4)
+
+    @info res_sde_pa
+
+    res_sde_u0a,
+        res_sde_pa = adjoint_sensitivities(
+        soloop, EulerHeun(), t = Array(t),
+        dgdu_discrete = dg!,
+        dt = dtnd, adaptive = false,
+        sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP())
     )
 
     @test isapprox(res_sde_u0a, res_sde_u0, rtol = 1.0e-5)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft, opened by an agent.

Closes #627.

## What

SDE adjoints with **non-diagonal** (or diagonal-mixing) noise route the noise-term VJP through `_jacNoise!`, which had methods for `ReverseDiffVJP`, `ZygoteVJP`, and the numerical fallback — but **not** `EnzymeVJP`. So `BacksolveAdjoint(autojacvec=EnzymeVJP())` / `InterpolatingAdjoint(autojacvec=EnzymeVJP())` on such problems failed with:

```
MethodError: no method matching _jacNoise!(..., ::EnzymeVJP, ...)
```

This adds the missing `_jacNoise!(::EnzymeVJP)` dispatch.

## How

Modeled on the existing in-place drift `_vecjacobian!(::EnzymeVJP)`. For each Wiener column `i in 1:m`, one Enzyme reverse pass over the noise function with the output cotangent seeded = `λ` in column `i` yields the state VJP (`dλ[:,i]`) and parameter VJP (`dgrad[:,i]`); the primal column gives `dy`. Covers:
- in-place (`g!(du,u,p,t)`) and out-of-place noise (via the existing `gclosure1` helper, same as the drift path),
- non-diagonal noise and diagonal-mixing noise,
- `NullParameters` / `dgrad === nothing` (→ `Const(p)`, matching the Gauss/Quadrature rhs), plain-array parameters, and SciMLStructures (non-array) parameters (canonicalize/repack).

## Verification (local — Julia 1.12.6, Enzyme 0.13.190, StochasticDiffEq 7.1.2)

- **Issue MWE**: `BacksolveAdjoint(EnzymeVJP())` gradient `[2.7641394244130852, -4.835564612004611, 5.139002172337797]` matches the `ReverseDiffVJP()` reference `[…, …, 5.139002172337796]` to ~1e-15 (also verified `d(u0)` and `InterpolatingAdjoint(EnzymeVJP())`).
- **Test suite**: added `EnzymeVJP` assertions to `test/SDE2/sde_nondiag_stratonovich.jl` (Backsolve + Interpolating, matching the shared `res_sde_u0`/`res_sde_p` references to rtol 1e-6 / 1e-4). The full file passes: `Non-diagonal noise 26/26`, `diagonal-mixing 32/32`, `mixing inplace/oop 14/14`, `Non-square diffusion 5/5` (the one pre-existing `@test_broken` is unrelated).

## Caveats
- Out-of-place noise with **immutable** state (`SVector`) is not covered (the path uses mutable `Duplicated` accumulators); standard `Vector`-state out-of-place works and is tested.
- Buffers take the `noise_rate_prototype` eltype; not specially handling solver-`Dual` eltypes (validated with explicit EM/EulerHeun). Allocation-per-column, matching the ReverseDiff/Zygote paths — correctness-first, not optimized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
