### PR TITLE
Revert #1569: init gradient back to Zygote (Core8 BoundsError still present on Enzyme 0.13.190)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.117.0"
+version = "7.117.1"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -426,28 +426,27 @@ function _init_originator_gradient(::SciMLBase.ADOriginator, f, tunables)
     return back(one(iy))[1]
 end
 
-# Init-path gradient for the `EnzymeOriginator` (outer-Enzyme) case, using a
-# nested `Enzyme.gradient` so the rrule does not pull Zygote into the Enzyme path.
+# Init-path gradient for the `EnzymeOriginator` (outer-Enzyme) case, routed
+# through a Zygote pullback (the #1467/#1515 workaround).
 #
-# `set_runtime_activity` is required: `f` differentiates an MTK DAE
-# initialization whose `remake(_prob, p = repack(t))` builds an `ODEProblem`
-# mixing constant memory (the captured problem's `u0`/`f`/`tspan`/caches) with
-# the active parameters, which Enzyme's static activity analysis rejects.
+# This runs in the adjoint backpass of the `solve` rrule — ordinary primal code
+# inside the outer Enzyme reverse pass that is NOT itself differentiated by
+# Enzyme — so a Zygote pullback here is safe and yields the same result as the
+# generic `ADOriginator` fallback above. (The init sub-VJP it calls may still be
+# `EnzymeVJP`; only the outer init differentiation is moved off Enzyme.)
 #
-# History of this dispatch: the nested `Enzyme.gradient` originally corrupted
-# state across repeated outer `Enzyme.autodiff` calls (#1469, upstream
-# EnzymeAD/Enzyme.jl#3139, fixed in Enzyme 0.13.163; #1467 routed it through
-# Zygote meanwhile, #1498 restored it). It was then reverted again (#1515)
-# because reverse-differentiating MTK's `__apply_copy_template` crashed with an
-# undersized shadow `Memory` `BoundsError` / TypeAnalysis blowup on the Core8
-# `DefaultInit` setup (#1514, upstream EnzymeAD/Enzyme.jl#3259, fixed via
-# EnzymeAD/Enzyme.jl#3279 in Enzyme 0.13.174 — the `[compat]` floor). With both
-# upstream fixes in the floor, the Enzyme-native path is correct and repeatable.
-# See #1514, #1469, #1467, #1415.
+# It deliberately does NOT use a nested `Enzyme.gradient`. #1498/#1569 restored an
+# Enzyme-native init gradient after the #1469 nesting bug (EnzymeAD/Enzyme.jl#3139)
+# and the #1514 `__apply_copy_template` crash (EnzymeAD/Enzyme.jl#3259/#3350) were
+# reported fixed, but the nested `Enzyme.gradient` still crashes the full Core8
+# `mtk.jl` "MTK Forward Mode" sweep under its compile ordering — an undersized
+# shadow `Memory{Float64}` `BoundsError` at `__apply_copy_template` — even on
+# Enzyme 0.13.190. So route the init gradient through Zygote until Enzyme fully
+# fixes it; repeated/multi-problem outer-Enzyme differentiation through MTK DAE
+# init then works. See #1514, #1569, #1515, #1467, #1469, #1415.
 function _init_originator_gradient(::SciMLBase.EnzymeOriginator, f, tunables)
-    return Enzyme.gradient(
-        Enzyme.set_runtime_activity(Enzyme.Reverse), Enzyme.Const(f), tunables,
-    )[1]
+    iy, back = Zygote.pullback(f, tunables)
+    return back(one(iy))[1]
 end
 
 function SciMLBase._concrete_solve_adjoint(


### PR DESCRIPTION
**Recommend merging to unbreak master.** Opened by an agent; @ChrisRackauckas please review.

## Why

#1569 (merged) restored the Enzyme-native nested `Enzyme.gradient` in `_init_originator_gradient(::EnzymeOriginator)`, on the basis that EnzymeAD/Enzyme.jl#3259/#3350 were fixed in Enzyme 0.13.190. I validated with an **isolated** `mtk.jl` setup sweep (11/15 incl. the previously-hanging `correctu0/NoInit`), which passed — but the **full `GROUP=Core8` suite**, under its real compile ordering, still errors:

```
MTK Forward Mode: Error During Test at test/Core8/mtk.jl:215
  BoundsError: attempt to access MemoryRef{Float64} at index [5]
  __apply_copy_template → override_bc_mapreduce → ...
```

`37 passed, 1 errored, 5 broken` — the one error is the reland-sensitive Enzyme-outer MTK sweep. This is the exact `__apply_copy_template` undersized-shadow crash #1514 tracks: **the upstream Enzyme fix is incomplete for the warm/full-suite compile state**, even though it holds for the isolated case. The isolated sweep and the full suite differ precisely in compile ordering, which is what triggers this crash.

This reverts `_init_originator_gradient(::EnzymeOriginator)` to the #1515 Zygote routing — the state that was green on master before #1569 — so Core8 goes green again.

## Verification

The revert restores the byte-for-byte pre-#1569 `_init_originator_gradient` (the #1515 Zygote path), which was green on Core8 for weeks. I have a full `GROUP=Core8` run on the reland branch showing the failure; I can post a confirming Core8 run on this revert branch if you want it before merging (≈60 min), but it restores a known-green state.

## Follow-up

Reopens #1514. The Enzyme-native re-land should only re-land once the upstream Enzyme fix is verified against the **full Core8 suite**, not just the isolated sweep — I'll re-file the residual on Enzyme (the #3350 fix doesn't cover the full-suite ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
