### PR TITLE
Keep ForwardDiffSensitivity's `u0` duals when the problem initializes

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -1675,11 +1675,25 @@ function SciMLBase._concrete_solve_adjoint(
                 end
 
                 # use the callback from kwargs, not prob
-                _prob = remake(
-                    prob, f = _f, u0 = u0dual,
-                    p = _p,
-                    tspan = tspandual, callback = nothing
-                )
+                # When the problem carries initialization data, `u0` is a derived
+                # quantity: a single `remake(prob; u0, p)` runs initialization and
+                # recomputes `u0` from `p`, discarding the seeded duals and leaving
+                # this chunk of `du0` identically zero. Setting `p` first and `u0`
+                # second keeps the seed, because the `u0`-only `remake` is what
+                # writes it back into the parameter object (for MTK, into the
+                # `Initial(x)` parameters that initialization reads).
+                _prob = if SciMLBase.has_initialization_data(prob.f)
+                    _pprob = remake(
+                        prob, f = _f, p = _p, tspan = tspandual, callback = nothing
+                    )
+                    remake(_pprob, u0 = u0dual)
+                else
+                    remake(
+                        prob, f = _f, u0 = u0dual,
+                        p = _p,
+                        tspan = tspandual, callback = nothing
+                    )
+                end
 
                 if _prob isa SDEProblem
                     _prob.noise_rate_prototype !== nothing && (

--- a/test/Core8/parameter_initialization.jl
+++ b/test/Core8/parameter_initialization.jl
@@ -9,6 +9,8 @@ using SciMLSensitivity
 using OrdinaryDiffEq
 using Tracker
 using Enzyme
+using ForwardDiff
+using Zygote
 import SciMLBase
 using Test
 
@@ -117,5 +119,52 @@ tunables, repack, _ = SS.canonicalize(SS.Tunable(), parameter_values(prob))
             )
             any(!iszero, dtunables)
         end
+    end
+end
+
+# https://github.com/SciML/SciMLSensitivity.jl/issues/1582
+# `ForwardDiffSensitivity` (the default here: length(u0) + length(tunables) <= 100)
+# seeds `u0` duals, but a problem carrying initialization data re-derives `u0`
+# from `p` during `remake`. If the seed is discarded the whole `du0` is zero, and
+# every `Initial(x)` gradient silently vanishes.
+@testset "Gradients w.r.t. `Initial` parameters (#1582)" begin
+    @parameters m2 = 1.5 d2 = 9.0
+    @variables s2(t) = 1.0 v2(t) = 1.0
+    initsys = mtkcompile(
+        System([D(s2) ~ v2, m2 * D(v2) ~ 1 - d2 * v2], t; name = :initmodel)
+    )
+    initprob = ODEProblem(initsys, [], (0.0, 1.0))
+    set_v0 = SII.setp_oop(initprob, [Initial(initsys.v2)])
+    get_s = SII.getsym(initprob, initsys.s2)
+
+    initloss = function (x)
+        sol = solve(remake(initprob; p = set_v0(initprob, x)), Tsit5(); saveat = 0.02)
+        return sum(abs2, get_s(sol))
+    end
+
+    x0 = [1.1]
+    @test SciMLSensitivity.automatic_sensealg_choice(
+        initprob, state_values(initprob), parameter_values(initprob), false, nothing
+    ) isa ForwardDiffSensitivity
+
+    reference = ForwardDiff.gradient(initloss, x0)
+    @test !iszero(only(reference))
+    @test Zygote.gradient(initloss, x0)[1] ≈ reference rtol = 1.0e-5
+
+    # The true adjoints reach the same value through `du0`.
+    for sensealg in (InterpolatingAdjoint(), GaussAdjoint(), QuadratureAdjoint())
+        g = Zygote.gradient(
+            x -> sum(
+                abs2,
+                get_s(
+                    solve(
+                        remake(initprob; p = set_v0(initprob, x)), Tsit5();
+                        saveat = 0.02, sensealg
+                    )
+                )
+            ),
+            x0
+        )[1]
+        @test g ≈ reference rtol = 1.0e-5
     end
 end


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.** Opened as a draft.
>
> **Depends on SciML/ModelingToolkit.jl#4905** — this change is inert without it. Both are required to fix #1582.

## What changed and why

Fixes #1582 (partially — see the dependency above).

`ForwardDiffSensitivity`'s `du0` thunk built its dual problem with a single `remake(prob; u0 = u0dual, p = _p)`. When the problem carries initialization data, `u0` is a *derived* quantity: that `remake` re-runs initialization, recomputes `u0` from `p`, and discards the seeded duals. Every chunk of `du0` then comes back identically zero.

Setting `p` first and `u0` second keeps the seed, because the `u0`-only `remake` is what writes it back into the parameter object (for MTK, into the `Initial(x)` parameters initialization reads). Guarded on `SciMLBase.has_initialization_data(prob.f)` so the non-initializing path keeps its single `remake`.

This matters because `ForwardDiffSensitivity` is the *default* for small MTK problems — `automatic_sensealg_choice` picks it when `length(u0) + length(tunables) <= 100`. The reporter's 2-state, 2-parameter model lands there, so the failure was silent and on the default path, while the true adjoints were already correct.

The discarding is directly observable:

```
one-shot  remake(prob; u0=[5.0,1.0], p)  => state_values = [1.1, 1.0]   # u0 discarded
two-step  remake(remake(prob; p); u0)    => state_values = [5.0, 1.0]   # u0 kept
```

and shows up in the rrule as:

```
sensealg                  du0                       dp.initials
ForwardDiffSensitivity    [0.0, 0.0]                nothing
InterpolatingAdjoint      [17.042405, 121.569166]   nothing
GaussAdjoint              [17.042405, 121.569166]   nothing
QuadratureAdjoint         [17.042405, 121.569166]   nothing
```

## Verification

New testset in `test/Core8/parameter_initialization.jl`. Failing on the unfixed code (fix stashed, MTK fix in place):

```
Test Summary:                                 | Pass  Fail  Error  Total     Time
Gradients w.r.t. `Initial` parameters (#1582) |    2     1      1      4  3m29.4s
ERROR: Some tests did not pass: 2 passed, 1 failed, 1 errored, 0 broken.
```

(The `errored` was a bad `verbose = false` kwarg in my own test — `Bool` is no longer accepted by OrdinaryDiffEq v7 — since removed.)

Passing with the fix applied, same file, including the pre-existing testset:

```
Test Summary:                            | Pass  Total      Time
Adjoint through Parameter Initialization |    3      3  15m48.8s
Test Summary:                                 | Pass  Total     Time
Gradients w.r.t. `Initial` parameters (#1582) |    6      6  4m27.2s
```

The issue's MRE, end to end:

```
                before                after
ForwardDiff     [17.042409339235398]  [17.042409339235398]
Zygote          nothing               [17.04241152270429]
Enzyme          [0.0]                 [17.04241152270429]
```

Julia 1.12.6, MTK 11.38.2, SciMLBase 3.43.0, Zygote 0.7.12, Enzyme 0.13.198. Runic and `typos` clean (no changes produced).

## What I did NOT verify

- Only `test/Core8/parameter_initialization.jl` was run. I did **not** run the rest of `Core8`, nor `QA`, docs, SDE/Callbacks/Shadowing groups, GPU, or downstream. The box sat at load 120–280 throughout and that one file took ~20 min; a full group was not feasible. Please let CI cover it.
- The two-step `remake` costs one extra `remake` per chunk on initializing problems. I did not benchmark it.
- No Mooncake/Tracker/ReverseDiff originator was exercised through this path.

## For a reviewer to push back on

- Returning a nonzero `du0` for MTK problems is arguably *wrong* w.r.t. the literal rrule contract: `u0` is a dead input there (`get_concrete_problem` → `get_updated_symbolic_problem` recomputes it from `p.initials` unconditionally, and `initializealg` does not gate that — perturbing `u0` by hand leaves the loss bit-identical). The end-to-end answer is right only because the caller's `u0` came from `remake` and is numerically tied to `p.initials`. This PR makes `ForwardDiffSensitivity` consistent with what the adjoints already do rather than changing that convention — but the convention itself deserves a decision.
- The `has_initialization_data` branch means initializing and non-initializing problems now take structurally different paths through the `du0` thunk.

## Separate defect, deliberately not included

`src/concrete_solve.jl:722-744` computes the initialization correction as

```julia
_init_originator_gradient(originator, t -> sum(get_initial_values(remake(_prob, p = repack(t)))[1]), tunables)
```

which is seeded with ones rather than the `du0` that `adjoint_sensitivities` produces later, and differentiates only `tunables` because `repack(t)` holds `Initials` fixed. Both look wrong to me, but neither produces *this* issue's zero — they would surface for a problem whose initialization is non-trivial and therefore deferred to solve time. The `sum` seed dates to d6290bf. Left for its own PR so this one stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs33bFwCYG5u4XvMHXJxCm
