### PR TITLE
Use Base as the owner of deleteat!

### DIFF
--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -39,7 +39,7 @@ using SciMLBase: SciMLBase, AbstractOverloadingSensitivityAlgorithm,
     ContinuousCallback, AbstractTimeseriesSolution, NonlinearFunction, NonlinearProblem,
     DiscreteCallback, LinearProblem, ODEFunction, ODEProblem, DAEFunction, DAEProblem,
     RODEFunction, RODEProblem, ReturnCode, SDEFunction,
-    SDEProblem, VectorContinuousCallback, deleteat!,
+    SDEProblem, VectorContinuousCallback,
     get_tmp_cache, isinplace, reinit!, remake,
     solve, derivative_discontinuity!, LinearAliasSpecifier, OverrideInit, AbstractOptimizationProblem
 using SciMLOperators: has_adjoint


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Stop explicitly importing `deleteat!` through `SciMLBase`.
- Continue using the unqualified `deleteat!` binding supplied by Base, which owns the function.
- Leave both call sites and runtime behavior unchanged.

The existing strict ExplicitImports QA checks are the regression tests for this change: they failed on the old import and pass after its removal, so no new test-only assertion is needed.

## Root cause and boundary

SciMLBase commit `b9c3507a2670fae804bf627ca32354efeee8dc15` (PR SciML/SciMLBase.jl#1472) stopped publicly reexporting `deleteat!` while making strict owner-contract QA clean.

I checked the boundary at runtime on Julia 1.12:

- Parent `7b806c50` (`SciMLBase` 3.40.0): `:deleteat! in names(SciMLBase) == true`; `Base.which(...).module === Base`.
- First bad `b9c3507a` (temporarily versioned 4.0.0; the version was later reset): `:deleteat! in names(SciMLBase) == false`; Base remains the owner.

Current SciMLBase master `ecba25f` is version 3.40.1 and therefore exposes the downstream regression before 3.40 is registered.

## Reproduction

From clean SciMLSensitivity master `df850807`, with SciMLBase master `ecba25f` developed locally:

```sh
JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=QA julia +1.12 --startup-file=no --project=. \
  -e 'using Pkg; Pkg.test()'
```

Baseline result:

```text
Quality Assurance | 20 passed, 2 errored, 22 total
```

The only errors were:

- `all_explicit_imports_via_owners`: `deleteat!` is owned by Base but imported from SciMLBase.
- `all_explicit_imports_are_public`: `deleteat!` is not public in SciMLBase.

## Local verification

- `GROUP=QA`, Julia 1.12, local SciMLBase `ecba25f` / 3.40.1: **22 passed / 22 total** (`2m42.5s`).
- `GROUP=Core1`, Julia 1.12, coherent registered SciMLBase 3.39.1 stack: **185 passed / 9 pre-existing broken / 194 total** (`52m27.8s`); package tests passed.
- Whole-repository `Runic --check .` with Runic 1.7.0: passed.
- `git diff --check`: passed.

A Core1 attempt combining local SciMLBase 3.40.1 with the currently released OrdinaryDiffEq solver stack fails before SciMLSensitivity tests because released OrdinaryDiffEqNonlinearSolve still accesses the removed `SciMLBase.setproperties` binding. That is an independent release-order boundary; current OrdinaryDiffEq master uses the owner API. It is not changed or hidden in this focused PR.

This PR is intentionally independent of the SciMLBase compatibility-floor change in #1575.