### PR TITLE
QA: retry the persistent-tasks wrapper precompile (fix flaky Aqua failure)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.116.3"
+version = "7.116.4"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]
@@ -109,6 +109,7 @@ OrdinaryDiffEqNonlinearSolve = "2"
 OrdinaryDiffEqRosenbrock = "2"
 OrdinaryDiffEqSDIRK = "2"
 OrdinaryDiffEqStabilizedRK = "2"
+Pkg = "1.10"
 PreallocationTools = "1.2"
 QuadGK = "2.11.3"
 Random = "1.10"
@@ -164,6 +165,7 @@ OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 OrdinaryDiffEqStabilizedRK = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -174,4 +176,4 @@ Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AlgebraicMultigrid", "Aqua", "Calculus", "ComponentArrays", "DelayDiffEq", "DifferentiationInterface", "Distributed", "ExplicitImports", "Logging", "Lux", "ModelingToolkit", "Mooncake", "NLsolve", "NonlinearSolve", "Optimization", "OptimizationOptimisers", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqFunctionMap", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqStabilizedRK", "Reactant", "SCCNonlinearSolve", "SafeTestsets", "SciMLTesting", "SparseArrays", "StableRNGs", "SteadyStateDiffEq", "StochasticDiffEq", "Sundials", "Test"]
+test = ["AlgebraicMultigrid", "Aqua", "Calculus", "ComponentArrays", "DelayDiffEq", "DifferentiationInterface", "Distributed", "ExplicitImports", "Logging", "Lux", "ModelingToolkit", "Mooncake", "NLsolve", "NonlinearSolve", "Optimization", "OptimizationOptimisers", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqFunctionMap", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqStabilizedRK", "Pkg", "Reactant", "SCCNonlinearSolve", "SafeTestsets", "SciMLTesting", "SparseArrays", "StableRNGs", "SteadyStateDiffEq", "StochasticDiffEq", "Sundials", "Test"]

--- a/test/QA/aqua.jl
+++ b/test/QA/aqua.jl
@@ -1,10 +1,16 @@
 using SciMLTesting, SciMLSensitivity, SciMLBase, Test
