### PR TITLE
Core4: un-skip ensemble tests on Julia 1.12+ using Enzyme (#1325)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.116.3"
+version = "7.116.5"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]

--- a/test/Core4/ensembles.jl
+++ b/test/Core4/ensembles.jl
@@ -1,58 +1,57 @@
 using SciMLSensitivity, OrdinaryDiffEq, Optimization, OptimizationOptimisers, Test
 using ADTypes
 
-# These tests require AD differentiation through ensemble solves
-# Mooncake doesn't have the necessary rules yet, and Zygote has compatibility
-# issues on Julia 1.12+, so we skip these tests on Julia 1.12+
-if VERSION >= v"1.12"
-    @info "Skipping Ensemble tests on Julia 1.12+ due to AD compatibility issues"
-    @testset "Ensemble Tests (skipped on Julia 1.12+)" begin
-        @test_skip false
-    end
+# These tests differentiate through ensemble solves. Zygote segfaults on Julia
+# 1.12+ (#1325), so use Enzyme, which differentiates the ODE `EnsembleProblem`
+# adjoint on 1.11 and 1.12. On the LTS (1.10) Enzyme's type analysis rejects the
+# reshaped-`ODESolution` indexing in the `sim.u` case (`EnzymeNoTypeError`), so
+# keep the working Zygote path there.
+if VERSION >= v"1.11"
+    using Enzyme
+    const AD_BACKEND = AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Reverse))
 else
     using Zygote
     const AD_BACKEND = AutoZygote()
+end
 
-    @testset "$(i): EnsembleAlg = $(alg)" for (i, alg) in enumerate(
-            (
-                EnsembleSerial(),
-                EnsembleThreads(), EnsembleSerial(),
-            )
+@testset "$(i): EnsembleAlg = $(alg)" for (i, alg) in enumerate(
+        (
+            EnsembleSerial(),
+            EnsembleThreads(), EnsembleSerial(),
         )
-        function prob_func(prob, ctx)
-            remake(prob, u0 = 0.5 .+ ctx.sim_id / 100 .* prob.u0)
-        end
-        function model(p)
-            prob = ODEProblem((u, p, t) -> 1.01u .* p, p[1:1], (0.0, 1.0), p[2:2])
+    )
+    function prob_func(prob, ctx)
+        remake(prob, u0 = 0.5 .+ ctx.sim_id / 100 .* prob.u0)
+    end
+    function model(p)
+        prob = ODEProblem((u, p, t) -> 1.01u .* p, p[1:1], (0.0, 1.0), p[2:2])
 
-            ensemble_prob = EnsembleProblem(prob; prob_func)
-            sim = solve(ensemble_prob, Tsit5(), alg, saveat = 0.1, trajectories = 100)
-            return i == 3 ? sim.u : sim
-        end
-
-        # loss function
-        loss = if i == 3
-            (p, _) -> sum(abs2, [sum(abs2, 1.0 .- u) for u in model(p)])
-        else
-            (p, _) -> sum(abs2, 1.0 .- Array(model(p)))
-        end
-
-        cb = function (p, l) # callback function to observe training
-            @info alg = alg loss = l
-            return false
-        end
-
-        l1 = loss([1.0, 3.0], nothing)
-        @show l1
-        res = solve(
-            OptimizationProblem(
-                OptimizationFunction(loss, AD_BACKEND),
-                [1.0, 3.0]
-            ),
-            Adam(0.1); callback = cb, maxiters = 10
-        )
-        l2 = loss(res.u, nothing)
-        @test 10l2 < l1
+        ensemble_prob = EnsembleProblem(prob; prob_func)
+        sim = solve(ensemble_prob, Tsit5(), alg, saveat = 0.1, trajectories = 100)
+        return i == 3 ? sim.u : sim
     end
 
-end  # VERSION < v"1.12" else block
+    # loss function
+    loss = if i == 3
+        (p, _) -> sum(abs2, [sum(abs2, 1.0 .- u) for u in model(p)])
+    else
+        (p, _) -> sum(abs2, 1.0 .- Array(model(p)))
+    end
+
+    cb = function (p, l) # callback function to observe training
+        @info alg = alg loss = l
+        return false
+    end
+
+    l1 = loss([1.0, 3.0], nothing)
+    @show l1
+    res = solve(
+        OptimizationProblem(
+            OptimizationFunction(loss, AD_BACKEND),
+            [1.0, 3.0]
+        ),
+        Adam(0.1); callback = cb, maxiters = 10
+    )
+    l2 = loss(res.u, nothing)
+    @test 10l2 < l1
+end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft, opened by an agent.

Part of #1325.

## What

`test/Core4/ensembles.jl` (ensemble-adjoint tests) was `@test_skip`-ped on Julia 1.12+ because Zygote segfaults there (#1325). This un-skips it by differentiating the ODE `EnsembleProblem` adjoint with **Enzyme** on `VERSION >= v"1.11"`, and keeps the existing working `AutoZygote` path on the LTS (1.10).

The 1.10 exception is real: on 1.10 Enzyme's type analysis rejects the reshaped-`ODESolution` indexing in the `sim.u` case (`EnzymeNoTypeError: … Base._unsafe_setindex!(::Matrix, ::ReshapedArray{…ODESolution…})`), so Zygote (which works there) is kept for the LTS only.

## Verification (local — ran the test file on each version)

| Julia | backend | result |
|---|---|---|
| 1.12.6 | Enzyme | ✅ Serial 1/1, Threads 1/1, `sim.u`-Serial 1/1 |
| 1.11.9 | Enzyme | ✅ Serial 1/1, Threads 1/1, `sim.u`-Serial 1/1 |
| 1.10 | Zygote | unchanged (previously-passing path; Enzyme errors here) |

No more `@test_skip` on 1.12+. Runic-clean.

## Scope note

#1325 also lists `test/Core8/parameter_initialization.jl` and `test/Core8/mtk.jl`; those are separate (the Core8 MTK path has its own Enzyme-native work, e.g. #1514) and are not touched here. This PR covers the ODE ensemble file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
