### PR TITLE
Fix GaussAdjoint parameter Jacobians for out-of-place ODEs

### DIFF
--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -608,7 +608,15 @@ function GaussIntegrand(sol, sensealg, checkpoints, dgdp = nothing)
         pf = nothing
         pJ = nothing
     else
-        pf = SciMLBase.ParamJacobianWrapper((du, u, p, t) -> unwrappedf(du, u, repack(p), t), tspan[1], y)
+        _needs_repack = isscimlstructure(p) && !(p isa AbstractArray)
+        _pjac_f = if _needs_repack && SciMLBase.isinplace(sol.prob.f)
+            (du, u, p, t) -> unwrappedf(du, u, repack(p), t)
+        elseif _needs_repack
+            (u, p, t) -> unwrappedf(u, repack(p), t)
+        else
+            unwrappedf
+        end
+        pf = SciMLBase.ParamJacobianWrapper(_pjac_f, tspan[1], y)
         pJ = similar(u0, length(u0), numparams)
         paramjac_config = build_param_jac_config(sensealg, pf, y, tunables)
     end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary
- preserve three-argument arity for out-of-place ODE parameter functions
- retain four-argument arity for in-place ODEs
- repack structured parameters without forcing every model through an in-place closure

The unchanged `test/Core1/sensealg_adtypes.jl` test is the regression coverage. On clean master, `GaussAdjoint(autodiff = AutoForwardDiff(), autojacvec = false)` calls the three-argument model as `f(du, u, p, t)` and errors. With this change, the same test exits successfully.

## Bisect
- underlying behavior regression: `054dc29d127013564c40ba810d1bb37bf2b4620e` (`Improve SciMLStructures support`)
- parent `4579890fa515882286931db5865f51a4644c8303` passes the focused reproduction and returns `dp = adjoint([16.729579605424085])`
- child `054dc29d1` exits 1 with the four-argument `MethodError`
- `bb399a88e58e21a1f7c308160735482e5fdc4c56` is only the suite-level boundary because it added the ADTypes test

## Validation
- Julia release 1.12.6, clean master, compatible resolution: unchanged `sensealg_adtypes.jl` exits 1 at `gauss_adjoint.jl:611`
- Julia release 1.12.6, patched source, compatible resolution: unchanged `sensealg_adtypes.jl` exits 0
- Julia release 1.12.6 with ArrayInterface master `b3e2a79`: complete `concrete_solve_derivatives.jl` exits 0; `BouncingBall ODE` passes 3/3
- supplied completed clean-compatible Core1 log: 200 passed, 3 errored, 6 broken, matching the two bouncing-ball errors and this GaussAdjoint error
- Runic passes on `src/gauss_adjoint.jl`
- all-tracked Runic was run and reports pre-existing formatting diffs only in `src/sensitivity_algorithms.jl` and `test/Core1/sensealg_adtypes.jl`
- `git diff --check` passes

The bouncing-ball failures are separately fixed at their owner by merged JuliaArrays/ArrayInterface.jl#498 and are not worked around here.