+using Pkg
 
 run_qa(
     SciMLSensitivity;
     explicit_imports = true,
     aqua_kwargs = (;
         ambiguities = (; recursive = false),
+        # The persistent-tasks check is run separately below with a retry on the
+        # retryable cold-cache parallel-precompile failure (SciML/SciMLSensitivity#1554,
+        # JuliaTesting/Aqua.jl#315). Disable Aqua's single-shot version here so it does
+        # not misclassify that flake as a persistent task.
+        persistent_tasks = false,
         piracies = (;
             treat_as_own = [
                 SciMLBase._concrete_solve_adjoint,
@@ -116,3 +122,85 @@ run_qa(
         ),
     ),
 )
+
+# Persistent-tasks check with a retry on the retryable cold-cache precompile failure.
+#
+# Aqua's built-in check (disabled above) spawns a throwaway wrapper package that
+# `using`s SciMLSensitivity and, from inside the precompilation process, writes a
+# `done.log` sentinel; a package that never lets that process exit within `tmax` is
+# reported as holding a persistent `Task`. When the wrapper's freshly resolved
+# dependency set precompiles cold and in parallel, one module can hit a *retryable*
+# "missing from the cache" failure (observed here: `Accessors`; in the issue:
+# `NonlinearSolveBaseChainRulesCoreExt` -- the culprit is scheduling-dependent).
+# `Pkg.precompile` then exits without compiling the wrapper, so `done.log` is never
+# written and the check misreports it as a persistent task
+# (SciML/SciMLSensitivity#1554, JuliaTesting/Aqua.jl#315). An immediate second
+# precompile finds the now-warm cache and succeeds.
+#
+# This faithfully reproduces Aqua's wrapper (its public API only exposes the
+# single-shot `Aqua.test_persistent_tasks`) but retries when the child precompile
+# exits without writing `done.log`. A genuine persistent task is unaffected: it
+# writes `done.log` and then keeps the process alive past `tmax`, which this still
+# detects, so the retry cannot mask a real background task.
+function has_persistent_tasks_with_retry(package::Module; tmax = 10, retries = 3)
+    pkgname = string(nameof(package))
+    pkgpath = pkgdir(package)
+    prev_project = Base.active_project()::String
+    isdefined(Pkg, :respect_sysimage_versions) && Pkg.respect_sysimage_versions(false)
+    try
+        for attempt in 1:retries
+            wrapperdir = tempname()
+            wrappername, _ = only(Pkg.generate(wrapperdir; io = devnull))
+            Pkg.activate(wrapperdir; io = devnull)
+            Pkg.develop(Pkg.PackageSpec(path = pkgpath); io = devnull)
+            statusfile = joinpath(wrapperdir, "done.log")
+            open(joinpath(wrapperdir, "src", wrappername * ".jl"), "w") do io
+                println(
+                    io,
+                    """
+                    module $wrappername
+                    using $pkgname
+                    open("$(escape_string(statusfile))", "w") do io
+                        println(io, "done")
+                        flush(io)
+                    end
+                    end
+                    """,
+                )
+            end
+            cmd = `$(Base.julia_cmd()) --project=$wrapperdir -e 'push!(LOAD_PATH, "@stdlib"); using Pkg; Pkg.precompile()'`
+            proc = run(cmd, stdin, stdout, stderr; wait = false)
+            while !isfile(statusfile) && process_running(proc)
+                sleep(0.5)
+            end
+            if !isfile(statusfile)
+                # Child precompile exited without loading the wrapper: the retryable
+                # cold-cache failure. Retry with a fresh wrapper; the next precompile
+                # hits the now-warm cache. Only give up after `retries` attempts.
+                if attempt < retries
+                    @info "Persistent-tasks wrapper precompile exited without writing done.log; retrying" attempt retries
+                    continue
+                end
+                @error "Persistent-tasks wrapper precompile never produced done.log after $retries attempts"
+                return true
+            end
+            t = time()
+            while process_running(proc) && time() - t < tmax
+                sleep(0.1)
+            end
+            exited = !process_running(proc)
+            exited || kill(proc, Base.SIGKILL)
+            return !exited
+        end
+        return true
+    finally
+        isdefined(Pkg, :respect_sysimage_versions) && Pkg.respect_sysimage_versions(true)
+        Pkg.activate(prev_project; io = devnull)
+    end
+end
+
+@testset "Persistent tasks" begin
+    with_clean_persistent_tasks_sources() do
+        @test !has_persistent_tasks_with_retry(SciMLSensitivity)
+    end
+end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft, opened by an agent.

Closes #1554.

## Root cause (confirmed by reproduction)

The QA group's Aqua persistent-tasks check fails intermittently on master with `done.log was not created, but precompilation exited`. It is **not** a persistent task in SciMLSensitivity — it's a retryable cold-cache parallel-precompile failure being misclassified, exactly as #1554 hypothesized.

Aqua's `test_persistent_tasks` spawns a throwaway wrapper package that `using`s SciMLSensitivity and writes a `done.log` sentinel from inside the precompile process; a package that never lets that process exit within `tmax` is flagged as holding a persistent `Task`. The wrapper's freshly-resolved dependency set precompiles **cold and in parallel**, and one module hits a *retryable* `"… is missing from the cache … 1 dependencies failed but may be precompilable after restarting julia"` failure. `Pkg.precompile` then exits without compiling the wrapper, so `done.log` is never written → misreported as a persistent task. The culprit module is scheduling-dependent (I reproduced it as `Accessors`; the issue saw `NonlinearSolveBaseChainRulesCoreExt`), which is why it's flaky rather than a deterministic regression. A `tmax` bump does **not** help — `tmax` governs the wait *after* `done.log` appears; here the process exits *before* writing it. The correct fix is a **retry**.

## Fix

Disable Aqua's single-shot `persistent_tasks` sub-check and run a local `has_persistent_tasks_with_retry` that faithfully reproduces Aqua's wrapper (its public API only exposes the asserting single-shot `test_persistent_tasks`; `has_persistent_tasks` is non-public, so per the public-API rule the small helper is reproduced rather than reached into) but **retries when the child precompile exits without writing `done.log`** (up to 3 attempts). Adds `Pkg` as a test dependency (the helper calls it directly).

**Not a cop-out:** it does not skip, `@test_broken`, or loosen anything. A genuine persistent task writes `done.log` and *then* keeps the process alive past `tmax`, which is still detected on every attempt; the retry only fires on the missing-`done.log` path, which is unreachable for a real background task.

## Verification (local, Julia 1.12.6)

- **3× with a wiped compile cache**: the retryable failure fired on all three cold runs and the retry recovered every time (`pass=true`).
- **1× end-to-end `GROUP=QA`** (`Pkg.test()`): `Quality Assurance | 22 pass / 22 total`, exit 0.
- Runic reports no changes.

## Note on placement

This is the repo-local unblock for the master red. The **durable** fix belongs upstream in `SciMLTesting`'s `with_clean_persistent_tasks_sources` / `run_qa` (or JuliaTesting/Aqua.jl#315), so the retry is fleet-wide and every SciML repo can drop the local copy. Happy to prepare that as a follow-up and revert this to a one-liner once it lands — flagging for your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
