### PR TITLE
Fix Mooncake ForwardSensitivity dispatch

### DIFF
--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -5,7 +5,7 @@ using Mooncake: Mooncake
 import SciMLSensitivity: get_paramjac_config, get_cb_paramjac_config, mooncake_run_ad,
     MooncakeVJP, MooncakeLoaded,
     DiffEqBase, MooncakeAdjoint, _init_originator_gradient,
-    ReverseDiffAdjoint, TrackerAdjoint, ForwardDiffSensitivity,
+    ReverseDiffAdjoint, TrackerAdjoint, ForwardSensitivity,
     EnzymeAdjoint
 using SciMLSensitivity: SciMLBase, SciMLStructures, canonicalize, Tunable, isscimlstructure,
     SciMLStructuresCompatibilityError, convert_tspan,
@@ -257,7 +257,7 @@ end
 # AbstractSensitivityAlgorithm}` signature, dispatch prefers these three
 # sensealgs and falls back to the generic rule for everything else.
 const _MooncakeOverAnotherADSensealg = Union{
-    ReverseDiffAdjoint, TrackerAdjoint, ForwardDiffSensitivity, EnzymeAdjoint
+    ReverseDiffAdjoint, TrackerAdjoint, ForwardSensitivity, EnzymeAdjoint,
 }
 
 function _solve_up_mooncake_over_another_ad(prob, sensealg, u0, p, alg_and_kwargs...; kwargs...)

--- a/test/Core1/concrete_solve_derivatives.jl
+++ b/test/Core1/concrete_solve_derivatives.jl
@@ -493,8 +493,10 @@ Tests callable structs with different AD backends
     # `MooncakeOriginator` dispatch added in #1420 replaces that cotangent
     # with `NoTangent()`. Same Mooncake-over-another-AD fix as above. See #1510.
     @testset "Mooncake with ForwardSensitivity (p-only)" begin
-        result = gradient_mooncake(senseloss_p(ForwardSensitivity()), p_only)
-        @test result ≈ ref_grad_p
+        for sensealg in (ForwardSensitivity(), ForwardSensitivity(autodiff = false))
+            result = gradient_mooncake(senseloss_p(sensealg), p_only)
+            @test result ≈ ref_grad_p
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

- dispatch Mooncake-over-another-AD solves for `ForwardSensitivity`, matching the rule body and existing regression
- cover both the default and `autodiff = false` ForwardSensitivity configurations for p-only differentiation

## Root cause

The original Mooncake rule change imported and dispatched on `ForwardSensitivity`, but a later review commit changed both sites to `ForwardDiffSensitivity` while the implementation, comments, and test continued to use `ForwardSensitivity`. The p-only Mooncake call therefore fell through to the generic rule and produced an invalid cotangent type.

This restores the intended `ForwardSensitivity` dispatch. No public API changes are involved.

## Validation

- exact clean-master Core1 baseline: 234 passed, 4 errored, 5 broken
- combined patched Core1 with SciML/OrdinaryDiffEq.jl#4101: 239 passed, 0 errored, 5 broken (244 total), 41m15.6s
- whole-repository `Runic --check .` passed

The other three clean-master Core1 errors are the independent Rosenbrock tracked-state regression addressed by SciML/OrdinaryDiffEq.jl#4101.

Ignore this PR until reviewed by @ChrisRackauckas.
