### PR TITLE
Accept ADTypes for sensealg autodiff kwargs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.117.0"
+version = "7.117.1"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -13,6 +13,34 @@ function SensitivityAlg(args...; kwargs...)
 end
 
 """
+    sensealg_autodiff_as_bool(autodiff) -> Bool
+
+Normalize a sensealg `autodiff` keyword to the Bool type parameter still used
+internally by SciMLSensitivity.
+
+Accepts:
+- `Bool` (`true`/`false`) — historical API
+- `AutoForwardDiff` — maps to `true` (build Jacobians via AD)
+- `AutoFiniteDiff` — maps to `false` (build Jacobians via finite differences)
+
+Other ADTypes backends are rejected because sensealg Jacobian construction is
+either ForwardDiff chunked AD or FiniteDiff; there is no Enzyme/Zygote path for
+the dense Jacobian (`autojacvec=false`) branch.
+"""
+@inline sensealg_autodiff_as_bool(autodiff::Bool) = autodiff
+@inline sensealg_autodiff_as_bool(::AutoForwardDiff) = true
+@inline sensealg_autodiff_as_bool(::Type{<:AutoForwardDiff}) = true
+@inline sensealg_autodiff_as_bool(::AutoFiniteDiff) = false
+@inline sensealg_autodiff_as_bool(::Type{<:AutoFiniteDiff}) = false
+function sensealg_autodiff_as_bool(autodiff)
+    throw(ArgumentError(
+        "sensealg autodiff must be a Bool, AutoForwardDiff, or AutoFiniteDiff; got $(typeof(autodiff)). " *
+        "Use `autodiff=AutoForwardDiff()` (or `true`) for AD Jacobians and " *
+        "`autodiff=AutoFiniteDiff()` (or `false`) for finite-difference Jacobians."))
+end
+
+
+"""
 ```julia
 ForwardSensitivity{CS, AD, FDT} <: AbstractForwardSensitivityAlgorithm{CS, AD, FDT}
 ```
@@ -35,7 +63,8 @@ ForwardSensitivity(;
 ## Keyword Arguments
 
   - `autodiff`: Use automatic differentiation in the internal sensitivity algorithm
-    computations. Default is `true`.
+    computations. Accepts `Bool` (`true`/`false`), `AutoForwardDiff()`, or
+    `AutoFiniteDiff()`. Default is `true`.
   - `chunk_size`: Chunk size for forward mode differentiation if full Jacobians are
     built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
     choice of chunk size.
@@ -68,13 +97,15 @@ end
 function ForwardSensitivity(;
         chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
-        autojacvec = autodiff,
+        autojacvec = nothing,
         autojacmat = false
     )
-    autojacvec && autojacmat &&
+    ad = sensealg_autodiff_as_bool(autodiff)
+    ajv = autojacvec === nothing ? ad : autojacvec
+    ajv && autojacmat &&
         error("Choose either Jacobian matrix products or Jacobian vector products,
                 autojacmat and autojacvec cannot both be true")
-    return ForwardSensitivity{chunk_size, autodiff, diff_type}(autojacvec, autojacmat)
+    return ForwardSensitivity{chunk_size, ad, diff_type}(ajv, autojacmat)
 end
 
 """
@@ -135,7 +166,8 @@ BacksolveAdjoint(; chunk_size = 0, autodiff = true,
 ## Keyword Arguments
 
   - `autodiff`: Use automatic differentiation for constructing the Jacobian
-    if the Jacobian needs to be constructed.  Defaults to `true`.
+    if the Jacobian needs to be constructed. Accepts `Bool`, `AutoForwardDiff()`,
+    or `AutoFiniteDiff()`. Defaults to `true`.
 
   - `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
     built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
@@ -273,7 +305,8 @@ Base.@pure function BacksolveAdjoint(;
         autojacvec = nothing,
         checkpointing = true, noisemixing = false
     )
-    BacksolveAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(
+    ad = sensealg_autodiff_as_bool(autodiff)
+    BacksolveAdjoint{chunk_size, ad, diff_type, typeof(autojacvec)}(
         autojacvec,
         checkpointing,
         noisemixing
@@ -310,7 +343,8 @@ InterpolatingAdjoint(; chunk_size = 0, autodiff = true,
 ## Keyword Arguments
 
   - `autodiff`: Use automatic differentiation for constructing the Jacobian
-    if the Jacobian needs to be constructed.  Defaults to `true`.
+    if the Jacobian needs to be constructed. Accepts `Bool`, `AutoForwardDiff()`,
+    or `AutoFiniteDiff()`. Defaults to `true`.
 
   - `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
     built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
@@ -403,7 +437,8 @@ Base.@pure function InterpolatingAdjoint(;
         autojacvec = nothing,
         checkpointing = false, noisemixing = false
     )
-    InterpolatingAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(
+    ad = sensealg_autodiff_as_bool(autodiff)
+    InterpolatingAdjoint{chunk_size, ad, diff_type, typeof(autojacvec)}(
         autojacvec,
         checkpointing,
         noisemixing
@@ -448,7 +483,8 @@ QuadratureAdjoint(; chunk_size = 0, autodiff = true,
 ## Keyword Arguments
 
   - `autodiff`: Use automatic differentiation for constructing the Jacobian
-    if the Jacobian needs to be constructed.  Defaults to `true`.
+    if the Jacobian needs to be constructed. Accepts `Bool`, `AutoForwardDiff()`,
+    or `AutoFiniteDiff()`. Defaults to `true`.
 
   - `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
     built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
@@ -515,7 +551,8 @@ Base.@pure function QuadratureAdjoint(;
         autojacvec = nothing, abstol = 1.0e-6,
         reltol = 1.0e-3, diff_tunables = Val(true)
     )
-    QuadratureAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec), typeof(diff_tunables)}(
+    ad = sensealg_autodiff_as_bool(autodiff)
+    QuadratureAdjoint{chunk_size, ad, diff_type, typeof(autojacvec), typeof(diff_tunables)}(
         autojacvec,
         abstol, reltol, diff_tunables
     )
@@ -556,7 +593,8 @@ GaussAdjoint(; chunk_size = 0, autodiff = true,
 ## Keyword Arguments
 
   - `autodiff`: Use automatic differentiation for constructing the Jacobian
-    if the Jacobian needs to be constructed.  Defaults to `true`.
+    if the Jacobian needs to be constructed. Accepts `Bool`, `AutoForwardDiff()`,
+    or `AutoFiniteDiff()`. Defaults to `true`.
 
   - `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
     built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
@@ -623,7 +661,8 @@ Base.@pure function GaussAdjoint(;
         checkpointing = false,
         diff_tunables = Val(true)
     )
-    GaussAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec), typeof(diff_tunables)}(
+    ad = sensealg_autodiff_as_bool(autodiff)
+    GaussAdjoint{chunk_size, ad, diff_type, typeof(autojacvec), typeof(diff_tunables)}(
         autojacvec, checkpointing, diff_tunables
     )
 end
@@ -657,7 +696,8 @@ GaussKronrodAdjoint(; chunk_size = 0, autodiff = true,
 ## Keyword Arguments
 
   - `autodiff`: Use automatic differentiation for constructing the Jacobian
-    if the Jacobian needs to be constructed.  Defaults to `true`.
+    if the Jacobian needs to be constructed. Accepts `Bool`, `AutoForwardDiff()`,
+    or `AutoFiniteDiff()`. Defaults to `true`.
 
   - `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
     built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
@@ -722,7 +762,8 @@ Base.@pure function GaussKronrodAdjoint(;
         autojacvec = nothing,
         checkpointing = false
     )
-    GaussKronrodAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(
+    ad = sensealg_autodiff_as_bool(autodiff)
+    GaussKronrodAdjoint{chunk_size, ad, diff_type, typeof(autojacvec)}(
         autojacvec, checkpointing
     )
 end
@@ -865,7 +906,8 @@ Base.@pure function SundialsAdjoint(;
     )
     interp in (:hermite, :polynomial) ||
         error("SundialsAdjoint `interp` must be `:hermite` or `:polynomial`, got `$(interp)`.")
-    SundialsAdjoint{chunk_size, autodiff, diff_type, typeof(autojacvec)}(
+    ad = sensealg_autodiff_as_bool(autodiff)
+    SundialsAdjoint{chunk_size, ad, diff_type, typeof(autojacvec)}(
         autojacvec, steps, interp, quad_error_control
     )
 end
@@ -1040,7 +1082,8 @@ ForwardLSS(;
 ## Keyword Arguments
 
   - `autodiff`: Use automatic differentiation for constructing the Jacobian
-    if the Jacobian needs to be constructed.  Defaults to `true`.
+    if the Jacobian needs to be constructed. Accepts `Bool`, `AutoForwardDiff()`,
+    or `AutoFiniteDiff()`. Defaults to `true`.
 
   - `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
     built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
@@ -1088,7 +1131,8 @@ Base.@pure function ForwardLSS(;
         LSSregularizer = TimeDilation(10.0, 0.0, 0.0),
         g = nothing
     )
-    ForwardLSS{chunk_size, autodiff, diff_type, typeof(LSSregularizer), typeof(g)}(
+    ad = sensealg_autodiff_as_bool(autodiff)
+    ForwardLSS{chunk_size, ad, diff_type, typeof(LSSregularizer), typeof(g)}(
         LSSregularizer,
         g
     )
@@ -1121,7 +1165,8 @@ AdjointLSS(;
 ## Keyword Arguments
 
   - `autodiff`: Use automatic differentiation for constructing the Jacobian
-    if the Jacobian needs to be constructed.  Defaults to `true`.
+    if the Jacobian needs to be constructed. Accepts `Bool`, `AutoForwardDiff()`,
+    or `AutoFiniteDiff()`. Defaults to `true`.
 
   - `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
     built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
@@ -1161,7 +1206,8 @@ Base.@pure function AdjointLSS(;
         LSSregularizer = TimeDilation(10.0, 0.0, 0.0),
         g = nothing
     )
-    AdjointLSS{chunk_size, autodiff, diff_type, typeof(LSSregularizer), typeof(g)}(
+    ad = sensealg_autodiff_as_bool(autodiff)
+    AdjointLSS{chunk_size, ad, diff_type, typeof(LSSregularizer), typeof(g)}(
         LSSregularizer,
         g
     )
@@ -1279,13 +1325,15 @@ Base.@pure function NILSS(
         rng = Xorshifts.Xoroshiro128Plus(rand(UInt64)),
         chunk_size = 0, autodiff = true,
         diff_type = Val{:central},
-        autojacvec = autodiff,
+        autojacvec = nothing,
         g = nothing
     )
-    NILSS{chunk_size, autodiff, diff_type, typeof(rng), typeof(nus), typeof(g)}(
+    ad = sensealg_autodiff_as_bool(autodiff)
+    ajv = autojacvec === nothing ? ad : autojacvec
+    NILSS{chunk_size, ad, diff_type, typeof(rng), typeof(nus), typeof(g)}(
         rng, nseg,
         nstep, nus,
-        autojacvec,
+        ajv,
         g
     )
 end
@@ -1349,7 +1397,8 @@ NILSAS(nseg, nstep, M = nothing; rng = Xorshifts.Xoroshiro128Plus(rand(UInt64)),
             is a boolean for whether to precompile the tape, which should only be done
             if there are no branches (`if` or `while` statements) in the `f` function.
   - `autodiff`: Use automatic differentiation for constructing the Jacobian
-    if the Jacobian needs to be constructed.  Defaults to `true`.
+    if the Jacobian needs to be constructed. Accepts `Bool`, `AutoForwardDiff()`,
+    or `AutoFiniteDiff()`. Defaults to `true`.
   - `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
     built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
     choice of chunk size.
@@ -1393,9 +1442,10 @@ Base.@pure function NILSAS(
     M === nothing &&
         error("Please provide an `M` with `M >= nus + 1`, where nus is the number of unstable covariant Lyapunov vectors.")
 
+    ad = sensealg_autodiff_as_bool(autodiff)
     NILSAS{
         chunk_size,
-        autodiff,
+        ad,
         diff_type,
         typeof(rng),
         typeof(adjoint_sensealg),
@@ -1426,7 +1476,8 @@ SteadyStateAdjoint(; chunk_size = 0, autodiff = true,
 ## Keyword Arguments
 
   - `autodiff`: Use automatic differentiation for constructing the Jacobian
-    if the Jacobian needs to be constructed.  Defaults to `true`.
+    if the Jacobian needs to be constructed. Accepts `Bool`, `AutoForwardDiff()`,
+    or `AutoFiniteDiff()`. Defaults to `true`.
 
   - `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
     built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
@@ -1485,8 +1536,9 @@ Base.@pure function SteadyStateAdjoint(;
         diff_type = Val{:central}, autojacvec = nothing, linsolve = nothing,
         linsolve_kwargs = (;), diff_tunables = Val(true)
     )
+    ad = sensealg_autodiff_as_bool(autodiff)
     return SteadyStateAdjoint{
-        chunk_size, autodiff, diff_type, typeof(autojacvec),
+        chunk_size, ad, diff_type, typeof(autojacvec),
         typeof(linsolve), typeof(linsolve_kwargs), typeof(diff_tunables),
     }(autojacvec, linsolve, linsolve_kwargs, diff_tunables)
 end
@@ -1572,8 +1624,9 @@ function UnconstrainedOptimizationAdjoint(;
         diff_type = Val{:central}, objective_ad = true, autojacvec = nothing, linsolve = nothing,
         linsolve_kwargs = (;)
     )
+    ad = sensealg_autodiff_as_bool(autodiff)
     return UnconstrainedOptimizationAdjoint{
-        chunk_size, autodiff, diff_type, typeof(autojacvec),
+        chunk_size, ad, diff_type, typeof(autojacvec),
         typeof(linsolve), typeof(linsolve_kwargs), typeof(objective_ad),
     }(autojacvec, linsolve, linsolve_kwargs, objective_ad)
 end

--- a/test/Core1/sensealg_adtypes.jl
+++ b/test/Core1/sensealg_adtypes.jl
@@ -1,0 +1,42 @@
+using SciMLSensitivity
+using ADTypes: AutoFiniteDiff, AutoForwardDiff
+using OrdinaryDiffEq
+using Test
+
+# Construction maps ADTypes onto the Bool type parameter used internally
+a_fd = InterpolatingAdjoint(autodiff = AutoFiniteDiff(), autojacvec = false)
+a_ad = InterpolatingAdjoint(autodiff = AutoForwardDiff(), autojacvec = false)
+a_true = InterpolatingAdjoint(autodiff = true, autojacvec = false)
+a_false = InterpolatingAdjoint(autodiff = false, autojacvec = false)
+@test SciMLSensitivity.alg_autodiff(a_fd) === false
+@test SciMLSensitivity.alg_autodiff(a_ad) === true
+@test SciMLSensitivity.alg_autodiff(a_true) === true
+@test SciMLSensitivity.alg_autodiff(a_false) === false
+
+f_fd = ForwardSensitivity(autodiff = AutoFiniteDiff(), autojacvec = false)
+f_ad = ForwardSensitivity(autodiff = AutoForwardDiff(), autojacvec = false)
+@test SciMLSensitivity.alg_autodiff(f_fd) === false
+@test SciMLSensitivity.alg_autodiff(f_ad) === true
+# default autojacvec follows the normalized autodiff Bool
+f_def = ForwardSensitivity(autodiff = AutoFiniteDiff())
+@test f_def.autojacvec === false
+
+# End-to-end: ADTypes sensealg no longer TypeErrors in boolean context
+f(u, p, t) = p[1] * u
+u0 = [1.0]
+tspan = (0.0, 1.0)
+p = [1.5]
+prob = ODEProblem(f, u0, tspan, p)
+sol = solve(prob, Tsit5(), saveat = 0.1, abstol = 1e-6, reltol = 1e-6)
+dg(out, u, p, t, i) = (out .= 1.0)
+for sensealg in (
+    InterpolatingAdjoint(autodiff = AutoFiniteDiff(), autojacvec = false),
+    InterpolatingAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
+    QuadratureAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
+    GaussAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
+)
+    du0, dp = adjoint_sensitivities(sol, Tsit5(); t = sol.t, dgdu_discrete = dg,
+        sensealg = sensealg, abstol = 1e-6, reltol = 1e-6)
+    @test length(dp) == length(p)
+    @test all(isfinite, dp)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ run_tests(;
                 @time @safetestset "SciMLStructures Interface" include("Core1/scimlstructures_interface.jl")
                 @time @safetestset "Functor Parameters" include("Core1/functor_params.jl")
                 @time @safetestset "Sensitivity Verbosity" include("Core1/sensitivity_verbosity.jl")
+                @time @safetestset "sensealg ADTypes autodiff" include("Core1/sensealg_adtypes.jl")
             end
         end,
         "Core2" => function ()


### PR DESCRIPTION
## Summary

Sensealg constructors (`InterpolatingAdjoint`, `QuadratureAdjoint`, `GaussAdjoint`, `ForwardSensitivity`, …) accepted `autodiff=true/false` only as a Bool type parameter. After the ADTypes migration of OrdinaryDiffEq, benchmarks and callers correctly pass `AutoFiniteDiff()` / `AutoForwardDiff()`, but that stored the ADTypes object as the type parameter and then hit:

```
TypeError: non-boolean (AutoFiniteDiff) used in boolean context
```

at every `if alg_autodiff(alg)` site (e.g. `forward_sensitivity.jl`, `derivative_wrappers.jl`).

This PR normalizes the constructor kwargs:

| input | type param |
|-------|------------|
| `true` / `AutoForwardDiff()` | `true` |
| `false` / `AutoFiniteDiff()` | `false` |

Bool remains accepted. Internal `alg_autodiff` still returns Bool so no call-site rewrites are needed.

## Verification

```julia
using SciMLSensitivity
using ADTypes: AutoFiniteDiff, AutoForwardDiff
a = InterpolatingAdjoint(autodiff=AutoFiniteDiff(), autojacvec=false)
@assert SciMLSensitivity.alg_autodiff(a) === false
@assert (SciMLSensitivity.alg_autodiff(a) ? 1 : 0) == 0  # previously TypeError
```

Also exercised ForwardSensitivity, Interpolating/Quadrature/Gauss/GaussKronrod/Backsolve/Sundials/SteadyState constructors with both ADTypes and Bool.

## Related

Needed so SciMLBenchmarks AutomaticDifferentiation can keep ADTypes for sensealgs (https://github.com/SciML/SciMLBenchmarks.jl/pull/1632).

## Ignore until reviewed by @ChrisRackauckas